### PR TITLE
Support for [ServiceContract] without Name attribute

### DIFF
--- a/src/SoapCore/OperationDescription.cs
+++ b/src/SoapCore/OperationDescription.cs
@@ -13,6 +13,11 @@ namespace SoapCore
             Contract = contract;
             Name = contractAttribute.Name ?? operationMethod.Name;
             SoapAction = contractAttribute.Action ?? $"{contract.Namespace.TrimEnd('/')}/{contract.Name}/{Name}";
+            if (string.IsNullOrEmpty(contract.Name))
+            {
+                SoapAction = contractAttribute.Action ?? $"{contract.Namespace.TrimEnd('/')}/{Name}";
+            }
+
             IsOneWay = contractAttribute.IsOneWay;
             ReplyAction = contractAttribute.ReplyAction;
             DispatchMethod = operationMethod;


### PR DESCRIPTION
I'm using SoapCore to implement a Soap WebService that must be compatible with a pre-WCF Soap WebService implementation from long ago. The old web service is marked with [ServiceContract] and specifies a Namespace, but no class name. This results in WebService action URLs like this:

`http://tempuri.org/operationName`

So there's no contract name (the classes name) between namespace and operation name. The following PR fixes generating the proper <soap:operation soapAction=""> tag attribute when no name is present in the ServiceContract C# attribute.