### PR TITLE
New IMessageInspector2 provided with the ServiceDescription

### DIFF
--- a/src/SoapCore/IMessageInspector2.cs
+++ b/src/SoapCore/IMessageInspector2.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SoapCore
+{
+	public interface IMessageInspector2
+	{
+		object AfterReceiveRequest(ref Message message, ServiceDescription serviceDescription);
+		void BeforeSendReply(ref Message reply, ServiceDescription serviceDescription, object correlationState);
+	}
+}

--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -10,20 +10,30 @@ namespace SoapCore
 	{
 		public static IApplicationBuilder UseSoapEndpoint<T>(this IApplicationBuilder builder, string path, MessageEncoder encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null)
 		{
+			return builder.UseSoapEndpoint(typeof(T), path, encoder, serializer, caseInsensitivePath, soapModelBounder);
+		}
+
+		public static IApplicationBuilder UseSoapEndpoint(this IApplicationBuilder builder, Type type, string path, MessageEncoder encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null)
+		{
 			if (soapModelBounder == null)
 			{
-				return builder.UseMiddleware<SoapEndpointMiddleware>(typeof(T), path, encoder, serializer, caseInsensitivePath);
+				return builder.UseMiddleware<SoapEndpointMiddleware>(type, path, encoder, serializer, caseInsensitivePath);
 			}
 
-			return builder.UseMiddleware<SoapEndpointMiddleware>(typeof(T), path, encoder, serializer, caseInsensitivePath, soapModelBounder);
+			return builder.UseMiddleware<SoapEndpointMiddleware>(type, path, encoder, serializer, caseInsensitivePath, soapModelBounder);
 		}
 
 		public static IApplicationBuilder UseSoapEndpoint<T>(this IApplicationBuilder builder, string path, Binding binding, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null)
 		{
+			return builder.UseSoapEndpoint(typeof(T), path, binding, serializer, caseInsensitivePath, soapModelBounder);
+		}
+
+		public static IApplicationBuilder UseSoapEndpoint(this IApplicationBuilder builder, Type type, string path, Binding binding, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null)
+		{
 			var element = binding.CreateBindingElements().Find<MessageEncodingBindingElement>();
 			var factory = element.CreateMessageEncoderFactory();
 			var encoder = factory.Encoder;
-			return builder.UseSoapEndpoint<T>(path, encoder, serializer, caseInsensitivePath, soapModelBounder);
+			return builder.UseSoapEndpoint(type, path, encoder, serializer, caseInsensitivePath, soapModelBounder);
 		}
 
 		public static IServiceCollection AddSoapExceptionTransformer(this IServiceCollection serviceCollection, Func<Exception, string> transformer)
@@ -33,6 +43,12 @@ namespace SoapCore
 		}
 
 		public static IServiceCollection AddSoapMessageInspector(this IServiceCollection serviceCollection, IMessageInspector messageInspector)
+		{
+			serviceCollection.TryAddSingleton(messageInspector);
+			return serviceCollection;
+		}
+
+		public static IServiceCollection AddSoapMessageInspector(this IServiceCollection serviceCollection, IMessageInspector2 messageInspector)
 		{
 			serviceCollection.TryAddSingleton(messageInspector);
 			return serviceCollection;

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -206,7 +206,7 @@ namespace SoapCore
 
 			var messageInspector2s = serviceProvider.GetServices<IMessageInspector2>();
 #pragma warning disable SA1008 // StyleCop has not yet been updated to support tuples
-			var correlationObjects2 = messageInspector2s.Select(mi => (inspector: mi, correlationObject: mi.AfterReceiveRequest(ref requestMessage, _service)));
+			var correlationObjects2 = messageInspector2s.Select(mi => (inspector: mi, correlationObject: mi.AfterReceiveRequest(ref requestMessage, _service))).ToList();
 #pragma warning restore SA1008
 
 			// for getting soapaction and parameters in body
@@ -302,10 +302,7 @@ namespace SoapCore
 					httpContext.Response.ContentType = httpContext.Request.ContentType;
 					httpContext.Response.Headers["SOAPAction"] = responseMessage.Headers.Action;
 
-					foreach (var correlationObj2 in correlationObjects2)
-					{
-						correlationObj2.inspector.BeforeSendReply(ref responseMessage, _service, correlationObj2.correlationObject);
-					}
+					correlationObjects2.ForEach(mi => mi.inspector.BeforeSendReply(ref responseMessage, _service, mi.correlationObject));
 
 					messageInspector?.BeforeSendReply(ref responseMessage, correlationObject);
 


### PR DESCRIPTION
Hi,

This is a PR to provide the feature for this:
https://github.com/DigDes/SoapCore/issues/164

To preserve backwards compatibility, I have added a new IMessageInspector2 interface, which is similar to the existing IMessageInspector one, except that:
1. It allows multiple message inspectors to be registered, each gets their own CorrelationObject
2. It passes in the ServiceDescription as a parameter to the MessageInspector, so that the implementor knows which service is being called

I also added a couple of overloads of the UseSoapEndpoint() method to take a Type, to enable the endpoint type to be specified at runtime as well as the existing methods that use generics at compile-type. This is also required by my use-case.

I haven't added any tests yet as I wanted to get your feedback on whether we're happy with making these changes?
