### PR TITLE
Ignoring props for WSDL with [IgnoreDataMember] attribute set

### DIFF
--- a/src/SoapCore/MetaBodyWriter.cs
+++ b/src/SoapCore/MetaBodyWriter.cs
@@ -165,7 +165,7 @@ namespace SoapCore
 					}
 					else
 					{
-						foreach (var property in toBuild.GetProperties())
+						foreach (var property in toBuild.GetProperties().Where(prop => !prop.CustomAttributes.Any(attr => attr.AttributeType.Name == "IgnoreDataMemberAttribute")))
 						{
 							AddSchemaType(writer, property.PropertyType, property.Name);
 						}


### PR DESCRIPTION
Modifed MetaBodyWriter.cs to exlcude any properties with [IgnoreDataMember] on them were omitted from the WSDL.

Example:
```
public class User {
    public long Id { get; set; }
    public string Username { get; set; }
    [IgnoreDataMember]
    public string Name { get; set; } // This property will not appear in the WSDL
    public int Age { get; set; }
}
```