### PR TITLE
[in progress] fix ref and out parameters deserialization

### DIFF
--- a/samples/Client/Client.csproj
+++ b/samples/Client/Client.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.ServiceModel.Http" Version="4.4.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Client/Program.cs
+++ b/samples/Client/Program.cs
@@ -20,6 +20,7 @@ namespace Client
 			});
 
 			var binding = new BasicHttpBinding();
+			// todo: why DataContractSerializer not working?
 			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:5050/Service.svc", Environment.MachineName)));
 			var channelFactory = new ChannelFactory<ISampleService>(binding, endpoint);
 			var serviceClient = channelFactory.CreateChannel();
@@ -34,27 +35,28 @@ namespace Client
 				//DateTimeOffsetProperty = new DateTimeOffset(2018, 12, 31, 13, 59, 59, TimeSpan.FromHours(1))
 			};
 
-			var complexResult = serviceClient.PingComplexModel(complexModel);
-			Console.WriteLine("PingComplexModel result. FloatProperty: {0}, StringProperty: {1}, ListProperty: {2}",
-				complexResult.FloatProperty, complexResult.StringProperty, string.Join(", ", complexResult.ListProperty));
-			Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(complexResult));
+			var pingComplexModelResult = serviceClient.PingComplexModel(complexModel);
+			Console.WriteLine($"{nameof(pingComplexModelResult)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(pingComplexModelResult)}\n");
 
 			serviceClient.EnumMethod(out var enumValue);
 			Console.WriteLine("Enum method result: {0}", enumValue);
 
-			var responseModelRef = new ComplexModelResponse { };
+			var responseModelRef1 = ComplexModelResponse.CreateSample1();
+			var responseModelRef2 = ComplexModelResponse.CreateSample2();
 			var pingComplexModelOutAndRefResult =
 				serviceClient.PingComplexModelOutAndRef(
-					complexModel,
-					ref responseModelRef,
-					new ComplexObject(),
-					out var responseModelOut,
-					new ComplexObject());
-			Console.WriteLine($"{nameof(pingComplexModelOutAndRefResult)}:{pingComplexModelOutAndRefResult}");
-			Console.WriteLine($"{nameof(responseModelRef)}:");
-			Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(responseModelRef));
-			Console.WriteLine($"{nameof(responseModelOut)}:");
-			Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(responseModelOut));
+					ComplexModelInput.CreateSample1(),
+					ref responseModelRef1,
+					ComplexObject.CreateSample1(),
+					ref responseModelRef2,
+					ComplexObject.CreateSample2(),
+					out var responseModelOut1,
+					out var responseModelOut2);
+			Console.WriteLine($"{nameof(pingComplexModelOutAndRefResult)}: {pingComplexModelOutAndRefResult}\n");
+			Console.WriteLine($"{nameof(responseModelRef1)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelRef1)}\n");
+			Console.WriteLine($"{nameof(responseModelRef2)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelRef2)}\n");
+			Console.WriteLine($"{nameof(responseModelOut1)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelOut1)}\n");
+			Console.WriteLine($"{nameof(responseModelOut2)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelOut2)}\n");
 
 			serviceClient.VoidMethod(out var stringValue);
 			Console.WriteLine("Void method result: {0}", stringValue);

--- a/samples/Models/ComplexModelInput.cs
+++ b/samples/Models/ComplexModelInput.cs
@@ -1,35 +1,119 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Xml.Serialization;
 
 namespace Models
 {
-	[DataContract]
+	[DataContract(Namespace = ServiceNamespace.Value)]
+	[XmlType(Namespace = ServiceNamespace.Value)]
+	public enum SampleEnum
+	{
+		[EnumMember]
+		A,
+
+		[EnumMember]
+		B,
+
+		[EnumMember]
+		C
+	}
+
+	[DataContract(Namespace = ServiceNamespace.Value)]
+	[XmlType(Namespace = ServiceNamespace.Value)]
 	public class ComplexModelInput
-    {
-		[DataMember]
+	{
+		[DataMember(Order = 0)]
+		[XmlAttribute]
 		public string StringProperty { get; set; }
 
-		[DataMember]
+		[DataMember(Order = 1)]
+		[XmlAttribute]
 		public int IntProperty { get; set; }
 
-		[DataMember]
+		[DataMember(Order = 2)]
+		[XmlElement(Order = 0)]
 		public List<string> ListProperty { get; set; }
 
-        [DataMember]
-        public DateTimeOffset DateTimeOffsetProperty { get; set; }
+		[DataMember(Order = 3)]
+		[XmlAttribute]
+		public SampleEnum EnumProperty { get; set; }
 
-        [DataMember]
-        public List<ComplexObject> ComplexListProperty { get; set; }
-    }
+		//[DataMember(Order = ...)]
+		//[XmlAttribute]
+		//public DateTimeOffset DateTimeOffsetProperty { get; set; }
 
-    [DataContract]
-    public class ComplexObject
-    {
-        [DataMember]
-        public string StringProperty { get; set; }
+		[DataMember(Order = 4)]
+		[XmlElement(Order = 1)]
+		public ComplexObject ComplexNestedObjectProperty { get; set; }
 
-        [DataMember]
-        public int IntProperty { get; set; }
-    }
+		[DataMember(Order = 5)]
+		[XmlElement(Order = 2)]
+		public List<ComplexObject> ComplexListProperty { get; set; }
+
+		public static ComplexModelInput CreateSample1()
+			=> new ComplexModelInput
+			{
+				StringProperty = $"{nameof(ComplexModelInput)} sample one",
+				IntProperty = 1,
+				ListProperty = new List<string> { "one" },
+				EnumProperty = SampleEnum.A,
+				// DateTimeOffsetProperty = DateTimeOffset.MinValue,
+				ComplexNestedObjectProperty = ComplexObject.CreateSample1(),
+				ComplexListProperty = new List<ComplexObject>
+				{
+					ComplexObject.CreateSample1()
+				}
+			};
+
+		public static ComplexModelInput CreateSample2()
+			=> new ComplexModelInput
+			{
+				StringProperty = $"{nameof(ComplexModelInput)} sample two",
+				IntProperty = 2,
+				ListProperty = new List<string> { "two" },
+				EnumProperty = SampleEnum.B,
+				// DateTimeOffsetProperty = DateTimeOffset.MaxValue,
+				ComplexNestedObjectProperty = ComplexObject.CreateSample2(),
+				ComplexListProperty = new List<ComplexObject>
+				{
+					ComplexObject.CreateSample1(),
+					ComplexObject.CreateSample2()
+				}
+			};
+	}
+
+	[DataContract(Namespace = ServiceNamespace.Value)]
+	[XmlType(Namespace = ServiceNamespace.Value)]
+	public class ComplexObject
+	{
+		[DataMember(Order = 0)]
+		[XmlAttribute]
+		public string StringProperty { get; set; }
+
+		[DataMember(Order = 1)]
+		[XmlAttribute]
+		public int IntProperty { get; set; }
+
+		public static ComplexObject CreateSample1()
+			=> new ComplexObject
+			{
+				IntProperty = 1,
+				StringProperty = $"{nameof(ComplexObject)} sample one"
+			};
+
+		public static ComplexObject CreateSample2()
+			=> new ComplexObject
+			{
+				IntProperty = 2,
+				StringProperty = $"{nameof(ComplexObject)} sample two"
+			};
+
+		public static ComplexObject CreateSample3()
+			=> new ComplexObject
+			{
+				IntProperty = 3,
+				StringProperty = $"{nameof(ComplexObject)} sample three"
+			};
+	}
 }

--- a/samples/Models/ComplexModelResponse.cs
+++ b/samples/Models/ComplexModelResponse.cs
@@ -1,14 +1,89 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.ServiceModel;
+using System.Xml.Serialization;
 
 namespace Models
 {
-    public class ComplexModelResponse
-    {
+	[DataContract(Namespace = ServiceNamespace.Value)]
+	[XmlType(Namespace = ServiceNamespace.Value)]
+	public class ComplexModelResponse
+	{
+		[DataMember(Order = 0)]
+		[XmlAttribute]
 		public float FloatProperty { get; set; }
+
+		[DataMember(Order = 1)]
+		[XmlAttribute]
 		public string StringProperty { get; set; }
+
+		[DataMember(Order = 2)]
+		[XmlAttribute]
 		public List<string> ListProperty { get; set; }
 
-        public DateTimeOffset DateTimeOffsetProperty { get; set; }
+		[DataMember(Order = 3)]
+		[XmlAttribute]
+		public SampleEnum EnumProperty { get; set; }
+
+		//[DataMember(Order = ...)]
+		//[XmlAttribute]
+		//public DateTimeOffset DateTimeOffsetProperty { get; set; }
+
+		[DataMember(Order = 4)]
+		[XmlElement(Order = 0)]
+		public ComplexObject ComplexNestedObjectProperty { get; set; }
+
+		[DataMember(Order = 5)]
+		[XmlElement(Order = 1)]
+		public List<ComplexObject> ComplexListProperty { get; set; }
+
+		public static ComplexModelResponse CreateSample1()
+			=> new ComplexModelResponse
+			{
+				FloatProperty = 1.1F,
+				StringProperty = $"{nameof(ComplexModelResponse)} sample one",
+				ListProperty = new List<string> { "one" },
+				EnumProperty = SampleEnum.A,
+				// DateTimeOffsetProperty = DateTimeOffset.MinValue,
+				ComplexNestedObjectProperty = ComplexObject.CreateSample1(),
+				ComplexListProperty = new List<ComplexObject>
+				{
+					ComplexObject.CreateSample1()
+				}
+			};
+
+		public static ComplexModelResponse CreateSample2()
+			=> new ComplexModelResponse
+			{
+				FloatProperty = 2.2F,
+				StringProperty = $"{nameof(ComplexModelResponse)} sample two",
+				ListProperty = new List<string> { "one" },
+				EnumProperty = SampleEnum.B,
+				// DateTimeOffsetProperty = DateTimeOffset.MaxValue,
+				ComplexNestedObjectProperty = ComplexObject.CreateSample2(),
+				ComplexListProperty = new List<ComplexObject>
+				{
+					ComplexObject.CreateSample1(),
+					ComplexObject.CreateSample2()
+				}
+			};
+
+		public static ComplexModelResponse CreateSample3()
+			=> new ComplexModelResponse
+			{
+				FloatProperty = 3.3F,
+				StringProperty = $"{nameof(ComplexModelResponse)} sample three",
+				ListProperty = new List<string> { "one" },
+				EnumProperty = SampleEnum.C,
+				//DateTimeOffsetProperty = DateTimeOffset.MaxValue,
+				ComplexNestedObjectProperty = ComplexObject.CreateSample3(),
+				ComplexListProperty = new List<ComplexObject>
+				{
+					ComplexObject.CreateSample1(),
+					ComplexObject.CreateSample2(),
+					ComplexObject.CreateSample2()
+				}
+			};
 	}
 }

--- a/samples/Models/ISampleService.cs
+++ b/samples/Models/ISampleService.cs
@@ -15,19 +15,26 @@ namespace Models
 		ComplexModelResponse PingComplexModel(ComplexModelInput inputModel);
 
 		// new style call with multiple out/ref/value params
-		// instead of packing them into single request/response class
+		//   instead of packing them into single request/response class
+		// produced/consumed xml response is compatible with legacy wcf/ws
+		// not sure that this operation contract can be consumed in legacy wcf/ws sources, you may check
+		// attention! out params should be last to work correctly! (no idea why)
 		[OperationContract(Action = ServiceNamespace.Value + nameof(PingComplexModelOutAndRef), ReplyAction = "*")]
 		[XmlSerializerFormat(SupportFaults = true)]
 		bool PingComplexModelOutAndRef(
 			ComplexModelInput inputModel,
-			ref ComplexModelResponse responseModelRef,
+			ref ComplexModelResponse responseModelRef1,
 			ComplexObject data1,
-			out ComplexModelResponse responseModelOut,
-			ComplexObject data2);
+			ref ComplexModelResponse responseModelRef2,
+			ComplexObject data2,
+			out ComplexModelResponse responseModelOut1,
+			out ComplexModelResponse responseModelOut2);
 
 		// old style call, with all in/out params packed into single request/response params
 		// both styles are completely compatible, if we have same method name
-		// and req/resp classes as {MethodName}{Request|Response}
+		//   and req/resp classes as {MethodName}{Request|Response}
+		// produced/consumed xml response is compatible with legacy wcf/ws
+		// this operation contract is exactly as in legacy wcf/ws sources and can be consumed there
 		[OperationContract(Action = ServiceNamespace.Value + nameof(PingComplexModelOldStyle), ReplyAction = "*")]
 		[XmlSerializerFormat(SupportFaults = true)]
 		PingComplexModelOldStyleResponse PingComplexModelOldStyle(

--- a/samples/Models/ISampleService.cs
+++ b/samples/Models/ISampleService.cs
@@ -1,27 +1,52 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.ServiceModel;
+﻿using System.ServiceModel;
 using System.Threading.Tasks;
 
 namespace Models
 {
-	[ServiceContract]
+	[ServiceContract(Namespace = ServiceNamespace.Value, ConfigurationName = "SampleService.SampleServiceSoap")]
 	public interface ISampleService
 	{
-		[OperationContract]
+		[OperationContract(Action = ServiceNamespace.Value + nameof(Ping), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
 		string Ping(string s);
 
-		[OperationContract]
+		[OperationContract(Action = ServiceNamespace.Value + nameof(PingComplexModel), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
 		ComplexModelResponse PingComplexModel(ComplexModelInput inputModel);
 
-		[OperationContract]
+		// new style call with multiple out/ref/value params
+		// instead of packing them into single request/response class
+		[OperationContract(Action = ServiceNamespace.Value + nameof(PingComplexModelOutAndRef), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
+		bool PingComplexModelOutAndRef(
+			ComplexModelInput inputModel,
+			ref ComplexModelResponse responseModelRef,
+			ComplexObject data1,
+			out ComplexModelResponse responseModelOut,
+			ComplexObject data2);
+
+		// old style call, with all in/out params packed into single request/response params
+		// both styles are completely compatible, if we have same method name
+		// and req/resp classes as {MethodName}{Request|Response}
+		[OperationContract(Action = ServiceNamespace.Value + nameof(PingComplexModelOldStyle), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
+		PingComplexModelOldStyleResponse PingComplexModelOldStyle(
+			PingComplexModelOldStyleRequest request);
+
+		[OperationContract(Action = ServiceNamespace.Value + nameof(EnumMethod), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
+		bool EnumMethod(out SampleEnum e);
+
+		[OperationContract(Action = ServiceNamespace.Value + nameof(VoidMethod), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
 		void VoidMethod(out string s);
 
-		[OperationContract]
+		[OperationContract(Action = ServiceNamespace.Value + nameof(AsyncMethod), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
 		Task<int> AsyncMethod();
 
-		[OperationContract]
+		[OperationContract(Action = ServiceNamespace.Value + nameof(NullableMethod), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
 		int? NullableMethod(bool? arg);
 	}
 }

--- a/samples/Models/PingComplexModelOldStyleRequest.cs
+++ b/samples/Models/PingComplexModelOldStyleRequest.cs
@@ -12,17 +12,22 @@ namespace Models
 
 		// ref (in and out) param, present both in request and response
 		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 1)]
-		public ComplexModelResponse responseModelRef;
+		public ComplexModelResponse responseModelRef1;
 
 		// pure input value
 		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 2)]
 		public ComplexObject data1;
 
-		// pure output param, not present in request
-		// out ComplexModelResponse responseModelOut
+		// ref (in and out) param, present both in request and response
+		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 3)]
+		public ComplexModelResponse responseModelRef2;
 
 		// pure input value
-		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 3)]
+		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 4)]
 		public ComplexObject data2;
+
+		// pure output param, not present in request
+		// out ComplexModelResponse responseModelOut1
+		// out ComplexModelResponse responseModelOut2
 	}
 }

--- a/samples/Models/PingComplexModelOldStyleRequest.cs
+++ b/samples/Models/PingComplexModelOldStyleRequest.cs
@@ -1,0 +1,28 @@
+using System.ServiceModel;
+using System.Runtime.Serialization;
+
+namespace Models
+{
+	[MessageContract(WrapperName = nameof(ISampleService.PingComplexModelOldStyle), WrapperNamespace = ServiceNamespace.Value, IsWrapped = true)]
+	public class PingComplexModelOldStyleRequest
+	{
+		// pure input value, similar to non-ref param in new style
+		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 0)]
+		public ComplexModelInput inputModel;
+
+		// ref (in and out) param, present both in request and response
+		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 1)]
+		public ComplexModelResponse responseModelRef;
+
+		// pure input value
+		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 2)]
+		public ComplexObject data1;
+
+		// pure output param, not present in request
+		// out ComplexModelResponse responseModelOut
+
+		// pure input value
+		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 3)]
+		public ComplexObject data2;
+	}
+}

--- a/samples/Models/PingComplexModelOldStyleResponse.cs
+++ b/samples/Models/PingComplexModelOldStyleResponse.cs
@@ -1,0 +1,33 @@
+using System.ServiceModel;
+using System.Runtime.Serialization;
+
+namespace Models
+{
+	[MessageContract(WrapperName = nameof(PingComplexModelOldStyleResponse), WrapperNamespace = ServiceNamespace.Value, IsWrapped = true)]
+	public class PingComplexModelOldStyleResponse
+	{
+		// similar to return result in new style
+		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 0)]
+		public bool PingComplexModelOldStyleResult;
+
+		// pure input value, similar to non-ref param in new style
+		// not present in response
+		// ComplexModelInput inputModel;
+
+		// ref (in and out) param, present both in request and response
+		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 1)]
+		public ComplexModelResponse responseModelRef;
+
+		// pure input value
+		// not present in response
+		// ComplexObject data1
+
+		// pure output param, present only in response
+		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 2)]
+		public ComplexModelResponse responseModelOut;
+
+		// pure input value
+		// not present in response
+		// ComplexObject data2
+	}
+}

--- a/samples/Models/PingComplexModelOldStyleResponse.cs
+++ b/samples/Models/PingComplexModelOldStyleResponse.cs
@@ -16,15 +16,25 @@ namespace Models
 
 		// ref (in and out) param, present both in request and response
 		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 1)]
-		public ComplexModelResponse responseModelRef;
+		public ComplexModelResponse responseModelRef1;
 
-		// pure input value
-		// not present in response
+		// pure input value, not present in response
 		// ComplexObject data1
 
-		// pure output param, present only in response
+		// ref (in and out) param, present both in request and response
 		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 2)]
-		public ComplexModelResponse responseModelOut;
+		public ComplexModelResponse responseModelRef2;
+
+		// pure input value, not present in response
+		// ComplexObject data2
+
+		// pure output param, present only in response
+		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 3)]
+		public ComplexModelResponse responseModelOut1;
+
+		// pure output param, present only in response
+		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 4)]
+		public ComplexModelResponse responseModelOut2;
 
 		// pure input value
 		// not present in response

--- a/samples/Models/ServiceNamespace.cs
+++ b/samples/Models/ServiceNamespace.cs
@@ -1,0 +1,7 @@
+﻿namespace Models
+{
+	public static class ServiceNamespace
+	{
+		public const string Value = "http://sampleservice.net/webservices/";
+	}
+}

--- a/samples/Server/SampleService.cs
+++ b/samples/Server/SampleService.cs
@@ -8,6 +8,17 @@ namespace Server
 {
 	public class SampleService : ISampleService
 	{
+		public SampleService()
+		{
+			Newtonsoft.Json.JsonConvert.DefaultSettings = (() =>
+			{
+				var settings = new Newtonsoft.Json.JsonSerializerSettings();
+				settings.Formatting = Newtonsoft.Json.Formatting.Indented;
+				settings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter { CamelCaseText = true });
+				return settings;
+			});
+		}
+
 		public string Ping(string s)
 		{
 			Console.WriteLine("Exec ping method");
@@ -18,13 +29,67 @@ namespace Server
 		{
 			Console.WriteLine("Input data. IntProperty: {0}, StringProperty: {1}", inputModel.IntProperty, inputModel.StringProperty);
 
-            return new ComplexModelResponse
+			return new ComplexModelResponse
 			{
 				FloatProperty = float.MaxValue / 2,
 				StringProperty = inputModel.StringProperty,
 				ListProperty = inputModel.ListProperty,
-                //DateTimeOffsetProperty = inputModel.DateTimeOffsetProperty
-            };
+				EnumProperty = SampleEnum.C
+				//DateTimeOffsetProperty = inputModel.DateTimeOffsetProperty
+			};
+		}
+
+		private bool PingComplexModelOutAndRefImplementation(
+			ComplexModelInput inputModel,
+			ref ComplexModelResponse responseModelRef,
+			ComplexObject data1,
+			out ComplexModelResponse responseModelOut,
+			ComplexObject data2)
+		{
+			Console.WriteLine("input params:\n");
+			Console.WriteLine($"{nameof(inputModel)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(inputModel)}\n");
+			Console.WriteLine($"{nameof(responseModelRef)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelRef)}\n");
+			Console.WriteLine($"{nameof(data1)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(data1)}\n");
+			Console.WriteLine($"{nameof(data2)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(data2)}\n");
+
+			responseModelRef = ComplexModelResponse.CreateSample2();
+			responseModelOut = ComplexModelResponse.CreateSample3();
+
+			Console.WriteLine("output params:\n");
+			Console.WriteLine($"{nameof(responseModelRef)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelRef)}\n");
+			Console.WriteLine($"{nameof(responseModelOut)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelOut)}\n");
+
+			Console.WriteLine("done.\n");
+
+			return true;
+		}
+
+		public bool PingComplexModelOutAndRef(
+			ComplexModelInput inputModel,
+			ref ComplexModelResponse responseModelRef,
+			ComplexObject data1,
+			out ComplexModelResponse responseModelOut,
+			ComplexObject data2)
+		{
+			Console.WriteLine($"{nameof(PingComplexModelOutAndRef)}:");
+			return PingComplexModelOutAndRefImplementation(inputModel, ref responseModelRef, data1, out responseModelOut, data2);
+		}
+
+		public PingComplexModelOldStyleResponse PingComplexModelOldStyle(
+			PingComplexModelOldStyleRequest request)
+		{
+			Console.WriteLine($"{nameof(PingComplexModelOldStyle)}:");
+			var response = new PingComplexModelOldStyleResponse();
+			var result = PingComplexModelOutAndRefImplementation(request.inputModel, ref request.responseModelRef, request.data1, out response.responseModelOut, request.data2);
+			response.responseModelRef = request.responseModelRef;
+			return response;
+		}
+
+
+		public bool EnumMethod(out SampleEnum e)
+		{
+			e = SampleEnum.B;
+			return true;
 		}
 
 		public void VoidMethod(out string s)

--- a/samples/Server/SampleService.cs
+++ b/samples/Server/SampleService.cs
@@ -41,23 +41,30 @@ namespace Server
 
 		private bool PingComplexModelOutAndRefImplementation(
 			ComplexModelInput inputModel,
-			ref ComplexModelResponse responseModelRef,
+			ref ComplexModelResponse responseModelRef1,
 			ComplexObject data1,
-			out ComplexModelResponse responseModelOut,
-			ComplexObject data2)
+			ref ComplexModelResponse responseModelRef2,
+			ComplexObject data2,
+			out ComplexModelResponse responseModelOut1,
+			out ComplexModelResponse responseModelOut2)
 		{
 			Console.WriteLine("input params:\n");
 			Console.WriteLine($"{nameof(inputModel)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(inputModel)}\n");
-			Console.WriteLine($"{nameof(responseModelRef)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelRef)}\n");
+			Console.WriteLine($"{nameof(responseModelRef1)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelRef1)}\n");
+			Console.WriteLine($"{nameof(responseModelRef2)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelRef2)}\n");
 			Console.WriteLine($"{nameof(data1)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(data1)}\n");
 			Console.WriteLine($"{nameof(data2)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(data2)}\n");
 
-			responseModelRef = ComplexModelResponse.CreateSample2();
-			responseModelOut = ComplexModelResponse.CreateSample3();
+			responseModelRef1 = ComplexModelResponse.CreateSample2();
+			responseModelRef2 = ComplexModelResponse.CreateSample1();
+			responseModelOut1 = ComplexModelResponse.CreateSample3();
+			responseModelOut2 = ComplexModelResponse.CreateSample1();
 
 			Console.WriteLine("output params:\n");
-			Console.WriteLine($"{nameof(responseModelRef)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelRef)}\n");
-			Console.WriteLine($"{nameof(responseModelOut)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelOut)}\n");
+			Console.WriteLine($"{nameof(responseModelRef1)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelRef1)}\n");
+			Console.WriteLine($"{nameof(responseModelRef2)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelRef2)}\n");
+			Console.WriteLine($"{nameof(responseModelOut1)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelOut1)}\n");
+			Console.WriteLine($"{nameof(responseModelOut2)}:\n{Newtonsoft.Json.JsonConvert.SerializeObject(responseModelOut2)}\n");
 
 			Console.WriteLine("done.\n");
 
@@ -66,13 +73,22 @@ namespace Server
 
 		public bool PingComplexModelOutAndRef(
 			ComplexModelInput inputModel,
-			ref ComplexModelResponse responseModelRef,
+			ref ComplexModelResponse responseModelRef1,
 			ComplexObject data1,
-			out ComplexModelResponse responseModelOut,
-			ComplexObject data2)
+			ref ComplexModelResponse responseModelRef2,
+			ComplexObject data2,
+			out ComplexModelResponse responseModelOut1,
+			out ComplexModelResponse responseModelOut2)
 		{
 			Console.WriteLine($"{nameof(PingComplexModelOutAndRef)}:");
-			return PingComplexModelOutAndRefImplementation(inputModel, ref responseModelRef, data1, out responseModelOut, data2);
+			return PingComplexModelOutAndRefImplementation(
+				inputModel,
+				ref responseModelRef1,
+				data1,
+				ref responseModelRef2,
+				data2,
+				out responseModelOut1,
+				out responseModelOut2);
 		}
 
 		public PingComplexModelOldStyleResponse PingComplexModelOldStyle(
@@ -80,8 +96,16 @@ namespace Server
 		{
 			Console.WriteLine($"{nameof(PingComplexModelOldStyle)}:");
 			var response = new PingComplexModelOldStyleResponse();
-			var result = PingComplexModelOutAndRefImplementation(request.inputModel, ref request.responseModelRef, request.data1, out response.responseModelOut, request.data2);
-			response.responseModelRef = request.responseModelRef;
+			var result = PingComplexModelOutAndRefImplementation(
+				request.inputModel,
+				ref request.responseModelRef1,
+				request.data1,
+				ref request.responseModelRef2,
+				request.data2,
+				out response.responseModelOut1,
+				out response.responseModelOut2);
+			response.responseModelRef1 = request.responseModelRef1;
+			response.responseModelRef2 = request.responseModelRef2;
 			return response;
 		}
 

--- a/samples/Server/Startup.cs
+++ b/samples/Server/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Models;
 using SoapCore;
 
 namespace Server
@@ -16,7 +17,7 @@ namespace Server
 	{
 		public void ConfigureServices(IServiceCollection services)
 		{
-			services.TryAddSingleton<SampleService>();
+			services.TryAddSingleton<ISampleService, SampleService>();
 			services.AddMvc();
 		}
 
@@ -25,8 +26,9 @@ namespace Server
 			loggerFactory.AddConsole();
 			loggerFactory.AddDebug();
 
-			app.UseSoapEndpoint<SampleService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
-			app.UseSoapEndpoint<SampleService>("/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
+			app.UseSoapEndpoint<ISampleService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint<ISampleService>("/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
+
 			app.UseMvc();
 		}
 	}

--- a/src/SoapCore.Tests.Serialization/SampleServiceFixture.cs
+++ b/src/SoapCore.Tests.Serialization/SampleServiceFixture.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.ServiceModel;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Models;
+using Moq;
+
+namespace SoapCore.Tests.Serialization
+{
+	public class SampleServiceFixture : IDisposable
+	{
+		public const int Port = 5050;
+		public Mock<ISampleService> sampleServiceMock { get; private set; }
+		public readonly ISampleService sampleServiceClient;
+		private readonly IWebHost host;
+
+		// todo: also test DataContractSerializer by using Service.svc endpoint
+		// perhaps make two clients in fixture and use theory to iterate through
+
+		public SampleServiceFixture()
+		{
+			// start service host
+
+			this.host = new WebHostBuilder()
+				.ConfigureServices(services =>
+				{
+					// init SampleService service mock
+					this.sampleServiceMock = new Mock<ISampleService>();
+					services.AddSingleton<ISampleService>(sampleServiceMock.Object);
+					services.AddMvc();
+				})
+				.Configure(appBuilder =>
+				{
+					appBuilder.UseSoapEndpoint<ISampleService>("/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
+					appBuilder.UseMvc();
+				})
+				.UseKestrel()
+				.UseUrls($"http://*:{Port}")
+				.UseContentRoot(Directory.GetCurrentDirectory())
+				.Build();
+
+#pragma warning disable 4014
+			host.RunAsync();
+#pragma warning restore 4014
+
+			// make service client
+
+			var binding = new BasicHttpBinding();
+			var endpoint = new EndpointAddress(new Uri($"http://localhost:{Port}/Service.asmx"));
+			var channelFactory = new ChannelFactory<ISampleService>(binding, endpoint);
+			this.sampleServiceClient = channelFactory.CreateChannel();
+		}
+
+		public void Dispose()
+		{
+			this.host.StopAsync().GetAwaiter().GetResult();
+		}
+	}
+}

--- a/src/SoapCore.Tests.Serialization/SampleServiceSerializationTest.cs
+++ b/src/SoapCore.Tests.Serialization/SampleServiceSerializationTest.cs
@@ -1,0 +1,69 @@
+using DeepEqual.Syntax;
+using Models;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace SoapCore.Tests.Serialization
+{
+	public class SampleServiceSerializationTest : IClassFixture<SampleServiceFixture>
+	{
+		private readonly SampleServiceFixture fixture;
+
+		public SampleServiceSerializationTest(SampleServiceFixture fixture)
+		{
+			this.fixture = fixture;
+		}
+
+		delegate void PingComplexModelOutAndRefCallback(
+			ComplexModelInput inputModel,
+			ref ComplexModelResponse responseModelRef,
+			ComplexObject data1,
+			out ComplexModelResponse responseModelOut,
+			ComplexObject data2);
+
+		[Fact]
+		public void TestPingComplexModelOutAndRefSerialization()
+		{
+			this.fixture.sampleServiceMock
+				.Setup(x => x.PingComplexModelOutAndRef(
+					It.IsAny<ComplexModelInput>(),
+					ref It.Ref<ComplexModelResponse>.IsAny,
+					It.IsAny<ComplexObject>(),
+					out It.Ref<ComplexModelResponse>.IsAny,
+					It.IsAny<ComplexObject>()))
+				.Callback(new PingComplexModelOutAndRefCallback(
+					(ComplexModelInput inputModel_service,
+						ref ComplexModelResponse responseModelRef_service,
+						ComplexObject data1_service,
+						out ComplexModelResponse responseModelOut_service,
+						ComplexObject data2_service) =>
+					{
+						// check input paremeters serialization
+						inputModel_service.ShouldDeepEqual(ComplexModelInput.CreateSample1());
+						responseModelRef_service.ShouldDeepEqual(ComplexModelResponse.CreateSample1());
+						data1_service.ShouldDeepEqual(ComplexObject.CreateSample1());
+						data2_service.ShouldDeepEqual(ComplexObject.CreateSample2());
+						// sample response
+						responseModelRef_service = ComplexModelResponse.CreateSample2();
+						responseModelOut_service = ComplexModelResponse.CreateSample3();
+					}))
+				.Returns(true);
+
+			var responseModelRef_client = ComplexModelResponse.CreateSample1();
+
+			var pingComplexModelOutAndRefResult_client =
+				this.fixture.sampleServiceClient.PingComplexModelOutAndRef(
+					ComplexModelInput.CreateSample1(),
+					ref responseModelRef_client,
+					ComplexObject.CreateSample1(),
+					out var responseModelOut_client,
+					ComplexObject.CreateSample2());
+
+			// check output paremeters serialization
+			pingComplexModelOutAndRefResult_client.ShouldBeTrue();
+			responseModelRef_client.ShouldDeepEqual(ComplexModelResponse.CreateSample2());
+			responseModelOut_client.ShouldDeepEqual(ComplexModelResponse.CreateSample3());
+		}
+	}
+}

--- a/src/SoapCore.Tests.Serialization/SampleServiceSerializationTest.cs
+++ b/src/SoapCore.Tests.Serialization/SampleServiceSerializationTest.cs
@@ -17,10 +17,12 @@ namespace SoapCore.Tests.Serialization
 
 		delegate void PingComplexModelOutAndRefCallback(
 			ComplexModelInput inputModel,
-			ref ComplexModelResponse responseModelRef,
+			ref ComplexModelResponse responseModelRef1,
 			ComplexObject data1,
-			out ComplexModelResponse responseModelOut,
-			ComplexObject data2);
+			ref ComplexModelResponse responseModelRef2,
+			ComplexObject data2,
+			out ComplexModelResponse responseModelOut1,
+			out ComplexModelResponse responseModelOut2);
 
 		[Fact]
 		public void TestPingComplexModelOutAndRefSerialization()
@@ -30,40 +32,52 @@ namespace SoapCore.Tests.Serialization
 					It.IsAny<ComplexModelInput>(),
 					ref It.Ref<ComplexModelResponse>.IsAny,
 					It.IsAny<ComplexObject>(),
+					ref It.Ref<ComplexModelResponse>.IsAny,
+					It.IsAny<ComplexObject>(),
 					out It.Ref<ComplexModelResponse>.IsAny,
-					It.IsAny<ComplexObject>()))
+					out It.Ref<ComplexModelResponse>.IsAny))
 				.Callback(new PingComplexModelOutAndRefCallback(
 					(ComplexModelInput inputModel_service,
-						ref ComplexModelResponse responseModelRef_service,
+						ref ComplexModelResponse responseModelRef1_service,
 						ComplexObject data1_service,
-						out ComplexModelResponse responseModelOut_service,
-						ComplexObject data2_service) =>
+						ref ComplexModelResponse responseModelRef2_service,
+						ComplexObject data2_service,
+						out ComplexModelResponse responseModelOut1_service,
+						out ComplexModelResponse responseModelOut2_service) =>
 					{
 						// check input paremeters serialization
 						inputModel_service.ShouldDeepEqual(ComplexModelInput.CreateSample1());
-						responseModelRef_service.ShouldDeepEqual(ComplexModelResponse.CreateSample1());
+						responseModelRef1_service.ShouldDeepEqual(ComplexModelResponse.CreateSample1());
+						responseModelRef2_service.ShouldDeepEqual(ComplexModelResponse.CreateSample2());
 						data1_service.ShouldDeepEqual(ComplexObject.CreateSample1());
 						data2_service.ShouldDeepEqual(ComplexObject.CreateSample2());
 						// sample response
-						responseModelRef_service = ComplexModelResponse.CreateSample2();
-						responseModelOut_service = ComplexModelResponse.CreateSample3();
+						responseModelRef1_service = ComplexModelResponse.CreateSample2();
+						responseModelRef2_service = ComplexModelResponse.CreateSample1();
+						responseModelOut1_service = ComplexModelResponse.CreateSample3();
+						responseModelOut2_service = ComplexModelResponse.CreateSample1();
 					}))
 				.Returns(true);
 
-			var responseModelRef_client = ComplexModelResponse.CreateSample1();
+			var responseModelRef1_client = ComplexModelResponse.CreateSample1();
+			var responseModelRef2_client = ComplexModelResponse.CreateSample2();
 
 			var pingComplexModelOutAndRefResult_client =
 				this.fixture.sampleServiceClient.PingComplexModelOutAndRef(
 					ComplexModelInput.CreateSample1(),
-					ref responseModelRef_client,
+					ref responseModelRef1_client,
 					ComplexObject.CreateSample1(),
-					out var responseModelOut_client,
-					ComplexObject.CreateSample2());
+					ref responseModelRef2_client,
+					ComplexObject.CreateSample2(),
+					out var responseModelOut1_client,
+					out var responseModelOut2_client);
 
 			// check output paremeters serialization
 			pingComplexModelOutAndRefResult_client.ShouldBeTrue();
-			responseModelRef_client.ShouldDeepEqual(ComplexModelResponse.CreateSample2());
-			responseModelOut_client.ShouldDeepEqual(ComplexModelResponse.CreateSample3());
+			responseModelRef1_client.ShouldDeepEqual(ComplexModelResponse.CreateSample2());
+			responseModelRef2_client.ShouldDeepEqual(ComplexModelResponse.CreateSample1());
+			responseModelOut1_client.ShouldDeepEqual(ComplexModelResponse.CreateSample3());
+			responseModelOut2_client.ShouldDeepEqual(ComplexModelResponse.CreateSample1());
 		}
 	}
 }

--- a/src/SoapCore.Tests.Serialization/SoapCore.Tests.Serialization.csproj
+++ b/src/SoapCore.Tests.Serialization/SoapCore.Tests.Serialization.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DeepEqual" Version="1.6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\samples\Models\Models.csproj" />
+    <ProjectReference Include="..\SoapCore\SoapCore.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SoapCore.sln
+++ b/src/SoapCore.sln
@@ -10,6 +10,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoapCore.Benchmark", "SoapC
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoapCore.BenchmarkOld", "SoapCore.BenchmarkOld\SoapCore.BenchmarkOld.csproj", "{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoapCore.Tests.Serialization", "SoapCore.Tests.Serialization\SoapCore.Tests.Serialization.csproj", "{529CE850-C05F-4193-A67D-F552BD265939}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Models", "..\samples\Models\Models.csproj", "{DE427C57-CBD7-4D9E-8C1C-5983AA6424F2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -68,6 +72,30 @@ Global
 		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Release|x64.Build.0 = Release|Any CPU
 		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Release|x86.ActiveCfg = Release|Any CPU
 		{B7C65BEC-2CD6-49AD-BCD0-F9D12BF1BF91}.Release|x86.Build.0 = Release|Any CPU
+		{529CE850-C05F-4193-A67D-F552BD265939}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{529CE850-C05F-4193-A67D-F552BD265939}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{529CE850-C05F-4193-A67D-F552BD265939}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{529CE850-C05F-4193-A67D-F552BD265939}.Debug|x64.Build.0 = Debug|Any CPU
+		{529CE850-C05F-4193-A67D-F552BD265939}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{529CE850-C05F-4193-A67D-F552BD265939}.Debug|x86.Build.0 = Debug|Any CPU
+		{529CE850-C05F-4193-A67D-F552BD265939}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{529CE850-C05F-4193-A67D-F552BD265939}.Release|Any CPU.Build.0 = Release|Any CPU
+		{529CE850-C05F-4193-A67D-F552BD265939}.Release|x64.ActiveCfg = Release|Any CPU
+		{529CE850-C05F-4193-A67D-F552BD265939}.Release|x64.Build.0 = Release|Any CPU
+		{529CE850-C05F-4193-A67D-F552BD265939}.Release|x86.ActiveCfg = Release|Any CPU
+		{529CE850-C05F-4193-A67D-F552BD265939}.Release|x86.Build.0 = Release|Any CPU
+		{DE427C57-CBD7-4D9E-8C1C-5983AA6424F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE427C57-CBD7-4D9E-8C1C-5983AA6424F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE427C57-CBD7-4D9E-8C1C-5983AA6424F2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DE427C57-CBD7-4D9E-8C1C-5983AA6424F2}.Debug|x64.Build.0 = Debug|Any CPU
+		{DE427C57-CBD7-4D9E-8C1C-5983AA6424F2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DE427C57-CBD7-4D9E-8C1C-5983AA6424F2}.Debug|x86.Build.0 = Debug|Any CPU
+		{DE427C57-CBD7-4D9E-8C1C-5983AA6424F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE427C57-CBD7-4D9E-8C1C-5983AA6424F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE427C57-CBD7-4D9E-8C1C-5983AA6424F2}.Release|x64.ActiveCfg = Release|Any CPU
+		{DE427C57-CBD7-4D9E-8C1C-5983AA6424F2}.Release|x64.Build.0 = Release|Any CPU
+		{DE427C57-CBD7-4D9E-8C1C-5983AA6424F2}.Release|x86.ActiveCfg = Release|Any CPU
+		{DE427C57-CBD7-4D9E-8C1C-5983AA6424F2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/SoapCore/MetaBodyWriter.cs
+++ b/src/SoapCore/MetaBodyWriter.cs
@@ -82,6 +82,7 @@ namespace SoapCore
 				writer.WriteStartElement("xs:complexType");
 				writer.WriteStartElement("xs:sequence");
 
+				// todo: fix here ref params also as in? (use already parsed params)
 				foreach (var parameter in operation.DispatchMethod.GetParameters().Where(x => !x.IsOut && !x.ParameterType.IsByRef))
 				{
 					var elementAttribute = parameter.GetCustomAttribute<XmlElementAttribute>();
@@ -96,6 +97,7 @@ namespace SoapCore
 				writer.WriteEndElement(); // xs:element
 
 				// output parameter / return of operation
+				// todo: add here out params as output? (use already parsed params)
 
 				writer.WriteStartElement("xs:element");
 				writer.WriteAttributeString("name", operation.Name + "Response");

--- a/src/SoapCore/MetaBodyWriter.cs
+++ b/src/SoapCore/MetaBodyWriter.cs
@@ -59,6 +59,18 @@ namespace SoapCore
 			AddService(writer);
 		}
 
+		private void WriteParameters(XmlDictionaryWriter writer, SoapMethodParameterInfo[] parameterInfos)
+		{
+			foreach (var parameterInfo in parameterInfos)
+			{
+				var elementAttribute = parameterInfo.Parameter.GetCustomAttribute<XmlElementAttribute>();
+				var parameterName = !string.IsNullOrEmpty(elementAttribute?.ElementName)
+										? elementAttribute.ElementName
+										: parameterInfo.Parameter.GetCustomAttribute<MessageParameterAttribute>()?.Name ?? parameterInfo.Parameter.Name;
+				AddSchemaType(writer, parameterInfo.Parameter.ParameterType, parameterName, @namespace: elementAttribute?.Namespace);
+			}
+		}
+
 		private void AddTypes(XmlDictionaryWriter writer)
 		{
 			writer.WriteStartElement("xs:schema");
@@ -82,22 +94,13 @@ namespace SoapCore
 				writer.WriteStartElement("xs:complexType");
 				writer.WriteStartElement("xs:sequence");
 
-				// todo: fix here ref params also as in? (use already parsed params)
-				foreach (var parameter in operation.DispatchMethod.GetParameters().Where(x => !x.IsOut && !x.ParameterType.IsByRef))
-				{
-					var elementAttribute = parameter.GetCustomAttribute<XmlElementAttribute>();
-					var parameterName = !string.IsNullOrEmpty(elementAttribute?.ElementName)
-						                    ? elementAttribute.ElementName
-						                    : parameter.GetCustomAttribute<MessageParameterAttribute>()?.Name ?? parameter.Name;
-					AddSchemaType(writer, parameter.ParameterType, parameterName, @namespace: elementAttribute?.Namespace);
-				}
+				WriteParameters(writer, operation.InParameters);
 
 				writer.WriteEndElement(); // xs:sequence
 				writer.WriteEndElement(); // xs:complexType
 				writer.WriteEndElement(); // xs:element
 
 				// output parameter / return of operation
-				// todo: add here out params as output? (use already parsed params)
 
 				writer.WriteStartElement("xs:element");
 				writer.WriteAttributeString("name", operation.Name + "Response");
@@ -113,6 +116,8 @@ namespace SoapCore
 					}
 					AddSchemaType(writer, returnType, operation.Name + "Result");
 				}
+
+				WriteParameters(writer, operation.OutParameters);
 
 				writer.WriteEndElement(); // xs:sequence
 				writer.WriteEndElement(); // xs:complexType

--- a/src/SoapCore/OperationDescription.cs
+++ b/src/SoapCore/OperationDescription.cs
@@ -6,18 +6,46 @@ using System.Linq;
 
 namespace SoapCore
 {
+	public enum SoapMethodParameterDirection
+	{
+		InOnly,
+		OutOnlyRef,
+		InAndOutRef
+	}
+
 	public class SoapMethodParameterInfo
 	{
 		public ParameterInfo Parameter { get; private set; }
+		public int Index { get; private set; }
+		public SoapMethodParameterDirection Direction { get; private set; }
 		public string Name { get; private set; }
 		public string Namespace { get; private set; }
-		public SoapMethodParameterInfo(ParameterInfo parameter, string name, string ns)
+		public SoapMethodParameterInfo(ParameterInfo parameter, int index, string name, string ns)
 		{
 			Parameter = parameter;
+			Index = index;
 			Name = name;
 			Namespace = ns;
+			if (!Parameter.IsOut && !Parameter.ParameterType.IsByRef)
+			{
+				Direction = SoapMethodParameterDirection.InOnly;
+			}
+			else if (Parameter.IsOut && Parameter.ParameterType.IsByRef)
+			{
+				Direction = SoapMethodParameterDirection.OutOnlyRef;
+			}
+			else if (!Parameter.IsOut && Parameter.ParameterType.IsByRef)
+			{
+				Direction = SoapMethodParameterDirection.InAndOutRef;
+			}
+			else
+			{
+				// non-ref out param (return type) not expected
+				throw new System.NotImplementedException($"unexpected combination of IsOut and IsByRef in parameter {Parameter.Name} of type {Parameter.ParameterType.FullName}");
+			}
 		}
 	}
+
 	public class OperationDescription
 	{
 		public ContractDescription Contract { get; private set; }
@@ -26,8 +54,9 @@ namespace SoapCore
 		public string Name { get; private set; }
 		public MethodInfo DispatchMethod { get; private set; }
 		public bool IsOneWay { get; private set; }
-		public SoapMethodParameterInfo[] NormalParameters { get; private set; }
-		public SoapMethodParameterInfo[] OutParameters { get;private set;}
+		public SoapMethodParameterInfo[] AllParameters { get; private set; }
+		public SoapMethodParameterInfo[] InParameters { get; private set; }
+		public SoapMethodParameterInfo[] OutParameters { get; private set;}
 		public string ReturnName {get;private set;}
 
 		public OperationDescription(ContractDescription contract, MethodInfo operationMethod, OperationContractAttribute contractAttribute)
@@ -38,20 +67,26 @@ namespace SoapCore
 			IsOneWay = contractAttribute.IsOneWay;
 			ReplyAction = contractAttribute.ReplyAction;
 			DispatchMethod = operationMethod;
-			NormalParameters = operationMethod.GetParameters().Where(x => !x.IsOut && !x.ParameterType.IsByRef)
-				.Select(info => CreateParameterInfo(info, contract)).ToArray();
-			OutParameters = operationMethod.GetParameters().Where(x => x.IsOut || x.ParameterType.IsByRef)
-				.Select(info => CreateParameterInfo(info, contract)).ToArray();
+			AllParameters = operationMethod.GetParameters()
+				.Select((info, index) => CreateParameterInfo(info, index, contract))
+				.ToArray();
+			InParameters = AllParameters
+				.Where(soapParam => soapParam.Direction != SoapMethodParameterDirection.OutOnlyRef)
+				.ToArray();
+			OutParameters = AllParameters
+				.Where(soapParam => soapParam.Direction != SoapMethodParameterDirection.InOnly)
+				.ToArray();
 			ReturnName = operationMethod.ReturnParameter.GetCustomAttribute<MessageParameterAttribute>()?.Name ?? Name + "Result";
 		}
-		static SoapMethodParameterInfo CreateParameterInfo(ParameterInfo info, ContractDescription contract)
+
+		static SoapMethodParameterInfo CreateParameterInfo(ParameterInfo info, int index, ContractDescription contract)
 		{
 			var elementAttribute = info.GetCustomAttribute<XmlElementAttribute>();
 			var parameterName = !string.IsNullOrEmpty(elementAttribute?.ElementName)
 									? elementAttribute.ElementName
 									: info.GetCustomAttribute<MessageParameterAttribute>()?.Name ?? info.Name;
 			var parameterNs = elementAttribute?.Namespace ?? contract.Namespace;
-			return new SoapMethodParameterInfo(info, parameterName, parameterNs);
+			return new SoapMethodParameterInfo(info, index, parameterName, parameterNs);
 		}
 	}
 }

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -300,6 +300,8 @@ namespace SoapCore
 				var parameterName = parameterInfo.Name;
 				var parameterNs = parameterInfo.Namespace;
 
+				// todo: still some issue here with ordering or something similar
+
 				if (xmlReader.IsStartElement(parameterName, parameterNs))
 				{
 					xmlReader.MoveToStartElement(parameterName, parameterNs);

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -209,8 +209,7 @@ namespace SoapCore
 					}
 
 					// Get operation arguments from message
-					Dictionary<string, object> outArgs = new Dictionary<string, object>();
-					var arguments = GetRequestArguments(requestMessage, reader, operation, ref outArgs);
+					var arguments = GetRequestArguments(requestMessage, reader, operation);
 
 					// Execute model binding filters
 					object modelBindingOutput = null;
@@ -218,23 +217,24 @@ namespace SoapCore
 					{
 						foreach (var modelType in modelBindingFilter.ModelTypes)
 						{
-							foreach (var arg in arguments)
-								if (arg != null && arg.GetType() == modelType) modelBindingFilter.OnModelBound(arg, serviceProvider, out modelBindingOutput);
+							foreach (var parameterInfo in operation.InParameters)
+							{
+								var arg = arguments[parameterInfo.Index];
+								if (arg != null && arg.GetType() == modelType)
+									modelBindingFilter.OnModelBound(arg, serviceProvider, out modelBindingOutput);
+							}
 						}
 					}
-
-					// avoid Concat() and ToArray() cost when no out args(this may be heavy operation)
-					var allArgs = outArgs.Count != 0 ? arguments.Concat(outArgs.Values).ToArray() : arguments;
 
 					// Execute Mvc ActionFilters
 					foreach (var actionFilterAttr in operation.DispatchMethod.CustomAttributes.Where(a => a.AttributeType.Name == "ServiceFilterAttribute"))
 					{
 						var actionFilter = serviceProvider.GetService(actionFilterAttr.ConstructorArguments[0].Value as Type);
-						actionFilter.GetType().GetMethod("OnSoapActionExecuting").Invoke(actionFilter, new object[] { operation.Name, allArgs, httpContext, modelBindingOutput });
+						actionFilter.GetType().GetMethod("OnSoapActionExecuting").Invoke(actionFilter, new object[] { operation.Name, arguments, httpContext, modelBindingOutput });
 					}
 
 					// Invoke Operation method
-					var responseObject = operation.DispatchMethod.Invoke(serviceInstance, allArgs);
+					var responseObject = operation.DispatchMethod.Invoke(serviceInstance, arguments);
 					if (operation.DispatchMethod.ReturnType.IsConstructedGenericType && operation.DispatchMethod.ReturnType.GetGenericTypeDefinition() == typeof(Task<>))
 					{
 						var responseTask = (Task)responseObject;
@@ -247,12 +247,11 @@ namespace SoapCore
 						// VoidTaskResult
 						responseObject = null;
 					}
-					int i = arguments.Length;
+
 					var resultOutDictionary = new Dictionary<string, object>();
-					foreach (var outArg in outArgs)
+					foreach (var parameterInfo in operation.OutParameters)
 					{
-						resultOutDictionary[outArg.Key] = allArgs[i];
-						i++;
+						resultOutDictionary[parameterInfo.Name] = arguments[parameterInfo.Index];
 					}
 
 					// Create response message
@@ -275,8 +274,9 @@ namespace SoapCore
 				}
 			}
 
-			// Execute response message filters			
-			try {
+			// Execute response message filters
+			try
+			{
 				foreach (var messageFilter in messageFilters) messageFilter.OnResponseExecuting(responseMessage);
 			}
 			catch (Exception ex) {
@@ -288,19 +288,17 @@ namespace SoapCore
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private object[] GetRequestArguments(Message requestMessage, System.Xml.XmlDictionaryReader xmlReader, OperationDescription operation, ref Dictionary<string, object> outArgs)
+		private object[] GetRequestArguments(Message requestMessage, System.Xml.XmlDictionaryReader xmlReader, OperationDescription operation)
 		{
-			var parameters = operation.NormalParameters;
-			// avoid reallocation
-			var arguments = new List<object>(parameters.Length + operation.OutParameters.Length);
+			var arguments = new object[operation.AllParameters.Length];
 
 			// Find the element for the operation's data
 			xmlReader.ReadStartElement(operation.Name, operation.Contract.Namespace);
 
-			for (int i = 0; i < parameters.Length; i++)
+			foreach (var parameterInfo in operation.InParameters)
 			{
-				var parameterName = parameters[i].Name;
-				var parameterNs = parameters[i].Namespace;
+				var parameterName = parameterInfo.Name;
+				var parameterNs = parameterInfo.Namespace;
 
 				if (xmlReader.IsStartElement(parameterName, parameterNs))
 				{
@@ -308,9 +306,9 @@ namespace SoapCore
 
 					if (xmlReader.IsStartElement(parameterName, parameterNs))
 					{
-						var elementType = parameters[i].Parameter.ParameterType.GetElementType();
-						if (elementType == null || parameters[i].Parameter.ParameterType.IsArray)
-							elementType = parameters[i].Parameter.ParameterType;
+						var elementType = parameterInfo.Parameter.ParameterType.GetElementType();
+						if (elementType == null || parameterInfo.Parameter.ParameterType.IsArray)
+							elementType = parameterInfo.Parameter.ParameterType;
 
 						switch (_serializer)
 						{
@@ -319,13 +317,13 @@ namespace SoapCore
 									// see https://referencesource.microsoft.com/System.Xml/System/Xml/Serialization/XmlSerializer.cs.html#c97688a6c07294d5
 									var serializer = CachedXmlSerializer.GetXmlSerializer(elementType, parameterName, parameterNs);
 									lock (serializer)
-										arguments.Add(serializer.Deserialize(xmlReader));
+										arguments[parameterInfo.Index] = serializer.Deserialize(xmlReader);
 								}
 								break;
 							case SoapSerializer.DataContractSerializer:
 								{
 									var serializer = new DataContractSerializer(elementType, parameterName, parameterNs);
-									arguments.Add(serializer.ReadObject(xmlReader, verifyObjectName: true));
+									arguments[parameterInfo.Index] = serializer.ReadObject(xmlReader, verifyObjectName: true);
 								}
 								break;
 							default: throw new NotImplementedException();
@@ -334,23 +332,30 @@ namespace SoapCore
 				}
 				else
 				{
-					arguments.Add(null);
+					arguments[parameterInfo.Index] = null;
 				}
 			}
 
 			foreach (var parameterInfo in operation.OutParameters)
 			{
+				if (arguments[parameterInfo.Index] != null)
+				{
+					// do not overwrite input ref parameters
+					continue;
+				}
+
 				if (parameterInfo.Parameter.ParameterType.Name == "Guid&")
-					outArgs[parameterInfo.Name] = Guid.Empty;
+					arguments[parameterInfo.Index] = Guid.Empty;
 				else if (parameterInfo.Parameter.ParameterType.Name == "String&" || parameterInfo.Parameter.ParameterType.GetElementType().IsArray)
-					outArgs[parameterInfo.Name] = null;
+					arguments[parameterInfo.Index] = null;
 				else
 				{
 					var type = parameterInfo.Parameter.ParameterType.GetElementType();
-					outArgs[parameterInfo.Name] = Activator.CreateInstance(type);
+					arguments[parameterInfo.Index] = Activator.CreateInstance(type);
 				}
 			}
-			return arguments.ToArray();
+
+			return arguments;
 		}
 
 		/// <summary>

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -295,12 +295,24 @@ namespace SoapCore
 			// Find the element for the operation's data
 			xmlReader.ReadStartElement(operation.Name, operation.Contract.Namespace);
 
+			// if any ordering issues, possible to rewrite like:
+			/*while (!xmlReader.EOF)
+			{
+				var parameterInfo = operation.InParameters.FirstOrDefault(p => p.Name == xmlReader.LocalName && p.Namespace == xmlReader.NamespaceURI);
+				if (parameterInfo == null)
+				{
+					xmlReader.Skip();
+					continue;
+				}
+				var parameterName = parameterInfo.Name;
+				var parameterNs = parameterInfo.Namespace;
+				...
+			}*/
+
 			foreach (var parameterInfo in operation.InParameters)
 			{
 				var parameterName = parameterInfo.Name;
 				var parameterNs = parameterInfo.Namespace;
-
-				// todo: still some issue here with ordering or something similar
 
 				if (xmlReader.IsStartElement(parameterName, parameterNs))
 				{


### PR DESCRIPTION
> issue: incorrect handle of mixture of multiple out/ref/value params while desearializing them and passing to service method invokation

fixed

> issue: missing out/ref params in schema generation

fixed with the same logic as above. however schema generation still incomplete, misses content of some types, and also need to get rid of '&' characters at the end of out/ref types. but this is another story.

to be done:
- tests

[issue/discussion](https://github.com/DigDes/SoapCore/issues/114)

[another issue:](https://github.com/DigDes/SoapCore/issues/116) perhaps I will implement something like [LegacyCompatibility] attribute to control additional envelope, need a bit more exploration. indeed other operations may be broken.