### PR TITLE
Fixed error when receiving SOAP messages from Postman/SoapUI

### DIFF
--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -200,13 +200,8 @@ namespace SoapCore
 									break;
 								case SoapSerializer.DataContractSerializer:
 									{
-										// Hacky workaround: using XmlSerializer only until we find out why the hell DataContractSerializer is not working
-										var serializer = new XmlSerializer(elementType, null, new Type[0], new XmlRootAttribute(parameterName), parameterNs);
-										arguments.Add(serializer.Deserialize(xmlReader));
-
-										//var serializer = new DataContractSerializer(elementType, parameterName, parameterNs);
-										//arguments.Add(serializer.ReadObject(xmlReader, verifyObjectName: true));
-
+										var serializer = new DataContractSerializer(elementType, parameterName, parameterNs);
+										arguments.Add(serializer.ReadObject(xmlReader, verifyObjectName: true));
 									}
 									break;
 								default: throw new NotImplementedException();

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -200,8 +200,13 @@ namespace SoapCore
 									break;
 								case SoapSerializer.DataContractSerializer:
 									{
-										var serializer = new DataContractSerializer(elementType, parameterName, parameterNs);
-										arguments.Add(serializer.ReadObject(xmlReader, verifyObjectName: true));
+										// Hacky workaround: using XmlSerializer only until we find out why the hell DataContractSerializer is not working
+										var serializer = new XmlSerializer(elementType, null, new Type[0], new XmlRootAttribute(parameterName), parameterNs);
+										arguments.Add(serializer.Deserialize(xmlReader));
+
+										//var serializer = new DataContractSerializer(elementType, parameterName, parameterNs);
+										//arguments.Add(serializer.ReadObject(xmlReader, verifyObjectName: true));
+
 									}
 									break;
 								default: throw new NotImplementedException();

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -90,9 +90,11 @@ namespace SoapCore
 				return ProcessMeta(httpContext);
 
 			//Get the message
-			var requestMessage = _messageEncoder.ReadMessage(httpContext.Request.Body, 0x10000, httpContext.Request.ContentType);
+			var requestBuffer = _messageEncoder.ReadMessage(httpContext.Request.Body, 0x10000, httpContext.Request.ContentType).CreateBufferedCopy(Int32.MaxValue);
+			var requestMessage = requestBuffer.CreateMessage();
+			var messageCopy = requestBuffer.CreateMessage();
 
-			var soapAction = (httpContext.Request.Headers["SOAPAction"].FirstOrDefault() ?? requestMessage.GetReaderAtBodyContents().LocalName).Trim('\"');
+			var soapAction = (httpContext.Request.Headers["SOAPAction"].FirstOrDefault() ?? messageCopy.GetReaderAtBodyContents().LocalName).Trim('\"');
 			if (!string.IsNullOrEmpty(soapAction))
 			{
 				requestMessage.Headers.Action = soapAction;


### PR DESCRIPTION
First of all, thanks for creating SoapCore! I had been having problems when passing an object as part of the requests as seen in your ComplexModel input when such request originated from external software, let's say Postman or SoapUI. 

### How to replicate

- In the sample solution, run the server normally.
- Use postman to send a request like this:

Type: POST
Format: raw, XML (text/xml)

```<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tem="http://tempuri.org/">
   <soapenv:Header/>
   <soapenv:Body>
      <tem:PingComplexModel>
         <!--Optional:-->
         <tem:inputModel>
            <!--Optional:-->
            <tem:IntProperty>10</tem:IntProperty>
            <tem:StringProperty>hi</tem:StringProperty>
         </tem:inputModel>
      </tem:PingComplexModel>
   </soapenv:Body>
</soapenv:Envelope>
```

Error `“This message cannot support the operation because it has been read”` will occur.

### Fix

It turns out that the error was originated by the message being read twice, which was easily solved by creating a buffered copy and using the copy to determine the soapAction. 

Hope this helps!