### PR TITLE
Fix for issue 117

### DIFF
--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -361,7 +361,7 @@ namespace SoapCore
 			var arguments = new object[operation.AllParameters.Length];
 
 			// Find the element for the operation's data
-			if (!operation.IsMessageContractRequest)
+			if (!operation.IsMessageContractRequest && string.Compare(xmlReader.LocalName, operation.Name, StringComparison.OrdinalIgnoreCase) != 0)
 			{
 				xmlReader.ReadStartElement(operation.Name, operation.Contract.Namespace);
 			}


### PR DESCRIPTION
Added `GetRequestArguments` check before reading the start element, in case we're already on the start element

Fixes #117 