### PR TITLE
Fix Serializer and Path issue

### DIFF
--- a/src/SoapCore/ServiceBodyWriter.cs
+++ b/src/SoapCore/ServiceBodyWriter.cs
@@ -49,7 +49,7 @@ namespace SoapCore
 						using (var ms = new MemoryStream())
 						using (var stream = new BufferedStream(ms))
 						{
-							new XmlSerializer(outResult.Value.GetType()).Serialize(ms, outResult.Value);
+							new XmlSerializer(outResult.Value.GetType(), _serviceNamespace).Serialize(ms, outResult.Value);
 							stream.Position = 0;
 							using (var reader = XmlReader.Create(stream))
 							{

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -52,7 +52,7 @@ namespace SoapCore
 		{
 			Message responseMessage = null;
 
-			string baseUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host.ToString() + httpContext.Request.Path;
+			string baseUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host.ToString() + httpContext.Request.PathBase + httpContext.Request.Path;
 
 			var bodyWriter = new MetaBodyWriter(_service, baseUrl);
 


### PR DESCRIPTION
This PR fixes two issues i found while using your library:
- Fixed XML Serializer not using default namespace forcing the output XML to emit it's namespace
- Fixed path problem when not hosted at /, you need PathBase to give the extra part of the path, so the soap endpoint winds up at the correct place
