### PR TITLE
Fix 0.9.9.3 breaks WSDL for enums #189

### DIFF
--- a/samples/Models/ComplexModelResponse.cs
+++ b/samples/Models/ComplexModelResponse.cs
@@ -1,14 +1,25 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Models
 {
-    public class ComplexModelResponse
-    {
+	[DataContract]
+	public class ComplexModelResponse
+	{
 		public float FloatProperty { get; set; }
 		public string StringProperty { get; set; }
 		public List<string> ListProperty { get; set; }
 
-        public DateTimeOffset DateTimeOffsetProperty { get; set; }
+		public DateTimeOffset DateTimeOffsetProperty { get; set; }
+
+		[DataMember]
+		public TestEnum TestEnum { get; set; }
+	}
+
+	public enum TestEnum
+	{
+		One,
+		Two
 	}
 }

--- a/samples/Server/Program.cs
+++ b/samples/Server/Program.cs
@@ -13,7 +13,7 @@ namespace Server
 		{
 			var host = new WebHostBuilder()
 				.UseKestrel()
-				.UseUrls("http://*:5050")
+				.UseUrls("http://*:5051")
 				.UseContentRoot(Directory.GetCurrentDirectory())
 				.UseStartup<Startup>()
 				.Build();

--- a/samples/Server/Program.cs
+++ b/samples/Server/Program.cs
@@ -13,7 +13,7 @@ namespace Server
 		{
 			var host = new WebHostBuilder()
 				.UseKestrel()
-				.UseUrls("http://*:5051")
+				.UseUrls("http://*:5050")
 				.UseContentRoot(Directory.GetCurrentDirectory())
 				.UseStartup<Startup>()
 				.Build();

--- a/src/SoapCore/MetaMessage.cs
+++ b/src/SoapCore/MetaMessage.cs
@@ -36,14 +36,17 @@ namespace SoapCore
 			writer.WriteStartElement("wsdl", "definitions", "http://schemas.xmlsoap.org/wsdl/");
 			writer.WriteAttributeString("xmlns:xsd", "http://www.w3.org/2001/XMLSchema");
 
-			if (Version == MessageVersion.Soap11 || Version == MessageVersion.Soap11WSAddressingAugust2004 || Version == MessageVersion.Soap11WSAddressingAugust2004) // Soap11
+			// Soap11
+			if (Version == MessageVersion.Soap11 || Version == MessageVersion.Soap11WSAddressingAugust2004 || Version == MessageVersion.Soap11WSAddressingAugust2004)
 			{
 				writer.WriteAttributeString("xmlns:soap", "http://schemas.xmlsoap.org/wsdl/soap/");
-            }
-			else if (Version == MessageVersion.Soap12WSAddressing10 || Version == MessageVersion.Soap12WSAddressingAugust2004) // Soap12
+			}
+
+			// Soap12
+			else if (Version == MessageVersion.Soap12WSAddressing10 || Version == MessageVersion.Soap12WSAddressingAugust2004)
 			{
 				writer.WriteAttributeString("xmlns:soap", "http://schemas.xmlsoap.org/wsdl/soap12/");
-            }
+			}
 			else
 			{
 				throw new ArgumentOutOfRangeException(nameof(Version), "Unsupported MessageVersion encountered while writing envelope.");

--- a/src/SoapCore/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/MetaWCFBodyWriter.cs
@@ -559,6 +559,7 @@ namespace SoapCore
 			if (typeInfo.IsEnum)
 			{
 				WriteComplexElementType(writer, type.Name, _schemaNamespace, objectNamespace);
+				writer.WriteAttributeString("name", type.Name);
 				_enumToBuild.Enqueue(type);
 			}
 			else if (typeInfo.IsValueType)
@@ -710,6 +711,8 @@ namespace SoapCore
 			{
 				writer.WriteAttributeString("type", $"tns:{typeName}");
 			}
+
+			//writer.WriteAttributeString("name", typeName);
 		}
 
 #pragma warning disable SA1009 // Closing parenthesis must be spaced correctly


### PR DESCRIPTION
Add name attribute for enum types for WCF WSDL generation.