### PR TITLE
Resolve .NET type Guid into XML schema type string, see issue #132

### DIFF
--- a/src/SoapCore/MetaBodyWriter.cs
+++ b/src/SoapCore/MetaBodyWriter.cs
@@ -598,6 +598,9 @@ namespace SoapCore
 				case "DateTime":
 					resolvedType = "xs:dateTime";
 					break;
+				case "Guid":
+					resolvedType = "xs:string";
+					break;
 			}
 
 			if (string.IsNullOrEmpty(resolvedType))


### PR DESCRIPTION
I just added the Guid type to resolve  as string into the XML schema.