### PR TITLE
Add IOperationInvoker to allow invoke behaviour to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ In Startup.cs:
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
+    services.AddSoapCore();
     services.TryAddSingleton<ServiceContractImpl>();
 }
 public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
@@ -42,6 +43,12 @@ See [Contributing guide](CONTRIBUTING.md)
 [![Build Status](https://travis-ci.com/DigDes/SoapCore.svg?branch=master)](https://travis-ci.com/DigDes/SoapCore)
 
 ### Tips and Tricks
+
+#### Extending the pipeline
+
+In your ConfigureServices method, you can register some additional items to extend the pipeline:
+* services.AddSoapMessageInspector() - add a custom MessageInspector. These function similarly to the `IDispatchMessageInspector` in WCF. The newer `IMessageInspector2` interface allows you to register multiple inspectors, and to know which service was being called.
+* services.AddSingleton<MyOperatorInvoker>() - add a custom OperationInvoker. Similar to WCF's `IOperationInvoker` this allows you to override the invoking of a service operation, commonly to add custom logging or exception handling logic around it.
 
 #### How to get custom HTTP header in SopaCore service
 

--- a/src/SoapCore.Tests/MessageFilter/Startup.cs
+++ b/src/SoapCore.Tests/MessageFilter/Startup.cs
@@ -11,6 +11,7 @@ namespace SoapCore.Tests.MessageFilter
 	{
 		public void ConfigureServices(IServiceCollection services)
 		{
+			services.AddSoapCore();
 			services.TryAddSingleton<TestService>();
 			services.AddSoapWsSecurityFilter("yourusername", "yourpassword");
 			services.AddMvc();

--- a/src/SoapCore.Tests/MessageInspector/Startup.cs
+++ b/src/SoapCore.Tests/MessageInspector/Startup.cs
@@ -11,6 +11,7 @@ namespace SoapCore.Tests.MessageInspector
 	{
 		public void ConfigureServices(IServiceCollection services)
 		{
+			services.AddSoapCore();
 			services.TryAddSingleton<TestService>();
 			services.AddSoapMessageInspector(new MessageInspectorMock());
 			services.AddMvc();

--- a/src/SoapCore.Tests/Serialization/ServiceFixture.cs
+++ b/src/SoapCore.Tests/Serialization/ServiceFixture.cs
@@ -28,6 +28,7 @@ namespace SoapCore.Tests.Serialization
 					// init SampleService service mock
 					ServiceMock = new Mock<IService>();
 					services.AddSingleton(ServiceMock.Object);
+					services.AddSoapCore();
 					services.AddMvc();
 				})
 				.Configure(appBuilder =>

--- a/src/SoapCore.Tests/ServiceOperationTuner/Startup.cs
+++ b/src/SoapCore.Tests/ServiceOperationTuner/Startup.cs
@@ -11,6 +11,7 @@ namespace SoapCore.Tests.ServiceOperationTuner
 	{
 		public void ConfigureServices(IServiceCollection services)
 		{
+			services.AddSoapCore();
 			services.TryAddSingleton<TestService>();
 			services.AddSoapServiceOperationTuner(new TestServiceOperationTuner());
 			services.AddMvc();

--- a/src/SoapCore.Tests/Startup.cs
+++ b/src/SoapCore.Tests/Startup.cs
@@ -15,6 +15,7 @@ namespace SoapCore.Tests
 	{
 		public void ConfigureServices(IServiceCollection services)
 		{
+			services.AddSoapCore();
 			services.TryAddSingleton<TestService>();
 			services.AddSoapModelBindingFilter(new ModelBindingFilter.TestModelBindingFilter(new List<Type> { typeof(ComplexModelInputForModelBindingFilter) }));
 			services.AddScoped<ActionFilter.TestActionFilter>();

--- a/src/SoapCore/DefaultOperationInvoker.cs
+++ b/src/SoapCore/DefaultOperationInvoker.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SoapCore
+{
+	public class DefaultOperationInvoker : IOperationInvoker
+	{
+		public async Task<object> InvokeAsync(MethodInfo methodInfo, object serviceInstance, object[] arguments)
+		{
+			// Invoke Operation method
+			var responseObject = methodInfo.Invoke(serviceInstance, arguments);
+			if (methodInfo.ReturnType.IsConstructedGenericType && methodInfo.ReturnType.GetGenericTypeDefinition() == typeof(Task<>))
+			{
+				var responseTask = (Task)responseObject;
+				await responseTask;
+				responseObject = responseTask.GetType().GetProperty("Result").GetValue(responseTask);
+			}
+			else if (responseObject is Task responseTask)
+			{
+				await responseTask;
+
+				//VoidTaskResult
+				responseObject = null;
+			}
+
+			return responseObject;
+		}
+	}
+}

--- a/src/SoapCore/IOperationInvoker.cs
+++ b/src/SoapCore/IOperationInvoker.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SoapCore
+{
+	public interface IOperationInvoker
+	{
+		Task<object> InvokeAsync(MethodInfo methodInfo, object instance, object[] inputs);
+	}
+}

--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -56,7 +56,7 @@ namespace SoapCore
 
 		public static IServiceCollection AddSoapMessageInspector(this IServiceCollection serviceCollection, IMessageInspector2 messageInspector)
 		{
-			serviceCollection.TryAddSingleton(messageInspector);
+			serviceCollection.AddSingleton(messageInspector);
 			return serviceCollection;
 		}
 

--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -36,6 +36,12 @@ namespace SoapCore
 			return builder.UseSoapEndpoint(type, path, encoder, serializer, caseInsensitivePath, soapModelBounder);
 		}
 
+		public static IServiceCollection AddSoapCore(this IServiceCollection serviceCollection)
+		{
+			serviceCollection.TryAddSingleton<IOperationInvoker, DefaultOperationInvoker>();
+			return serviceCollection;
+		}
+
 		public static IServiceCollection AddSoapExceptionTransformer(this IServiceCollection serviceCollection, Func<Exception, string> transformer)
 		{
 			serviceCollection.TryAddSingleton(new ExceptionTransformer(transformer));

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -271,7 +271,7 @@ namespace SoapCore
 						operationTuner.Tune(httpContext, serviceInstance, operation);
 					}
 
-					var invoker = serviceProvider.GetRequiredService<IOperationInvoker>();
+					var invoker = serviceProvider.GetService<IOperationInvoker>() ?? new DefaultOperationInvoker();
 					var responseObject = await invoker.InvokeAsync(operation.DispatchMethod, serviceInstance, arguments);
 
 					var resultOutDictionary = new Dictionary<string, object>();

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -271,21 +271,8 @@ namespace SoapCore
 						operationTuner.Tune(httpContext, serviceInstance, operation);
 					}
 
-					// Invoke Operation method
-					var responseObject = operation.DispatchMethod.Invoke(serviceInstance, arguments);
-					if (operation.DispatchMethod.ReturnType.IsConstructedGenericType && operation.DispatchMethod.ReturnType.GetGenericTypeDefinition() == typeof(Task<>))
-					{
-						var responseTask = (Task)responseObject;
-						await responseTask;
-						responseObject = responseTask.GetType().GetProperty("Result").GetValue(responseTask);
-					}
-					else if (responseObject is Task responseTask)
-					{
-						await responseTask;
-
-						//VoidTaskResult
-						responseObject = null;
-					}
+					var invoker = serviceProvider.GetRequiredService<IOperationInvoker>();
+					var responseObject = await invoker.InvokeAsync(operation.DispatchMethod, serviceInstance, arguments);
 
 					var resultOutDictionary = new Dictionary<string, object>();
 					foreach (var parameterInfo in operation.OutParameters)


### PR DESCRIPTION
One feature that WCF had that was missing from SoapCore was the ability to register a custom IOperationInvoker that could override the way that the service method was invoked.

The common use-case for this is adding custom logging and exception handling logic around the calls to service methods.

This PR implements this feature.

**NOTE**: The way I have done this is to add a `services.AddSoapCore()` method which registers the default OperationInvoker, which the application can then override. This `AddSoapCore` method is probably useful to have generally on the IServiceCollection but as it would be a breaking change requiring existing apps to add a call to it, I have also defaulted it in the code so it will continue to work if this is not specified.

I also fixed the new AddSoapMessageInspector extension method as it was using TryAddSingleton which meant that only one could be registered, this has been changed to AddSingleton.