### PR TITLE
WSDL output - Change List/IEnumberables to ArrayOf

### DIFF
--- a/samples/Client/Program.cs
+++ b/samples/Client/Program.cs
@@ -21,10 +21,12 @@ namespace Client
 			var complexModel = new ComplexModelInput
 			{
 				StringProperty = Guid.NewGuid().ToString(),
-				IntProperty = int.MaxValue / 2
+				IntProperty = int.MaxValue / 2,
+				ListProperty = new List<string> { "test", "list", "of", "strings" }
 			};
 			var complexResult = serviceClient.PingComplexModel(complexModel);
-			Console.WriteLine("PingComplexModel result. FloatProperty: {0}, StringProperty: {1}", complexResult.FloatProperty, complexResult.StringProperty);
+			Console.WriteLine("PingComplexModel result. FloatProperty: {0}, StringProperty: {1}, ListProperty: {2}",
+				complexResult.FloatProperty, complexResult.StringProperty, string.Join(", ", complexResult.ListProperty));
 
 			serviceClient.VoidMethod(out var stringValue);
 			Console.WriteLine("Void method result: {0}", stringValue);

--- a/samples/Client461/Connected Services/SampleService/Reference.cs
+++ b/samples/Client461/Connected Services/SampleService/Reference.cs
@@ -9,11 +9,11 @@
 //------------------------------------------------------------------------------
 
 namespace ConsoleApp1.SampleService {
-    using System.Runtime.Serialization;
-    using System;
-    
-    
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
+	using System;
+	using System.Collections.Generic;
+	using System.Runtime.Serialization;
+
+	[System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Runtime.Serialization", "4.0.0.0")]
     [System.Runtime.Serialization.DataContractAttribute(Name="ComplexModelInput", Namespace="http://tempuri.org/")]
     [System.SerializableAttribute()]
@@ -26,8 +26,10 @@ namespace ConsoleApp1.SampleService {
         private string StringPropertyField;
         
         private int IntPropertyField;
-        
-        [global::System.ComponentModel.BrowsableAttribute(false)]
+
+		private List<string> ListPropertyField;
+
+		[global::System.ComponentModel.BrowsableAttribute(false)]
         public System.Runtime.Serialization.ExtensionDataObject ExtensionData {
             get {
                 return this.extensionDataField;
@@ -62,8 +64,21 @@ namespace ConsoleApp1.SampleService {
                 }
             }
         }
-        
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+		[System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 2)]
+		public List<string> ListProperty {
+			get {
+				return this.ListPropertyField;
+			}
+			set {
+				if ((this.ListPropertyField.Equals(value) != true)) {
+					this.ListPropertyField = value;
+					this.RaisePropertyChanged("ListProperty");
+				}
+			}
+		}
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
         
         protected void RaisePropertyChanged(string propertyName) {
             System.ComponentModel.PropertyChangedEventHandler propertyChanged = this.PropertyChanged;
@@ -86,8 +101,10 @@ namespace ConsoleApp1.SampleService {
         
         [System.Runtime.Serialization.OptionalFieldAttribute()]
         private string StringPropertyField;
-        
-        [global::System.ComponentModel.BrowsableAttribute(false)]
+
+		private List<string> ListPropertyField;
+
+		[global::System.ComponentModel.BrowsableAttribute(false)]
         public System.Runtime.Serialization.ExtensionDataObject ExtensionData {
             get {
                 return this.extensionDataField;
@@ -122,8 +139,21 @@ namespace ConsoleApp1.SampleService {
                 }
             }
         }
-        
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+		[System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue=false)]
+		public List<string> ListProperty {
+			get {
+				return this.ListPropertyField;
+			}
+			set {
+				if ((this.ListPropertyField.Equals(value) != true)) {
+					this.ListPropertyField = value;
+					this.RaisePropertyChanged("ListProperty");
+				}
+			}
+		}
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
         
         protected void RaisePropertyChanged(string propertyName) {
             System.ComponentModel.PropertyChangedEventHandler propertyChanged = this.PropertyChanged;

--- a/samples/Models/ComplexModelInput.cs
+++ b/samples/Models/ComplexModelInput.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
-using System.Threading.Tasks;
 
 namespace Models
 {
@@ -14,5 +11,8 @@ namespace Models
 
 		[DataMember]
 		public int IntProperty { get; set; }
-    }
+
+		[DataMember]
+		public List<string> ListProperty { get; set; }
+	}
 }

--- a/samples/Models/ComplexModelResponse.cs
+++ b/samples/Models/ComplexModelResponse.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Models
 {
@@ -9,5 +6,6 @@ namespace Models
     {
 		public float FloatProperty { get; set; }
 		public string StringProperty { get; set; }
-    }
+		public List<string> ListProperty { get; set; }
+	}
 }

--- a/samples/Server/SampleService.cs
+++ b/samples/Server/SampleService.cs
@@ -20,7 +20,8 @@ namespace Server
 			return new ComplexModelResponse
 			{
 				FloatProperty = float.MaxValue / 2,
-				StringProperty = Guid.NewGuid().ToString()
+				StringProperty = Guid.NewGuid().ToString(),
+				ListProperty = new List<string> { "test", "list", "of", "strings" }
 			};
 		}
 

--- a/src/SoapCore.Tests/MessageInspector/MessageInspectorTests.cs
+++ b/src/SoapCore.Tests/MessageInspector/MessageInspectorTests.cs
@@ -84,7 +84,11 @@ namespace SoapCore.Tests.MessageInspector
 		{
 			var client = CreateClient(new Dictionary<string, object>() {
 				{
-					"complex", new ComplexModelInput() { StringProperty = "hello, world", IntProperty = 1000 }
+					"complex", new ComplexModelInput() {
+						StringProperty = "hello, world",
+						IntProperty = 1000,
+						ListProperty = new List<string> { "test", "list", "of", "strings" }
+					}
 				}
 			});
 
@@ -93,6 +97,7 @@ namespace SoapCore.Tests.MessageInspector
 			var complex = msg.Headers.GetHeader<ComplexModelInput>(msg.Headers.FindHeader("complex", "SoapCore"));
 			Assert.AreEqual(complex.StringProperty, "hello, world");
 			Assert.AreEqual(complex.IntProperty, 1000);
+			Assert.AreEqual(complex.ListProperty, new List<string> { "test", "list", "of", "strings" });
 		}
 	}
 }

--- a/src/SoapCore.Tests/Models.cs
+++ b/src/SoapCore.Tests/Models.cs
@@ -13,5 +13,8 @@ namespace SoapCore.Tests
 
 		[DataMember]
 		public int IntProperty { get; set; }
+
+		[DataMember]
+		public List<string> ListProperty { get; set; }
 	}
 }

--- a/src/SoapCore.Tests/TestService.cs
+++ b/src/SoapCore.Tests/TestService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace SoapCore.Tests
@@ -62,6 +63,7 @@ namespace SoapCore.Tests
 			test = new ComplexModelInput();
 			test.StringProperty = "test message";
 			test.IntProperty = 10;
+			test.ListProperty = new List<string> { "test", "list", "of", "strings" };
 		}
 
 		public void RefParam(ref string message)


### PR DESCRIPTION
This changes MetaBodyWriter.cs to output a WSDL where all List or IEnumerable properties are changed into `type="ArrayOf***"`. The appropriate `xs:complexType` is created as well.

This is done based on behavior observed in an actual .Net WCF project.