### PR TITLE
Fault message details #105

### DIFF
--- a/src/SoapCore.Tests/ITestService.cs
+++ b/src/SoapCore.Tests/ITestService.cs
@@ -53,6 +53,10 @@ namespace SoapCore.Tests
 		void ThrowExceptionWithMessage(string message);
 
 		[OperationContract]
+		[FaultContract(typeof(FaultDetail))]
+		void ThrowDetailedFault(string detailMessage);
+
+		[OperationContract]
 		[ServiceFilter(typeof(ActionFilter.TestActionFilter))]
 		ComplexModelInput ComplexParamWithActionFilter(ComplexModelInput test);
 	}

--- a/src/SoapCore.Tests/IntegrationTests.cs
+++ b/src/SoapCore.Tests/IntegrationTests.cs
@@ -163,5 +163,17 @@ namespace SoapCore.Tests
 			});
 			Assert.AreEqual("Your error message here", e.Message);
 		}
+
+		[TestMethod]
+		public void ThrowsDetailedFault()
+		{
+			var client = CreateClient();
+			var e = Assert.ThrowsException<FaultException<FaultDetail>>(() =>
+			{
+				client.ThrowDetailedFault("Detail message");
+			});
+			Assert.IsNotNull(e.Detail);
+			Assert.AreEqual("Detail message", e.Detail.ExceptionProperty);
+		}
 	}
 }

--- a/src/SoapCore.Tests/Models.cs
+++ b/src/SoapCore.Tests/Models.cs
@@ -23,7 +23,7 @@ namespace SoapCore.Tests
 	[DataContract]
 	public class ComplexModelInputForModelBindingFilter : ComplexModelInput { }
 
-	[DataContract(Namespace = "")]
+	[DataContract]
 	public class FaultDetail
 	{
 		[DataMember]

--- a/src/SoapCore.Tests/Models.cs
+++ b/src/SoapCore.Tests/Models.cs
@@ -22,4 +22,11 @@ namespace SoapCore.Tests
 
 	[DataContract]
 	public class ComplexModelInputForModelBindingFilter : ComplexModelInput { }
+
+	[DataContract(Namespace = "")]
+	public class FaultDetail
+	{
+		[DataMember]
+		public string ExceptionProperty { get; set; }
+	}
 }

--- a/src/SoapCore.Tests/TestService.cs
+++ b/src/SoapCore.Tests/TestService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ServiceModel;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
@@ -40,6 +41,11 @@ namespace SoapCore.Tests
 		public void ThrowExceptionWithMessage(string message)
 		{
 			throw new Exception(message);
+		}
+
+		public void ThrowDetailedFault(string detailMessage)
+		{
+			throw new FaultException<FaultDetail>(new FaultDetail { ExceptionProperty = detailMessage }, new FaultReason("test"), new FaultCode("test"), "test");
 		}
 
 		public string Overload(double d)

--- a/src/SoapCore/Fault.cs
+++ b/src/SoapCore/Fault.cs
@@ -1,3 +1,5 @@
+using System.IO;
+using System.Runtime.Serialization;
 using System.Xml;
 using System.Xml.Serialization;
 using Microsoft.Extensions.ObjectPool;
@@ -28,14 +30,16 @@ namespace SoapCore
 		private XmlElement SerializeDetails(object detailObject)
 		{
 			if (detailObject == null) return null;
-
-			XmlDocument doc = new XmlDocument();
-			using (XmlWriter writer = doc.CreateNavigator().AppendChild())
+			
+			using (var ms = new MemoryStream())
 			{
-				new XmlSerializer(detailObject.GetType()).Serialize(writer, detailObject);
+				var serializer = new DataContractSerializer(detailObject.GetType());
+				serializer.WriteObject(ms, detailObject);
+				ms.Position = 0;
+				var doc = new XmlDocument();
+				doc.Load(ms);
+				return doc.DocumentElement;
 			}
-
-			return doc.DocumentElement;
 		}
 	}
 }

--- a/src/SoapCore/Fault.cs
+++ b/src/SoapCore/Fault.cs
@@ -1,4 +1,6 @@
-﻿using System.Xml.Serialization;
+using System.Xml;
+using System.Xml.Serialization;
+using Microsoft.Extensions.ObjectPool;
 
 namespace SoapCore
 {
@@ -11,12 +13,29 @@ namespace SoapCore
 		public string FaultString { get; set; }
 
 		[XmlElement(ElementName = "detail")]
-		public string Details { get; set; }
+		public XmlElement Details { get; set; }
 
 		public Fault()
 		{
-			Details = string.Empty;
 			FaultCode = "s:Client";
+		}
+
+		public Fault(object detailObject) : this()
+		{
+			Details = SerializeDetails(detailObject);
+		}
+
+		private XmlElement SerializeDetails(object detailObject)
+		{
+			if (detailObject == null) return null;
+
+			XmlDocument doc = new XmlDocument();
+			using (XmlWriter writer = doc.CreateNavigator().AppendChild())
+			{
+				new XmlSerializer(detailObject.GetType()).Serialize(writer, detailObject);
+			}
+
+			return doc.DocumentElement;
 		}
 	}
 }


### PR DESCRIPTION
Fault details are serialized into Detail element when the operation throws a detailed fault `FaultException<TDetail>`.

The Fault DTO object generation could still be enhanced to get the fault code and reason from the caught `FaultException`.