### PR TITLE
fix attributes in xml out params

### DIFF
--- a/src/SoapCore/ServiceBodyWriter.cs
+++ b/src/SoapCore/ServiceBodyWriter.cs
@@ -60,8 +60,9 @@ namespace SoapCore
 								case SoapSerializer.XmlSerializer:
 									// todo: write element with outResult.Key name and type information outResultType
 									// i.e. <outResult.Key xsi:type="outResultType" ... />
+									// upd: custom element name is ok, missing type info
 									var outResultType = outResult.Value.GetType();
-									var serializer = CachedXmlSerializer.GetXmlSerializer(outResultType, outResultType.Name, _serviceNamespace);
+									var serializer = CachedXmlSerializer.GetXmlSerializer(outResultType, outResult.Key, _serviceNamespace);
 									lock (serializer)
 										serializer.Serialize(writer, outResult.Value);
 									break;


### PR DESCRIPTION
purpose - proper serialize out/ref params in response, include attributes, custom param name and its type for XmlSerializer. see outComplexParam example below. ComplexParamType fields are marked as [XmlAttribute] and missing in original implementation.

```
[ServiceContract(Namespace = ServiceNamespace ConfigurationName = "...")]
[XmlSerializerFormat(SupportFaults = true)]
public interface ISomeService
{
    [OperationContract(Action = ServiceNamespace + nameof(SomeMethod), ReplyAction = "*")]
    [XmlSerializerFormat(SupportFaults = true)]
    bool SomeMethod(
        OtherComplexParamType inComplexParam,
        int inSimpleParam,
        out int outSimpleParam,
        out ComplexParamType outComplexParam);
}

<s:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
   <s:Body>
      <SomeMethodResponse xmlns="http://ournamespace.net/webservices/">
         <SomeMethodResult>true</SomeMethodResult>
         <outSimpleParam>simple_value</outSimpleParam>
         <outComplexParam xsi:type="ComplexParamType" Field1="..." Field2="..." ... />
      </SomeMethodResponse>
   </s:Body>
</s:Envelope>
```