### PR TITLE
performance tuning(mainly caching parameter's meta info)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,4 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+**/BenchmarkDotNet.Artifacts/

--- a/src/SoapCore.Benchmark.Shared/PingService.cs
+++ b/src/SoapCore.Benchmark.Shared/PingService.cs
@@ -1,0 +1,26 @@
+using System.ServiceModel;
+using System.Threading.Tasks;
+
+namespace SoapCore.Benchmark
+{
+	[ServiceContract(Name="PingService", Namespace="http://example.org/PingService")]
+	public interface IPingService
+	{
+		[OperationContract(Action="http://example.org/PingService/Echo", Name="Echo", ReplyAction="http://example.org/PingService/Echo")]
+		string Echo(string str);
+		[OperationContract(Action="http://example.org/PingService/EchoAsync", Name="EchoAsync", ReplyAction="http://example.org/PingService/EchoAsync")]
+		Task<string> EchoAsync(string str);
+	}
+	public class PingService : IPingService
+	{
+		public string Echo(string str)
+		{
+			return $"{str}";
+		}
+
+		public Task<string> EchoAsync(string str)
+		{
+			return Task.FromResult($"{str}");
+		}
+	}
+}

--- a/src/SoapCore.Benchmark.Shared/Program.cs
+++ b/src/SoapCore.Benchmark.Shared/Program.cs
@@ -21,7 +21,7 @@ namespace SoapCore.Benchmark
 	public class EchoBench
 	{
 		// 0 measures overhead of creating host
-		[Params(0, 100)]
+		[Params(100)]
 		public int LoopNum;
 		static string EchoContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <soap:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:soap=""http://schemas.xmlsoap.org/soap/envelope/"">

--- a/src/SoapCore.Benchmark.Shared/Program.cs
+++ b/src/SoapCore.Benchmark.Shared/Program.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using System.Threading.Tasks;
+using System.Threading;
+using Microsoft.AspNetCore.TestHost;
+using System.Net.Http;
+using System.Net;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Attributes.Jobs;
+using BenchmarkDotNet.Diagnosers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SoapCore.Benchmark
+{
+	[MemoryDiagnoser]
+	[SimpleJob(targetCount: 5)]
+	public class EchoBench
+	{
+		// 0 measures overhead of creating host
+		[Params(0, 100)]
+		public int LoopNum;
+		static string EchoContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<soap:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:soap=""http://schemas.xmlsoap.org/soap/envelope/"">
+  <soap:Body>
+    <Echo xmlns=""http://example.org/PingService""><str>abc</str></Echo>
+  </soap:Body>
+</soap:Envelope>
+";
+		static TestServer CreateTestHost()
+		{
+			var builder = WebHost.CreateDefaultBuilder()
+				.ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Critical))
+				.UseStartup<Startup>();
+			return new TestServer(builder);
+		}
+		TestServer m_Host;
+		[GlobalSetup]
+		public void Setup()
+		{
+			m_Host = CreateTestHost();
+		}
+		[GlobalCleanup]
+		public void Cleanup()
+		{
+			m_Host.Dispose();
+		}
+		[Benchmark]
+		public async Task EmptyTask()
+		{
+			for (int i = 0; i < LoopNum; i++)
+			{
+				using (var content = new StringContent(EchoContent, Encoding.UTF8, "text/xml"))
+				{
+					using (var res = await m_Host.CreateRequest("/")
+						.AddHeader("SOAPAction", "http://example.org/PingService/Echo")
+						.And(msg =>
+						{
+							msg.Content = content;
+						}).PostAsync().ConfigureAwait(false))
+					{
+						res.EnsureSuccessStatusCode();
+					}
+				}
+			}
+		}
+		[Benchmark]
+		public async Task Echo()
+		{
+			for (int i = 0; i < LoopNum; i++)
+			{
+				using (var content = new StringContent(EchoContent, Encoding.UTF8, "text/xml"))
+				{
+					using (var res = await m_Host.CreateRequest("/TestService.asmx")
+						.AddHeader("SOAPAction", "http://example.org/PingService/Echo")
+						.And(msg =>
+						{
+							msg.Content = content;
+						}).PostAsync().ConfigureAwait(false))
+					{
+						res.EnsureSuccessStatusCode();
+					}
+				}
+			}
+		}
+	}
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			var reporter = BenchmarkRunner.Run<EchoBench>();
+		}
+	}
+}

--- a/src/SoapCore.Benchmark.Shared/Startup.cs
+++ b/src/SoapCore.Benchmark.Shared/Startup.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.ServiceModel.Channels;
+using System.ServiceModel;
+using SoapCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
+using System.Text;
+
+namespace SoapCore.Benchmark
+{
+	public class Startup
+	{
+		public void ConfigureServices(IServiceCollection services)
+		{
+			services.AddSingleton<PingService>();
+		}
+		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+		{
+			if (env.IsDevelopment())
+			{
+				app.UseDeveloperExceptionPage();
+			}
+
+			// var elm = new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, Encoding.UTF8);
+			// var customBinding = new CustomBinding("MarWebSvcSoap", "http://intercom/malion/MarWebSvc", new BindingElement[] { elm });
+			// var customBinding = new BasicHttpBinding();
+
+			app.UseSoapEndpoint<PingService>("/TestService.asmx", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+			app.Use(async (ctx, next) =>
+			{
+				await ctx.Response.WriteAsync("").ConfigureAwait(false);
+			});
+		}
+	}
+}

--- a/src/SoapCore.Benchmark/SoapCore.Benchmark.csproj
+++ b/src/SoapCore.Benchmark/SoapCore.Benchmark.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="../SoapCore/SoapCore.csproj">
+		</ProjectReference>
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="../SoapCore.Benchmark.Shared/*.cs"/>
+	</ItemGroup>
+	<ItemGroup>
+	  <PackageReference Include="BenchmarkDotNet" Version="0.10.13" />
+	  <PackageReference Include="Microsoft.AspNetCore" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.2" />
+	  <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.1" />
+	</ItemGroup>
+
+</Project>

--- a/src/SoapCore.BenchmarkOld/SoapCore.BenchmarkOld.csproj
+++ b/src/SoapCore.BenchmarkOld/SoapCore.BenchmarkOld.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SoapCore" Version="0.9.7" />
+  </ItemGroup>
+	<ItemGroup>
+		<Compile Include="../SoapCore.Benchmark.Shared/*.cs"/>
+	</ItemGroup>
+	<ItemGroup>
+	  <PackageReference Include="BenchmarkDotNet" Version="0.10.13" />
+	  <PackageReference Include="Microsoft.AspNetCore" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.2" />
+	  <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.1" />
+	</ItemGroup>
+
+</Project>

--- a/src/SoapCore.sln
+++ b/src/SoapCore.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2036
@@ -7,10 +7,18 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoapCore", "SoapCore\SoapCo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoapCore.Tests", "SoapCore.Tests\SoapCore.Tests.csproj", "{2B200D78-B473-4590-9E4C-532AD0219BA9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SoapCore.Benchmark", "SoapCore.Benchmark\SoapCore.Benchmark.csproj", "{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SoapCore.BenchmarkOld", "SoapCore.BenchmarkOld\SoapCore.BenchmarkOld.csproj", "{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{576F47D4-97EC-4D42-8CD5-89648EEAB688}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -21,6 +29,30 @@ Global
 		{2B200D78-B473-4590-9E4C-532AD0219BA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2B200D78-B473-4590-9E4C-532AD0219BA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2B200D78-B473-4590-9E4C-532AD0219BA9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Debug|x64.ActiveCfg = Debug|x64
+		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Debug|x64.Build.0 = Debug|x64
+		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Debug|x86.ActiveCfg = Debug|x86
+		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Debug|x86.Build.0 = Debug|x86
+		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Release|x64.ActiveCfg = Release|x64
+		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Release|x64.Build.0 = Release|x64
+		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Release|x86.ActiveCfg = Release|x86
+		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Release|x86.Build.0 = Release|x86
+		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Debug|x64.ActiveCfg = Debug|x64
+		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Debug|x64.Build.0 = Debug|x64
+		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Debug|x86.ActiveCfg = Debug|x86
+		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Debug|x86.Build.0 = Debug|x86
+		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Release|x64.ActiveCfg = Release|x64
+		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Release|x64.Build.0 = Release|x64
+		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Release|x86.ActiveCfg = Release|x86
+		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/SoapCore/OperationDescription.cs
+++ b/src/SoapCore/OperationDescription.cs
@@ -1,8 +1,23 @@
 ﻿using System.Reflection;
 using System.ServiceModel;
+using System.Xml;
+using System.Xml.Serialization;
+using System.Linq;
 
 namespace SoapCore
 {
+	public class SoapMethodParameterInfo
+	{
+		public ParameterInfo Parameter { get; private set; }
+		public string Name { get; private set; }
+		public string Namespace { get; private set; }
+		public SoapMethodParameterInfo(ParameterInfo parameter, string name, string ns)
+		{
+			Parameter = parameter;
+			Name = name;
+			Namespace = ns;
+		}
+	}
 	public class OperationDescription
 	{
 		public ContractDescription Contract { get; private set; }
@@ -11,6 +26,9 @@ namespace SoapCore
 		public string Name { get; private set; }
 		public MethodInfo DispatchMethod { get; private set; }
 		public bool IsOneWay { get; private set; }
+		public SoapMethodParameterInfo[] NormalParameters { get; private set; }
+		public SoapMethodParameterInfo[] OutParameters { get;private set;}
+		public string ReturnName {get;private set;}
 
 		public OperationDescription(ContractDescription contract, MethodInfo operationMethod, OperationContractAttribute contractAttribute)
 		{
@@ -20,6 +38,20 @@ namespace SoapCore
 			IsOneWay = contractAttribute.IsOneWay;
 			ReplyAction = contractAttribute.ReplyAction;
 			DispatchMethod = operationMethod;
+			NormalParameters = operationMethod.GetParameters().Where(x => !x.IsOut && !x.ParameterType.IsByRef)
+				.Select(info => CreateParameterInfo(info, contract)).ToArray();
+			OutParameters = operationMethod.GetParameters().Where(x => x.IsOut || x.ParameterType.IsByRef)
+				.Select(info => CreateParameterInfo(info, contract)).ToArray();
+			ReturnName = operationMethod.ReturnParameter.GetCustomAttribute<MessageParameterAttribute>()?.Name ?? Name + "Result";
+		}
+		static SoapMethodParameterInfo CreateParameterInfo(ParameterInfo info, ContractDescription contract)
+		{
+			var elementAttribute = info.GetCustomAttribute<XmlElementAttribute>();
+			var parameterName = !string.IsNullOrEmpty(elementAttribute?.ElementName)
+									? elementAttribute.ElementName
+									: info.GetCustomAttribute<MessageParameterAttribute>()?.Name ?? info.Name;
+			var parameterNs = elementAttribute?.Namespace ?? contract.Namespace;
+			return new SoapMethodParameterInfo(info, parameterName, parameterNs);
 		}
 	}
 }


### PR DESCRIPTION
following method can be heavy sometimes(found in my private investigates),
so I fixed to avoid these methods as possible as I could.
* `MethodInfo.GetParameters`(caching when startup)
* `ParameterInfo.GetCustomAttribute`(caching when startup)
* reloading stream with `StreamReader` and related(using `MemoryStream` directly)
* `IE<T>.Concat`(do not use when there are no 'out' parameter)
* `IE<T>.ToArray`(do not use when there are no 'out' parameter)

benchmark results in my development machine are as follows(10-15% improvement);

## before

``` ini

BenchmarkDotNet=v0.10.13, OS=Windows 8.1 (6.3.9600.0)
Intel Core i7-4770 CPU 3.40GHz (Haswell), 1 CPU, 8 logical cores and 4 physical cores
Frequency=3312636 Hz, Resolution=301.8744 ns, Timer=TSC
.NET Core SDK=2.1.100
  [Host]     : .NET Core 2.0.5 (CoreCLR 4.6.26020.03, CoreFX 4.6.26018.01), 64bit RyuJIT
  Job-YACQPT : .NET Core 2.0.5 (CoreCLR 4.6.26020.03, CoreFX 4.6.26018.01), 64bit RyuJIT

TargetCount=5  

```
|    Method | LoopNum |      Mean |     Error |    StdDev |    Gen 0 | Allocated |
|---------- |-------- |----------:|----------:|----------:|---------:|----------:|
| EmptyTask |     100 |  2.349 ms | 0.6062 ms | 0.1575 ms | 242.1875 |   8.13 KB |
|      Echo |     100 | 10.843 ms | 0.2343 ms | 0.0609 ms | 921.8750 |   8.29 KB |

## after

``` ini

BenchmarkDotNet=v0.10.13, OS=Windows 8.1 (6.3.9600.0)
Intel Core i7-4770 CPU 3.40GHz (Haswell), 1 CPU, 8 logical cores and 4 physical cores
Frequency=3312636 Hz, Resolution=301.8744 ns, Timer=TSC
.NET Core SDK=2.1.100
  [Host]     : .NET Core 2.0.5 (CoreCLR 4.6.26020.03, CoreFX 4.6.26018.01), 64bit RyuJIT
  Job-GNPZMU : .NET Core 2.0.5 (CoreCLR 4.6.26020.03, CoreFX 4.6.26018.01), 64bit RyuJIT

TargetCount=5  

```
|    Method | LoopNum |     Mean |     Error |    StdDev |    Gen 0 | Allocated |
|---------- |-------- |---------:|----------:|----------:|---------:|----------:|
| EmptyTask |     100 | 2.294 ms | 0.1480 ms | 0.0384 ms | 242.1875 |   8.13 KB |
|      Echo |     100 | 9.013 ms | 0.6711 ms | 0.1743 ms | 796.8750 |   8.29 KB |
