### PR TITLE
Add custom exception transformer

### DIFF
--- a/src/SoapCore.Tests/FaultExceptionTransformer/FaultExceptionTransformerTests.cs
+++ b/src/SoapCore.Tests/FaultExceptionTransformer/FaultExceptionTransformerTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SoapCore.Tests.FaultExceptionTransformer
+{
+	[TestClass]
+	public class FaultExceptionTransformerTests
+	{
+		private static IWebHost _host;
+
+		[ClassInitialize]
+		public static void StartServer(TestContext testContext)
+		{
+			Task.Run(() =>
+			{
+				_host = new WebHostBuilder()
+					.UseKestrel()
+					.UseUrls("http://127.0.0.1:0")
+					.UseStartup<Startup>()
+					.Build();
+
+				_host.Run();
+			});
+
+			while (_host == null || _host.ServerFeatures.Get<IServerAddressesFeature>().Addresses.First().EndsWith(":0"))
+			{
+				Thread.Sleep(2000);
+			}
+		}
+
+		public ITestService CreateClient()
+		{
+			var addresses = _host.ServerFeatures.Get<IServerAddressesFeature>();
+			var address = addresses.Addresses.Single();
+
+			var binding = new BasicHttpBinding();
+			var endpoint = new EndpointAddress(new Uri(string.Format("{0}/Service.svc", address)));
+			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);
+			var serviceClient = channelFactory.CreateChannel();
+			return serviceClient;
+		}
+
+		[TestMethod]
+		public void CustomFaultMessage()
+		{
+			try
+			{
+				var client = CreateClient();
+				client.ThrowExceptionWithMessage("foo");
+			}
+			catch (FaultException exception)
+			{
+				Assert.AreEqual("foo", exception.Message);
+
+				var messageFault = exception.CreateMessageFault();
+				var detail = messageFault.GetDetail<TestFault>();
+
+				Assert.IsNotNull(detail);
+
+				Assert.AreEqual("foo:bar", detail.AdditionalProperty);
+			}
+		}
+	}
+}

--- a/src/SoapCore.Tests/FaultExceptionTransformer/Startup.cs
+++ b/src/SoapCore.Tests/FaultExceptionTransformer/Startup.cs
@@ -1,0 +1,26 @@
+using System.ServiceModel;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace SoapCore.Tests.FaultExceptionTransformer
+{
+	public class Startup
+	{
+		public void ConfigureServices(IServiceCollection services)
+		{
+			services.AddSoapCore();
+			services.TryAddSingleton<TestService>();
+			services.AddSingleton<IFaultExceptionTransformer, TestFaultExceptionTransformer>();
+			services.AddMvc();
+		}
+
+		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+		{
+			app.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+			app.UseMvc();
+		}
+	}
+}

--- a/src/SoapCore.Tests/FaultExceptionTransformer/TestFault.cs
+++ b/src/SoapCore.Tests/FaultExceptionTransformer/TestFault.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace SoapCore.Tests.FaultExceptionTransformer
+{
+	[DataContract]
+	public class TestFault
+	{
+		public TestFault()
+		{
+		}
+
+		[DataMember]
+		public string Message { get; set; }
+
+		[DataMember]
+		public string AdditionalProperty { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/FaultExceptionTransformer/TestFaultExceptionTransformer.cs
+++ b/src/SoapCore.Tests/FaultExceptionTransformer/TestFaultExceptionTransformer.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Text;
+
+namespace SoapCore.Tests.FaultExceptionTransformer
+{
+	public class TestFaultExceptionTransformer : IFaultExceptionTransformer
+	{
+		public Message ProvideFault(Exception exception, MessageVersion messageVersion)
+		{
+			var fault = new TestFault
+			{
+				Message = exception.Message,
+				AdditionalProperty = "foo:bar"
+			};
+
+			var faultException = new FaultException<TestFault>(fault, new FaultReason(exception.Message), new FaultCode(nameof(TestFault)), nameof(TestFault));
+
+			var messageFault = faultException.CreateMessageFault();
+			var bodyWriter = new MessageFaultBodyWriter(messageFault, messageVersion);
+			var faultMessage = Message.CreateMessage(messageVersion, null, bodyWriter);
+
+			return faultMessage;
+		}
+	}
+}

--- a/src/SoapCore/IFaultExceptionTransformer.cs
+++ b/src/SoapCore/IFaultExceptionTransformer.cs
@@ -3,8 +3,22 @@ using System.ServiceModel.Channels;
 
 namespace SoapCore
 {
+	/// <summary>
+	/// Allows for applications to define their own fault message type
+	/// </summary>
 	public interface IFaultExceptionTransformer
 	{
-		Message ProvideFault(Exception exception);
+		/// <summary>
+		/// Transforms a provided exception to a formatted SOAP Message.
+		///
+		/// If porting an existing application that uses FaultException CreateMessageFault(),
+		/// you will need to format it by creating an instance of MessageFaultBodyWriter
+		/// and passing that to Message.CreateMessage
+		/// </summary>
+		/// <param name="exception">Exception to transform</param>
+		/// <param name="messageVersion">SOAP message version</param>
+		/// <returns>Fully formatted SOAP Message</returns>
+		/// <seealso cref="MessageFaultBodyWriter"/>
+		Message ProvideFault(Exception exception, MessageVersion messageVersion);
 	}
 }

--- a/src/SoapCore/IFaultExceptionTransformer.cs
+++ b/src/SoapCore/IFaultExceptionTransformer.cs
@@ -1,0 +1,10 @@
+using System;
+using System.ServiceModel.Channels;
+
+namespace SoapCore
+{
+	public interface IFaultExceptionTransformer
+	{
+		Message ProvideFault(Exception exception);
+	}
+}

--- a/src/SoapCore/MessageFaultBodyWriter.cs
+++ b/src/SoapCore/MessageFaultBodyWriter.cs
@@ -1,0 +1,29 @@
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Xml;
+
+namespace SoapCore
+{
+	/// <summary>
+	/// BodyWriter implementation that formats MessageFault messages (from FaultException)
+	/// </summary>
+	public class MessageFaultBodyWriter : BodyWriter
+	{
+		private readonly MessageFault _fault;
+		private readonly MessageVersion _messageVersion;
+
+		public MessageFaultBodyWriter(MessageFault fault, MessageVersion messageVersion, bool isBuffered = true) : base(isBuffered)
+		{
+			_fault = fault;
+			_messageVersion = messageVersion;
+		}
+
+		protected override void OnWriteBodyContents(XmlDictionaryWriter writer)
+		{
+			// This uses reflection to find the WriteTo method.
+			// For some reason, even though its in the assembly, its not exposed in the .NET Standard API
+			var writeToMethod = _fault.GetType().GetMethod("WriteTo", new[] { typeof(XmlDictionaryWriter), typeof(EnvelopeVersion) });
+			writeToMethod.Invoke(_fault, new object[] { writer, _messageVersion.Envelope });
+		}
+	}
+}

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.ServiceModel;
@@ -333,6 +334,11 @@ namespace SoapCore
 				}
 				catch (Exception exception)
 				{
+					if (exception is TargetInvocationException targetInvocationException)
+					{
+						exception = targetInvocationException.InnerException;
+					}
+
 					_logger.LogWarning(0, exception, exception.Message);
 					responseMessage = WriteErrorResponseMessage(exception, StatusCodes.Status500InternalServerError, serviceProvider, messageEncoder, httpContext);
 				}
@@ -524,14 +530,13 @@ namespace SoapCore
 			MessageEncoder messageEncoder,
 			HttpContext httpContext)
 		{
-
 			Message faultMessage;
 
 			var faultExceptionTransformer = serviceProvider.GetService<IFaultExceptionTransformer>();
 
 			if (faultExceptionTransformer != null)
 			{
-				faultMessage = faultExceptionTransformer.ProvideFault(exception);
+				faultMessage = faultExceptionTransformer.ProvideFault(exception, messageEncoder.MessageVersion);
 			}
 			else
 			{


### PR DESCRIPTION
WCF has the ability to define your own error handler (IErrorHandler) that formats an Exception to a SOAP Message.

This provides similar capability to SoapCore, using a simpler interface.

This also adds a helper class that many users of this interface will need (MessageFaultBodyWriter) since Microsoft in their infinite wisdom doesn't expose publically the API needed to take a MessageFault (created from a FaultException) and convert that to a Message.

This will allow services that used custom faults in WCF, but used an IErrorHandler to create them, to remain 100% API compatible when ported to SoapCore with minimal code changes.