### PR TITLE
Updated System.ServiceModel.Primitives from 4.4.0 to 4.5.0

### DIFF
--- a/src/SoapCore.Benchmark/SoapCore.Benchmark.csproj
+++ b/src/SoapCore.Benchmark/SoapCore.Benchmark.csproj
@@ -16,7 +16,7 @@
 	  <PackageReference Include="Microsoft.AspNetCore" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.2" />
-	  <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.1" />
+	  <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.0" />
 	</ItemGroup>
 
 </Project>

--- a/src/SoapCore.BenchmarkOld/SoapCore.BenchmarkOld.csproj
+++ b/src/SoapCore.BenchmarkOld/SoapCore.BenchmarkOld.csproj
@@ -16,7 +16,7 @@
 	  <PackageReference Include="Microsoft.AspNetCore" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.2" />
-	  <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.1" />
+	  <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.0" />
 	</ItemGroup>
 
 </Project>

--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.1" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.0" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.4.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Updated System.ServiceModel.Primitives from 4.4.0 to 4.5.0 so that it would in turn pull down System.Private.ServiceModel 4.5.0 as that release includes a runtime fix that is compatible with ASP.NET Core 2.1 running on Azure.

Fix for issue #88 