### PR TITLE
Added TimeSpan to ResolveType

### DIFF
--- a/src/SoapCore/MetaBodyWriter.cs
+++ b/src/SoapCore/MetaBodyWriter.cs
@@ -624,6 +624,9 @@ namespace SoapCore
 				case "Char":
 					resolvedType = "xs:string";
 					break;
+				case "TimeSpan":
+					resolvedType = "xs:duration";
+					break;
 			}
 
 			if (string.IsNullOrEmpty(resolvedType))


### PR DESCRIPTION
I added TimeSpan to the ResolveType. This was found to be missing. As per several StackOverflow posts I chose to use xs:duration rather than xs:time.