### PR TITLE
Add interface IServiceOperationTuner that helps to some extra tuning …

### DIFF
--- a/src/SoapCore.Tests/ITestService.cs
+++ b/src/SoapCore.Tests/ITestService.cs
@@ -60,5 +60,8 @@ namespace SoapCore.Tests
 		[OperationContract]
 		[ServiceFilter(typeof(ActionFilter.TestActionFilter))]
 		ComplexModelInput ComplexParamWithActionFilter(ComplexModelInput test);
+
+		[OperationContract]
+		string PingWithServiceOperationTuning();
 	}
 }

--- a/src/SoapCore.Tests/ServiceOperationTuner/ClientMessageInspector.cs
+++ b/src/SoapCore.Tests/ServiceOperationTuner/ClientMessageInspector.cs
@@ -1,0 +1,41 @@
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Dispatcher;
+
+namespace SoapCore.Tests.ServiceOperationTuner
+{
+	public class ClientMessageInspector : IClientMessageInspector
+	{
+		private readonly string _customPingValue;
+
+		public ClientMessageInspector(string customPingValue)
+		{
+			_customPingValue = customPingValue;
+		}
+
+		public void AfterReceiveReply(ref Message reply, object correlationState)
+		{
+		}
+
+		public object BeforeSendRequest(ref Message request, IClientChannel channel)
+		{
+			HttpRequestMessageProperty httpRequestMessage;
+			object httpRequestMessageObject;
+
+			if (request.Properties.TryGetValue(HttpRequestMessageProperty.Name, out httpRequestMessageObject))
+			{
+				httpRequestMessage = httpRequestMessageObject as HttpRequestMessageProperty;
+			}
+			else
+			{
+				httpRequestMessage = new HttpRequestMessageProperty();
+				request.Properties.Add(HttpRequestMessageProperty.Name, httpRequestMessage);
+			}
+
+			httpRequestMessage.Headers["ping_value"] = _customPingValue;
+
+			return Guid.NewGuid();
+		}
+	}
+}

--- a/src/SoapCore.Tests/ServiceOperationTuner/CustomHeadersEndpointBehavior.cs
+++ b/src/SoapCore.Tests/ServiceOperationTuner/CustomHeadersEndpointBehavior.cs
@@ -1,0 +1,33 @@
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+
+namespace SoapCore.Tests.ServiceOperationTuner
+{
+	public class CustomHeadersEndpointBehavior : IEndpointBehavior
+	{
+		private string _customPingValue;
+
+		public CustomHeadersEndpointBehavior(string customPingValue)
+		{
+			_customPingValue = customPingValue;
+		}
+
+		public void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
+		{
+			clientRuntime.ClientMessageInspectors.Add(new ClientMessageInspector(_customPingValue));
+		}
+
+		public void AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
+		{
+		}
+
+		public void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
+		{
+		}
+
+		public void Validate(ServiceEndpoint endpoint)
+		{
+		}
+	}
+}

--- a/src/SoapCore.Tests/ServiceOperationTuner/ServiceOperationTunerTests.cs
+++ b/src/SoapCore.Tests/ServiceOperationTuner/ServiceOperationTunerTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.ServiceModel;
+using System.Threading;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SoapCore.Tests.ServiceOperationTuner
+{
+	[TestClass]
+	public class ServiceOperationTunerTests
+	{
+		private static CancellationTokenSource _cancelTokenSource = new CancellationTokenSource();
+
+		[ClassInitialize]
+		public static void StartServer(TestContext testContext)
+		{
+			var host = new WebHostBuilder()
+					.UseKestrel()
+					.UseUrls("http://localhost:5054")
+					.UseStartup<Startup>()
+					.Build();
+
+			host.RunAsync(_cancelTokenSource.Token);
+		}
+
+		[ClassCleanup]
+		public static void StopServer()
+		{
+			_cancelTokenSource.Cancel();
+		}
+
+		[TestInitialize]
+		public void Reset()
+		{
+			TestServiceOperationTuner.Reset();
+		}
+
+		public ITestService CreateClient(string pingValue)
+		{
+			var binding = new BasicHttpBinding();
+			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:5054/Service.svc", "localhost")));
+			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);
+			channelFactory.Endpoint.EndpointBehaviors.Add(new CustomHeadersEndpointBehavior(pingValue));
+			var serviceClient = channelFactory.CreateChannel();
+			return serviceClient;
+		}
+
+		[TestMethod]
+		public void PassParameterViaHttpHeader()
+		{
+			Assert.IsFalse(TestServiceOperationTuner.IsCalled);
+			Assert.IsFalse(TestServiceOperationTuner.IsSetPingValue);
+
+			string expected = "ping value";
+			var client = CreateClient(expected);
+			var result = client.PingWithServiceOperationTuning();
+
+			Assert.IsTrue(TestServiceOperationTuner.IsCalled);
+			Assert.IsTrue(TestServiceOperationTuner.IsSetPingValue);
+			Assert.AreEqual(expected, result);
+		}
+
+		[TestMethod]
+		public void CheckThatPingIsNotAffectedByOperationTuner()
+		{
+			Assert.IsFalse(TestServiceOperationTuner.IsCalled);
+			Assert.IsFalse(TestServiceOperationTuner.IsSetPingValue);
+
+			string expected = "ping";
+			var client = CreateClient("bla-bla-bla");
+			var result = client.Ping("ping");
+
+			Assert.IsTrue(TestServiceOperationTuner.IsCalled);
+			Assert.IsFalse(TestServiceOperationTuner.IsSetPingValue);
+			Assert.AreEqual(expected, result);
+		}
+	}
+}

--- a/src/SoapCore.Tests/ServiceOperationTuner/Startup.cs
+++ b/src/SoapCore.Tests/ServiceOperationTuner/Startup.cs
@@ -1,0 +1,25 @@
+using System.ServiceModel;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace SoapCore.Tests.ServiceOperationTuner
+{
+	public class Startup
+	{
+		public void ConfigureServices(IServiceCollection services)
+		{
+			services.TryAddSingleton<TestService>();
+			services.AddSoapServiceOperationTuner(new TestServiceOperationTuner());
+			services.AddMvc();
+		}
+
+		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+		{
+			app.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+			app.UseMvc();
+		}
+	}
+}

--- a/src/SoapCore.Tests/ServiceOperationTuner/TestServiceOperationTuner.cs
+++ b/src/SoapCore.Tests/ServiceOperationTuner/TestServiceOperationTuner.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using SoapCore;
+
+namespace SoapCore.Tests.ServiceOperationTuner
+{
+	public class TestServiceOperationTuner : IServiceOperationTuner
+	{
+		public static bool IsCalled { get; private set; }
+		public static bool IsSetPingValue { get; private set; }
+
+		public static void Reset()
+		{
+			IsCalled = false;
+			IsSetPingValue = false;
+		}
+
+		public void Tune(HttpContext httpContext, object serviceInstance, SoapCore.OperationDescription operation)
+		{
+			IsCalled = true;
+			if ((serviceInstance != null) && (serviceInstance is TestService)
+				&& operation.Name.Equals("PingWithServiceOperationTuning"))
+			{
+				TestService service = serviceInstance as TestService;
+				string result = string.Empty;
+
+				StringValues pingValue;
+				if (httpContext.Request.Headers.TryGetValue("ping_value", out pingValue))
+				{
+					result = pingValue[0];
+				}
+
+				service.SetPingResult(result);
+				IsSetPingValue = true;
+			}
+		}
+	}
+}

--- a/src/SoapCore.Tests/TestService.cs
+++ b/src/SoapCore.Tests/TestService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ServiceModel;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using SoapCore.Tests.Model;
@@ -9,6 +10,8 @@ namespace SoapCore.Tests
 {
 	public class TestService : ITestService
 	{
+		private ThreadLocal<string> _pingResultValue = new ThreadLocal<string>() { Value = string.Empty };
+
 		public string Ping(string s)
 		{
 			return s;
@@ -93,6 +96,16 @@ namespace SoapCore.Tests
 		public ComplexModelInput ComplexParamWithActionFilter(ComplexModelInput test)
 		{
 			return test;
+		}
+
+		public void SetPingResult(string value)
+		{
+			_pingResultValue.Value = value;
+		}
+
+		public string PingWithServiceOperationTuning()
+		{
+			return _pingResultValue.Value;
 		}
 	}
 }

--- a/src/SoapCore/IServiceOperationTuner.cs
+++ b/src/SoapCore/IServiceOperationTuner.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Http;
+
+namespace SoapCore
+{
+	/// <summary>
+	/// Interface for tuning each operation call
+	/// </summary>
+	public interface IServiceOperationTuner
+	{
+		/// <summary>
+		/// Tune operation call.
+		/// Use this method if it is needed to do some extra configs for operation call.
+		/// For example if you need to get some data from http header for some of operations.
+		/// </summary>
+		/// <param name="httpContext">Current http context</param>
+		/// <param name="serviceInstance">Service instance</param>
+		/// <param name="operation">Operation description</param>
+		void Tune(HttpContext httpContext, object serviceInstance, OperationDescription operation);
+	}
+}

--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -55,5 +55,11 @@ namespace SoapCore
 			serviceCollection.TryAddSingleton(modelBindingFilter);
 			return serviceCollection;
 		}
+
+		public static IServiceCollection AddSoapServiceOperationTuner(this IServiceCollection serviceCollection, IServiceOperationTuner serviceOperationTuner)
+		{
+			serviceCollection.TryAddSingleton(serviceOperationTuner);
+			return serviceCollection;
+		}
 	}
 }

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -259,6 +259,13 @@ namespace SoapCore
 					// Invoke OnModelBound
 					_soapModelBounder?.OnModelBound(operation.DispatchMethod, arguments);
 
+					// Tune service instance for operation call
+					var serviceOperationTuners = serviceProvider.GetServices<IServiceOperationTuner>();
+					foreach (var operationTuner in serviceOperationTuners)
+					{
+						operationTuner.Tune(httpContext, serviceInstance, operation);
+					}
+
 					// Invoke Operation method
 					var responseObject = operation.DispatchMethod.Invoke(serviceInstance, arguments);
 					if (operation.DispatchMethod.ReturnType.IsConstructedGenericType && operation.DispatchMethod.ReturnType.GetGenericTypeDefinition() == typeof(Task<>))


### PR DESCRIPTION
…for each

operation call.
Method Tune() from that interface takes 3 parameters:
 * httpContext - current http context
 * serviceInstance - instance of service
 * operation - operation description

Use IServiceOperationTuner to get some information from http context
for operation call.
It's helps to migrate from old asmx to .net core SOAP implementation when
not possible to change clients for backward compatibility and clients sends additional
parameters in http headers. It is sad but it is not rare situation in real life.
Using additional midlleware is more complex and not clear solulion.

Added new interface instead of extend of IMessageInspector to avoid
break working solution for SoapCore users.

Extension AddSoapServiceOperationTuner() for IServiceCollection helps to
add operation tuner.

Note: use some thread sinhronization stuff (like ThreadLocal) if service is register as  singleton.