### PR TITLE
Soap namespace fix for SOAP 1.2

### DIFF
--- a/src/SoapCore/MetaMessage.cs
+++ b/src/SoapCore/MetaMessage.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.ServiceModel.Channels;
 using System.Xml;
@@ -45,7 +46,7 @@ namespace SoapCore
             }
 			else
 			{
-				throw new Exception("Unsupported MessageVersion encountered while writing envelope: " + Version);
+				throw new ArgumentOutOfRangeException(nameof(Version), "Unsupported MessageVersion encountered while writing envelope.");
 			}
 
 			writer.WriteAttributeString("xmlns:tns", _service.Contracts.First().Namespace);

--- a/src/SoapCore/MetaMessage.cs
+++ b/src/SoapCore/MetaMessage.cs
@@ -34,7 +34,20 @@ namespace SoapCore
 		{
 			writer.WriteStartElement("wsdl", "definitions", "http://schemas.xmlsoap.org/wsdl/");
 			writer.WriteAttributeString("xmlns:xsd", "http://www.w3.org/2001/XMLSchema");
-			writer.WriteAttributeString("xmlns:soap", "http://schemas.xmlsoap.org/wsdl/soap/");
+
+			if (Version == MessageVersion.Soap11 || Version == MessageVersion.Soap11WSAddressingAugust2004 || Version == MessageVersion.Soap11WSAddressingAugust2004) // Soap11
+			{
+				writer.WriteAttributeString("xmlns:soap", "http://schemas.xmlsoap.org/wsdl/soap/");
+            }
+			else if(Version == MessageVersion.Soap12WSAddressing10 || Version == MessageVersion.Soap12WSAddressingAugust2004) // Soap12
+			{
+				writer.WriteAttributeString("xmlns:soap", "http://schemas.xmlsoap.org/wsdl/soap12/");
+            }
+			else
+			{
+				throw new ArgumentOutOfRangeException(nameof(Version), "Unsupported MessageVersion encountered while writing envelope.");
+			}
+
 			writer.WriteAttributeString("xmlns:tns", _service.Contracts.First().Namespace);
 			writer.WriteAttributeString("xmlns:wsam", "http://www.w3.org/2007/05/addressing/metadata");
 			writer.WriteAttributeString("targetNamespace", _service.Contracts.First().Namespace);

--- a/src/SoapCore/MetaMessage.cs
+++ b/src/SoapCore/MetaMessage.cs
@@ -39,13 +39,13 @@ namespace SoapCore
 			{
 				writer.WriteAttributeString("xmlns:soap", "http://schemas.xmlsoap.org/wsdl/soap/");
             }
-			else if(Version == MessageVersion.Soap12WSAddressing10 || Version == MessageVersion.Soap12WSAddressingAugust2004) // Soap12
+			else if (Version == MessageVersion.Soap12WSAddressing10 || Version == MessageVersion.Soap12WSAddressingAugust2004) // Soap12
 			{
 				writer.WriteAttributeString("xmlns:soap", "http://schemas.xmlsoap.org/wsdl/soap12/");
             }
 			else
 			{
-				throw new ArgumentOutOfRangeException(nameof(Version), "Unsupported MessageVersion encountered while writing envelope.");
+				throw new Exception("Unsupported MessageVersion encountered while writing envelope: " + Version);
 			}
 
 			writer.WriteAttributeString("xmlns:tns", _service.Contracts.First().Namespace);


### PR DESCRIPTION
Updated namespace for SOAP 1.2 to fix #181 

I had to wrote it this way, because .NET Core currently doesn't have 'Soap12' MessageVersion member. When it will be present (see https://github.com/dotnet/wcf/issues/2711) implementation should be updated to cover new member.