### PR TITLE
Update Middleware to use trailing path

### DIFF
--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -39,8 +39,10 @@ namespace SoapCore
 
 		public async Task Invoke(HttpContext httpContext, IServiceProvider serviceProvider)
 		{
-			httpContext.Request.EnableRewind();
-			if (httpContext.Request.Path.Equals(_endpointPath, _pathComparisonStrategy))
+			httpContext.Request.EnableRewind();			
+			string servicePathPart = httpContext.Request.Path.Value.Substring(httpContext.Request.Path.Value.LastIndexOf('/'));
+			
+			if (servicePathPart.Equals(_endpointPath, _pathComparisonStrategy))
 			{
 				_logger.LogDebug($"Received SOAP Request for {httpContext.Request.Path} ({httpContext.Request.ContentLength ?? 0} bytes)");
 


### PR DESCRIPTION
We are using a url with a dynamic path part which is not known at service startup time. There are too many variations of the path to register them all as service endpoints. This PR changes the middleware Invoke to compare the path to a service endpoint using only the trailing part of the path.

Example:
Url: http://localhost/AppName/DynamicPathPart/Service.asmx
compare on trailing path: "/Service.asmx"  
instead of path: "/DynamicPathPart/Service.asmx"