### PR TITLE
Adding support for RoutingStyle.RequestElement

### DIFF
--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -72,7 +72,7 @@ namespace SoapCore
 			// Read request message
 			var requestMessage = _messageEncoder.ReadMessage(httpContext.Request.Body, 0x10000, httpContext.Request.ContentType);
 
-			var soapAction = httpContext.Request.Headers["SOAPAction"].ToString().Trim('\"');
+			var soapAction = (httpContext.Request.Headers["SOAPAction"].FirstOrDefault() ?? requestMessage.GetReaderAtBodyContents().LocalName).Trim('\"');
 			if (!string.IsNullOrEmpty(soapAction))
 			{
 				requestMessage.Headers.Action = soapAction;
@@ -80,7 +80,7 @@ namespace SoapCore
 
 			var operation =
 				_service.Operations.FirstOrDefault(
-					o => o.SoapAction.Equals(requestMessage.Headers.Action, StringComparison.Ordinal));
+					o => o.SoapAction.Equals(soapAction, StringComparison.Ordinal) || o.Name.Equals(soapAction, StringComparison.Ordinal));
 			if (operation == null)
 			{
 				throw new InvalidOperationException($"No operation found for specified action: {requestMessage.Headers.Action}");


### PR DESCRIPTION
My current soap/webservice service route the messages to methods using RequestElement routing style (please see https://msdn.microsoft.com/en-us/library/system.web.services.protocols.soapserviceroutingstyle(v=vs.110).aspx)

Although this is an pre-soap behavior, I think is a good-to-have to make possible old projects run on aspnet core stack (which is actually very good and better than running old style asmx)