### PR TITLE
Resolve #190 and #63

### DIFF
--- a/src/SoapCore/MetaMessage.cs
+++ b/src/SoapCore/MetaMessage.cs
@@ -35,6 +35,7 @@ namespace SoapCore
 		{
 			writer.WriteStartElement("wsdl", "definitions", "http://schemas.xmlsoap.org/wsdl/");
 			writer.WriteAttributeString("xmlns:xsd", "http://www.w3.org/2001/XMLSchema");
+			writer.WriteAttributeString("xmlns:msc", "http://schemas.microsoft.com/ws/2005/12/wsdl/contract");
 
 			// Soap11
 			if (Version == MessageVersion.Soap11 || Version == MessageVersion.Soap11WSAddressingAugust2004 || Version == MessageVersion.Soap11WSAddressingAugust2004)

--- a/src/SoapCore/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/MetaWCFBodyWriter.cs
@@ -197,8 +197,17 @@ namespace SoapCore
 				writer.WriteEndElement(); // xs:annotation
 
 				writer.WriteStartElement("xs:sequence");
-				AddSchemaType(writer, typeof(DateTime), "DateTime", false);
-				AddSchemaType(writer, typeof(short), "OffsetMinutes", false);
+
+				writer.WriteStartElement("xs:element");
+				writer.WriteAttributeString("name", "DateTime");
+				writer.WriteAttributeString("type", "xs:dateTime");
+				writer.WriteEndElement();
+
+				writer.WriteStartElement("xs:element");
+				writer.WriteAttributeString("name", "OffsetMinutes");
+				writer.WriteAttributeString("type", "xs:short");
+				writer.WriteEndElement();
+
 				writer.WriteEndElement(); // xs:sequence
 
 				writer.WriteEndElement(); // xs:complexType

--- a/src/SoapCore/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/MetaWCFBodyWriter.cs
@@ -112,6 +112,7 @@ namespace SoapCore
 			writer.WriteAttributeString("elementFormDefault", "qualified");
 			writer.WriteAttributeString("targetNamespace", TargetNameSpace);
 			writer.WriteAttributeString("xmlns:xs", XMLNS_XS);
+
 			_schemaNamespace = TargetNameSpace;
 			_namespaceCounter = 1;
 
@@ -354,6 +355,8 @@ namespace SoapCore
 			writer.WriteAttributeString("targetNamespace", ModelNameSpace);
 			writer.WriteAttributeString("xmlns:xs", XMLNS_XS);
 			writer.WriteAttributeString("xmlns:tns", ModelNameSpace);
+			writer.WriteAttributeString("xmlns:ser", SERIALIZATION_NS);
+
 			_namespaceCounter = 1;
 			_schemaNamespace = ModelNameSpace;
 
@@ -377,6 +380,7 @@ namespace SoapCore
 				{
 					writer.WriteStartElement("xs:complexType");
 					writer.WriteAttributeString("name", toBuildName);
+					writer.WriteAttributeString("xmlns:ser", SERIALIZATION_NS);
 					writer.WriteStartElement("xs:sequence");
 
 					if (toBuild.IsArray || typeof(IEnumerable).IsAssignableFrom(toBuild))


### PR DESCRIPTION
Fix: Generated WSDL reply uses a namespace before declaring it #190
Fix: Support DateTimeOffset in wsdl generation #62 (WCF) 