### PR TITLE
Add ModelBindingFilter

### DIFF
--- a/src/SoapCore.Tests/ActionFilter/ActionFilterTests.cs
+++ b/src/SoapCore.Tests/ActionFilter/ActionFilterTests.cs
@@ -16,7 +16,7 @@ namespace SoapCore.Tests.ActionFilter
 			Task.Run(() => {
 				var host = new WebHostBuilder()
 					.UseKestrel()
-					.UseUrls("http://localhost:5051")
+					.UseUrls("http://localhost:5052")
 					.UseStartup<Startup>()
 					.Build();
 				host.Run();
@@ -26,7 +26,7 @@ namespace SoapCore.Tests.ActionFilter
 		public ITestService CreateClient(Dictionary<string, object> headers = null)
 		{
 			var binding = new BasicHttpBinding();
-			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:5051/Service.svc", "localhost")));
+			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:5052/Service.svc", "localhost")));
 			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);
 			var serviceClient = channelFactory.CreateChannel();
 			return serviceClient;

--- a/src/SoapCore.Tests/ActionFilter/ActionFilterTests.cs
+++ b/src/SoapCore.Tests/ActionFilter/ActionFilterTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SoapCore.Tests.ActionFilter
+{
+	[TestClass]
+	public class ActionFilterTests
+	{
+		[ClassInitialize]
+		public static void StartServer(TestContext testContext)
+		{
+			Task.Run(() => {
+				var host = new WebHostBuilder()
+					.UseKestrel()
+					.UseUrls("http://localhost:5051")
+					.UseStartup<Startup>()
+					.Build();
+				host.Run();
+			}).Wait(1000);
+		}
+
+		public ITestService CreateClient(Dictionary<string, object> headers = null)
+		{
+			var binding = new BasicHttpBinding();
+			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:5051/Service.svc", "localhost")));
+			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);
+			var serviceClient = channelFactory.CreateChannel();
+			return serviceClient;
+		}
+
+		[TestMethod]
+		public void ModelWasAlteredInActionFilter()
+		{
+			var inputModel = new ComplexModelInput {
+				StringProperty = "string property test value",
+				IntProperty = 123,
+				ListProperty = new List<string> { "test", "list", "of", "strings" },
+				DateTimeOffsetProperty = new DateTimeOffset(2018, 12, 31, 13, 59, 59, TimeSpan.FromHours(1))
+			};
+
+			var client = CreateClient();
+			var result = client.ComplexParamWithActionFilter(inputModel);
+			Assert.AreNotEqual(inputModel.StringProperty, result.StringProperty);
+			Assert.AreNotEqual(inputModel.IntProperty, result.IntProperty);
+		}
+	}
+}

--- a/src/SoapCore.Tests/ActionFilter/TestActionFilter.cs
+++ b/src/SoapCore.Tests/ActionFilter/TestActionFilter.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace SoapCore.Tests.ActionFilter
+{
+    class TestActionFilter: ActionFilterAttribute
+    {
+		public void OnSoapActionExecuting(string operationName, object[] allArgs, HttpContext httpContext, object result)
+		{
+			var complexModel = (ComplexModelInput)allArgs[0];
+			complexModel.StringProperty += "MODIFIED BY TestActionFilter";
+			complexModel.IntProperty = complexModel.IntProperty * 2;
+		}
+	}
+}

--- a/src/SoapCore.Tests/ITestService.cs
+++ b/src/SoapCore.Tests/ITestService.cs
@@ -1,5 +1,6 @@
 using System.ServiceModel;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 
 namespace SoapCore.Tests
 {
@@ -50,5 +51,9 @@ namespace SoapCore.Tests
 
 		[OperationContract]
 		void ThrowExceptionWithMessage(string message);
+
+		[OperationContract]
+		[ServiceFilter(typeof(ActionFilter.TestActionFilter))]
+		ComplexModelInput ComplexParamWithActionFilter(ComplexModelInput test);
 	}
 }

--- a/src/SoapCore.Tests/ITestService.cs
+++ b/src/SoapCore.Tests/ITestService.cs
@@ -37,6 +37,12 @@ namespace SoapCore.Tests
 		void OutComplexParam(out ComplexModelInput test);
 
 		[OperationContract]
+		ComplexModelInput ComplexParam(ComplexModelInput test);
+
+		[OperationContract]
+		ComplexModelInputForModelBindingFilter ComplexParamWithModelBindingFilter(ComplexModelInputForModelBindingFilter test);
+
+		[OperationContract]
 		void RefParam(ref string message);
 
 		[OperationContract]

--- a/src/SoapCore.Tests/MessageFilter/RawMessageFilterTests.cs
+++ b/src/SoapCore.Tests/MessageFilter/RawMessageFilterTests.cs
@@ -23,7 +23,8 @@ namespace SoapCore.Tests.MessageFilter
 			RawMessageFilterTests.host = new TestServer(host);
 		}
 
-		public ITestService CreateClient(Dictionary<string, object> headers = null) {
+		public ITestService CreateClient(Dictionary<string, object> headers = null)
+		{
 			var binding = new BasicHttpBinding();
 			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:5051/Service.svc", "localhost")));
 			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);

--- a/src/SoapCore.Tests/ModelBindingFilter/ModelBindingFilterTests.cs
+++ b/src/SoapCore.Tests/ModelBindingFilter/ModelBindingFilterTests.cs
@@ -16,7 +16,7 @@ namespace SoapCore.Tests.ModelBindingFilter
 			Task.Run(() => {
 				var host = new WebHostBuilder()
 					.UseKestrel()
-					.UseUrls("http://localhost:5051")
+					.UseUrls("http://localhost:5053")
 					.UseStartup<Startup>()
 					.Build();
 				host.Run();
@@ -26,7 +26,7 @@ namespace SoapCore.Tests.ModelBindingFilter
 		public ITestService CreateClient(Dictionary<string, object> headers = null)
 		{
 			var binding = new BasicHttpBinding();
-			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:5051/Service.svc", "localhost")));
+			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:5053/Service.svc", "localhost")));
 			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);
 			var serviceClient = channelFactory.CreateChannel();
 			return serviceClient;

--- a/src/SoapCore.Tests/ModelBindingFilter/ModelBindingFilterTests.cs
+++ b/src/SoapCore.Tests/ModelBindingFilter/ModelBindingFilterTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SoapCore.Tests.ModelBindingFilter
+{
+	[TestClass]
+	public class ModelBindingFilterTests
+	{
+		[ClassInitialize]
+		public static void StartServer(TestContext testContext)
+		{
+			Task.Run(() => {
+				var host = new WebHostBuilder()
+					.UseKestrel()
+					.UseUrls("http://localhost:5051")
+					.UseStartup<Startup>()
+					.Build();
+				host.Run();
+			}).Wait(1000);
+		}
+
+		public ITestService CreateClient(Dictionary<string, object> headers = null)
+		{
+			var binding = new BasicHttpBinding();
+			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:5051/Service.svc", "localhost")));
+			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);
+			var serviceClient = channelFactory.CreateChannel();
+			return serviceClient;
+		}
+
+		[TestMethod]
+		public void ModelWasAlteredInModelBindingFilter()
+		{
+			var inputModel = new ComplexModelInputForModelBindingFilter {
+				StringProperty = "string property test value",
+				IntProperty = 123,
+				ListProperty = new List<string> { "test", "list", "of", "strings" },
+				DateTimeOffsetProperty = new DateTimeOffset(2018, 12, 31, 13, 59, 59, TimeSpan.FromHours(1))
+			};
+
+			var client = CreateClient();
+			var result = client.ComplexParamWithModelBindingFilter(inputModel);
+			Assert.AreNotEqual(inputModel.StringProperty, result.StringProperty);
+			Assert.AreNotEqual(inputModel.IntProperty, result.IntProperty);
+		}
+
+		[TestMethod]
+		public void ModelWasNotAlteredInModelBindingFilter()
+		{
+			var inputModel = new ComplexModelInput {
+				StringProperty = "string property test value",
+				IntProperty = 123,
+				ListProperty = new List<string> { "test", "list", "of", "strings" },
+				DateTimeOffsetProperty = new DateTimeOffset(2018, 12, 31, 13, 59, 59, TimeSpan.FromHours(1))
+			};
+
+			var client = CreateClient();
+			var result = client.ComplexParam(inputModel);
+			Assert.AreEqual(inputModel.StringProperty, result.StringProperty);
+			Assert.AreEqual(inputModel.IntProperty, result.IntProperty);
+		}
+	}
+}

--- a/src/SoapCore.Tests/ModelBindingFilter/TestModelBindingFilter.cs
+++ b/src/SoapCore.Tests/ModelBindingFilter/TestModelBindingFilter.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace SoapCore.Tests.ModelBindingFilter
+{
+	public class TestModelBindingFilter : IModelBindingFilter
+	{
+		public List<Type> ModelTypes { get; set; }
+
+		public TestModelBindingFilter(List<Type> modelTypes)
+		{
+			ModelTypes = modelTypes;
+		}
+
+		public void OnModelBound(object model, IServiceProvider serviceProvider, out object result)
+		{
+			var complexModel = (ComplexModelInputForModelBindingFilter)model;
+			complexModel.StringProperty += "MODIFIED BY TestModelBindingFilter";
+			complexModel.IntProperty = complexModel.IntProperty * 2;
+			result = true;
+		}
+	}
+}

--- a/src/SoapCore.Tests/Models.cs
+++ b/src/SoapCore.Tests/Models.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
-using System.Text;
 
 namespace SoapCore.Tests
 {
@@ -20,4 +19,7 @@ namespace SoapCore.Tests
 		[DataMember]
 		public DateTimeOffset DateTimeOffsetProperty { get; set; }
 	}
+
+	[DataContract]
+	public class ComplexModelInputForModelBindingFilter : ComplexModelInput { }
 }

--- a/src/SoapCore.Tests/Startup.cs
+++ b/src/SoapCore.Tests/Startup.cs
@@ -18,6 +18,7 @@ namespace SoapCore.Tests
 			services.AddSoapModelBindingFilter(
 				new ModelBindingFilter.TestModelBindingFilter(new List<Type> { typeof(ComplexModelInputForModelBindingFilter) })
 			);
+			services.AddScoped<ActionFilter.TestActionFilter>();
 			services.AddMvc();
 		}
 

--- a/src/SoapCore.Tests/Startup.cs
+++ b/src/SoapCore.Tests/Startup.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using Microsoft.AspNetCore.Builder;
@@ -13,6 +15,9 @@ namespace SoapCore.Tests
 		public void ConfigureServices(IServiceCollection services)
 		{
 			services.TryAddSingleton<TestService>();
+			services.AddSoapModelBindingFilter(
+				new ModelBindingFilter.TestModelBindingFilter(new List<Type> { typeof(ComplexModelInputForModelBindingFilter) })
+			);
 			services.AddMvc();
 		}
 

--- a/src/SoapCore.Tests/TestService.cs
+++ b/src/SoapCore.Tests/TestService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 
 namespace SoapCore.Tests
 {
@@ -79,6 +80,12 @@ namespace SoapCore.Tests
 		public void RefParam(ref string message)
 		{
 			message = "hello, world";
+		}
+
+		[ServiceFilter(typeof(ActionFilter.TestActionFilter))]
+		public ComplexModelInput ComplexParamWithActionFilter(ComplexModelInput test)
+		{
+			return test;
 		}
 	}
 }

--- a/src/SoapCore.Tests/TestService.cs
+++ b/src/SoapCore.Tests/TestService.cs
@@ -66,6 +66,16 @@ namespace SoapCore.Tests
 			test.ListProperty = new List<string> { "test", "list", "of", "strings" };
 		}
 
+		public ComplexModelInput ComplexParam(ComplexModelInput test)
+		{
+			return test;
+		}
+
+		public ComplexModelInputForModelBindingFilter ComplexParamWithModelBindingFilter(ComplexModelInputForModelBindingFilter test)
+		{
+			return test;
+		}
+
 		public void RefParam(ref string message)
 		{
 			message = "hello, world";

--- a/src/SoapCore/IModelBindingFilter.cs
+++ b/src/SoapCore/IModelBindingFilter.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Collections.Generic;
+
+namespace SoapCore {
+	public interface IModelBindingFilter {
+		List<Type> ModelTypes { get; set; }
+		void OnModelBound(object model, IServiceProvider serviceProvider, out object output);
+	}
+}

--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -43,5 +43,10 @@ namespace SoapCore
 			serviceCollection.AddSoapMessageFilter(new WsMessageFilter(username, password));
 			return serviceCollection;
 		}
+
+		public static IServiceCollection AddSoapModelBindingFilter(this IServiceCollection serviceCollection, IModelBindingFilter modelBindingFilter) {
+			serviceCollection.TryAddSingleton(modelBindingFilter);
+			return serviceCollection;
+		}
 	}
 }

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -164,8 +164,9 @@ namespace SoapCore
 			//Get the message
 			var requestMessage = _messageEncoder.ReadMessage(httpContext.Request.Body, 0x10000, httpContext.Request.ContentType);
 
-			// Get MessageFilters
+			// Get MessageFilters, ModelBindingFilters
 			var messageFilters = serviceProvider.GetServices<IMessageFilter>();
+			var modelBindingFilters = serviceProvider.GetServices<IModelBindingFilter>();
 
 			// Execute request message filters
 			try
@@ -208,6 +209,18 @@ namespace SoapCore
 					// Get operation arguments from message
 					Dictionary<string, object> outArgs = new Dictionary<string, object>();
 					var arguments = GetRequestArguments(requestMessage, reader, operation, ref outArgs);
+
+					// Execute model binding filters
+					object modelBindingOutput = null;
+					foreach (var modelBindingFilter in modelBindingFilters)
+					{
+						foreach (var modelType in modelBindingFilter.ModelTypes)
+						{
+							foreach (var arg in arguments)
+								if (arg != null && arg.GetType() == modelType) modelBindingFilter.OnModelBound(arg, serviceProvider, out modelBindingOutput);
+						}
+					}
+
 					// avoid Concat() and ToArray() cost when no out args(this may be heavy operation)
 					var allArgs = outArgs.Count != 0 ? arguments.Concat(outArgs.Values).ToArray() : arguments;
 
@@ -251,6 +264,15 @@ namespace SoapCore
 					_logger.LogWarning(0, exception, exception.Message);
 					responseMessage = WriteErrorResponseMessage(exception, StatusCodes.Status500InternalServerError, serviceProvider, httpContext);
 				}
+			}
+
+			// Execute response message filters			
+			try {
+				foreach (var messageFilter in messageFilters) messageFilter.OnResponseExecuting(responseMessage);
+			}
+			catch (Exception ex) {
+				responseMessage = WriteErrorResponseMessage(ex, StatusCodes.Status500InternalServerError, serviceProvider, httpContext);
+				return responseMessage;
 			}
 
 			return responseMessage;


### PR DESCRIPTION
- `services.AddSoapModelBindingFilter()`
  - This allows you to specify which Object types you want run through a specified filter. The filter runs after your model(s) is deserialized, and before invoking the Operation. This lets you perform work on the model object before it enters into the `[OperationContract]` in your Service class.

Example:
```
public void ConfigureServices(IServiceCollection services)
{
    services.TryAddSingleton<TestService>();
    services.AddSoapModelBindingFilter(
        new ModelBindingFilter.TestModelBindingFilter(new List<Type> { typeof(ComplexModelInputForModelBindingFilter) })
    );
    services.AddMvc();
}
```

Now for any calls which take the input as a `ComplexModelInputForModelBindingFilter` object will be run through the `TestModelBindingFilter` class before starting the Soap Operation.
The `new List<Type>` allows you to specify multiple object types per filter class.