### PR TITLE
Implement ability to use non-wrapped MessageContract

### DIFF
--- a/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
@@ -54,6 +54,11 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 		NotWrappedFieldComplexInputResponse NotWrappedFieldComplexInputRequestMethod(
 			NotWrappedFieldComplexInputRequest request);
 
+		[OperationContract(Action = ServiceNamespace.Value + nameof(NotWrappedFieldDoubleComplexInputRequestMethod), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
+		NotWrappedFieldComplexInputResponse NotWrappedFieldDoubleComplexInputRequestMethod(
+			NotWrappedFieldDoubleComplexInputRequest request);
+
 		[OperationContract(Action = ServiceNamespace.Value + nameof(EnumMethod), ReplyAction = "*")]
 		[XmlSerializerFormat(SupportFaults = true)]
 		bool EnumMethod(out SampleEnum e);

--- a/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
@@ -44,6 +44,16 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 		PingComplexModelOldStyleResponse PingComplexModelOldStyle(
 			PingComplexModelOldStyleRequest request);
 
+		[OperationContract(Action = ServiceNamespace.Value + nameof(NotWrappedPropertyComplexInputRequestMethod), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
+		NotWrappedPropertyComplexInputResponse NotWrappedPropertyComplexInputRequestMethod(
+			NotWrappedPropertyComplexInputRequest request);
+
+		[OperationContract(Action = ServiceNamespace.Value + nameof(NotWrappedFieldComplexInputRequestMethod), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
+		NotWrappedFieldComplexInputResponse NotWrappedFieldComplexInputRequestMethod(
+			NotWrappedFieldComplexInputRequest request);
+
 		[OperationContract(Action = ServiceNamespace.Value + nameof(EnumMethod), ReplyAction = "*")]
 		[XmlSerializerFormat(SupportFaults = true)]
 		bool EnumMethod(out SampleEnum e);

--- a/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedFieldComplexInput.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedFieldComplexInput.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Runtime.Serialization;
+using System.ServiceModel;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[Serializable]
+	[XmlType(AnonymousType = true, Namespace = "http://tempuri.org/NotWrappedFieldComplexInput")]
+	public class NotWrappedFieldComplexInput
+	{
+		[XmlElement(Order = 0)]
+		public string StringProperty { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedFieldComplexInputRequest.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedFieldComplexInputRequest.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Runtime.Serialization;
+using System.ServiceModel;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[MessageContract(IsWrapped = false)]
+	public class NotWrappedFieldComplexInputRequest
+	{
+		[MessageBodyMember(Namespace = "http://tempuri.org/NotWrappedFieldComplexInput", Order = 0)]
+#pragma warning disable SA1401 // Fields must be private
+		public NotWrappedFieldComplexInput NotWrappedComplexInput;
+#pragma warning restore SA1401 // Fields must be private
+	}
+}

--- a/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedFieldComplexInputResponse.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedFieldComplexInputResponse.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Runtime.Serialization;
+using System.ServiceModel;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[MessageContract(IsWrapped = false)]
+	public class NotWrappedFieldComplexInputResponse
+	{
+		[MessageBodyMember(Namespace = "http://tempuri.org/NotWrappedFieldComplexInput", Order = 0)]
+#pragma warning disable SA1401 // Fields must be private
+		public NotWrappedFieldComplexInput NotWrappedComplexInput;
+#pragma warning restore SA1401 // Fields must be private
+	}
+}

--- a/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedFieldDoubleComplexInputRequest.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedFieldDoubleComplexInputRequest.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Runtime.Serialization;
+using System.ServiceModel;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[MessageContract(IsWrapped = false)]
+	public class NotWrappedFieldDoubleComplexInputRequest
+	{
+#pragma warning disable SA1401 // Fields must be private
+		[MessageBodyMember(Namespace = "http://tempuri.org/NotWrappedFieldDoubleComplexInput", Order = 0)]
+		public NotWrappedFieldComplexInput NotWrappedComplexInput1;
+
+		[MessageBodyMember(Namespace = "http://tempuri.org/NotWrappedFieldDoubleComplexInput", Order = 1)]
+		public NotWrappedFieldComplexInput NotWrappedComplexInput2;
+#pragma warning restore SA1401 // Fields must be private
+	}
+}

--- a/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedPropertyComplexInput.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedPropertyComplexInput.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Runtime.Serialization;
+using System.ServiceModel;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[Serializable]
+	[XmlType(AnonymousType = true, Namespace = "http://tempuri.org/NotWrappedPropertyComplexInput")]
+	public class NotWrappedPropertyComplexInput
+	{
+		[XmlElement(Order = 0)]
+		public string StringProperty { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedPropertyComplexInputRequest.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedPropertyComplexInputRequest.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Runtime.Serialization;
+using System.ServiceModel;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[MessageContract(IsWrapped = false)]
+	public class NotWrappedPropertyComplexInputRequest
+	{
+		[MessageBodyMember(Namespace = "http://tempuri.org/NotWrappedPropertyComplexInput", Order = 0)]
+		public NotWrappedPropertyComplexInput NotWrappedComplexInput { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedPropertyComplexInputResponse.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/NotWrappedPropertyComplexInputResponse.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Runtime.Serialization;
+using System.ServiceModel;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[MessageContract(IsWrapped = false)]
+	public class NotWrappedPropertyComplexInputResponse
+	{
+		[MessageBodyMember(Namespace = "http://tempuri.org/NotWrappedPropertyComplexInput", Order = 0)]
+		public NotWrappedPropertyComplexInput NotWrappedComplexInput { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
+++ b/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
@@ -318,6 +318,84 @@ namespace SoapCore.Tests.Serialization
 		//not compatible with DataContractSerializer
 		[Theory]
 		[InlineData(SoapSerializer.XmlSerializer)]
+		public void TestNotWrappedPropertyComplexInput(SoapSerializer soapSerializer)
+		{
+			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
+
+			_fixture.ServiceMock
+				.Setup(x => x.NotWrappedPropertyComplexInputRequestMethod(It.IsAny<NotWrappedPropertyComplexInputRequest>()))
+				.Callback((NotWrappedPropertyComplexInputRequest request) =>
+				{
+					// Check deserialisation in service!
+					request.NotWrappedComplexInput.ShouldNotBeNull();
+					request.NotWrappedComplexInput.StringProperty.ShouldBe("z");
+				})
+				.Returns(() => new NotWrappedPropertyComplexInputResponse
+				{
+					NotWrappedComplexInput = new NotWrappedPropertyComplexInput
+					{
+						StringProperty = "z"
+					}
+				});
+
+			var clientResponse = sampleServiceClient.NotWrappedPropertyComplexInputRequestMethod(new NotWrappedPropertyComplexInputRequest
+			{
+				NotWrappedComplexInput = new NotWrappedPropertyComplexInput
+				{
+					StringProperty = "z"
+				}
+			});
+
+			clientResponse.ShouldNotBeNull();
+
+			// The client does not support unpacking these message contracts, so further assertions have been
+			// commented
+			//	clientResponse.NotWrappedComplexInput.ShouldNotBeNull();
+			//	clientResponse.NotWrappedComplexInput.StringProperty.ShouldBe("z");
+		}
+
+		//not compatible with DataContractSerializer
+		[Theory]
+		[InlineData(SoapSerializer.XmlSerializer)]
+		public void TestNotWrappedFieldComplexInput(SoapSerializer soapSerializer)
+		{
+			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
+
+			_fixture.ServiceMock
+				.Setup(x => x.NotWrappedFieldComplexInputRequestMethod(It.IsAny<NotWrappedFieldComplexInputRequest>()))
+				.Callback((NotWrappedFieldComplexInputRequest request) =>
+				{
+					// Check deserialisation in service!
+					request.NotWrappedComplexInput.ShouldNotBeNull();
+					request.NotWrappedComplexInput.StringProperty.ShouldBe("z");
+				})
+				.Returns(() => new NotWrappedFieldComplexInputResponse
+				{
+					NotWrappedComplexInput = new NotWrappedFieldComplexInput
+					{
+						StringProperty = "z"
+					}
+				});
+
+			var clientResponse = sampleServiceClient.NotWrappedFieldComplexInputRequestMethod(new NotWrappedFieldComplexInputRequest
+			{
+				NotWrappedComplexInput = new NotWrappedFieldComplexInput
+				{
+					StringProperty = "z"
+				}
+			});
+
+			clientResponse.ShouldNotBeNull();
+
+			// The client does not support unpacking these message contracts, so further assertions have been
+			// commented
+			//	clientResponse.NotWrappedComplexInput.ShouldNotBeNull();
+			//	clientResponse.NotWrappedComplexInput.StringProperty.ShouldBe("z");
+		}
+
+		//not compatible with DataContractSerializer
+		[Theory]
+		[InlineData(SoapSerializer.XmlSerializer)]
 		public void TestPingComplexModelOldStyleSerialization(SoapSerializer soapSerializer)
 		{
 			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);

--- a/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
+++ b/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
@@ -396,6 +396,53 @@ namespace SoapCore.Tests.Serialization
 		//not compatible with DataContractSerializer
 		[Theory]
 		[InlineData(SoapSerializer.XmlSerializer)]
+		public void TestNotWrappedFieldDoubleComplexInput(SoapSerializer soapSerializer)
+		{
+			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
+
+			_fixture.ServiceMock
+				.Setup(x => x.NotWrappedFieldDoubleComplexInputRequestMethod(It.IsAny<NotWrappedFieldDoubleComplexInputRequest>()))
+				.Callback((NotWrappedFieldDoubleComplexInputRequest request) =>
+				{
+					// Check deserialisation in service!
+					request.NotWrappedComplexInput1.ShouldNotBeNull();
+					request.NotWrappedComplexInput1.StringProperty.ShouldBe("z");
+
+					request.NotWrappedComplexInput2.ShouldNotBeNull();
+					request.NotWrappedComplexInput2.StringProperty.ShouldBe("x");
+				})
+				.Returns(() => new NotWrappedFieldComplexInputResponse
+				{
+					NotWrappedComplexInput = new NotWrappedFieldComplexInput
+					{
+						StringProperty = "z"
+					}
+				});
+
+			var clientResponse = sampleServiceClient.NotWrappedFieldDoubleComplexInputRequestMethod(new NotWrappedFieldDoubleComplexInputRequest
+			{
+				NotWrappedComplexInput1 = new NotWrappedFieldComplexInput
+				{
+					StringProperty = "z"
+				},
+
+				NotWrappedComplexInput2 = new NotWrappedFieldComplexInput
+				{
+					StringProperty = "x"
+				}
+			});
+
+			clientResponse.ShouldNotBeNull();
+
+			// The client does not support unpacking these message contracts, so further assertions have been
+			// commented
+			//	clientResponse.NotWrappedComplexInput.ShouldNotBeNull();
+			//	clientResponse.NotWrappedComplexInput.StringProperty.ShouldBe("z");
+		}
+
+		//not compatible with DataContractSerializer
+		[Theory]
+		[InlineData(SoapSerializer.XmlSerializer)]
 		public void TestPingComplexModelOldStyleSerialization(SoapSerializer soapSerializer)
 		{
 			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);

--- a/src/SoapCore/ReflectionExtensions.cs
+++ b/src/SoapCore/ReflectionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -70,6 +71,37 @@ namespace SoapCore
 			}
 
 			return result?.MakeGenericMethod(typeArguments);
+		}
+
+		/// <summary>
+		/// Gets the field or property members of the specific type.
+		/// </summary>
+		/// <param name="type">The type to look for field or property members for</param>
+		/// <returns>An enumerable containing members which are fields or properties</returns>
+		internal static IEnumerable<MemberInfo> GetPropertyOrFieldMembers(this Type type) =>
+			type.GetFields()
+				.Cast<MemberInfo>()
+				.Concat(type.GetProperties());
+
+		/// <summary>
+		/// Gets the field or property type of a member. Returns null if the member is neither a field or
+		/// a property member
+		/// </summary>
+		/// <param name="memberInfo">The member to get the field or property type</param>
+		/// <returns>The return type of the member, null if it could not be determined</returns>
+		internal static Type GetPropertyOrFieldType(this MemberInfo memberInfo)
+		{
+			if (memberInfo is FieldInfo fi)
+			{
+				return fi.FieldType;
+			}
+
+			if (memberInfo is PropertyInfo pi)
+			{
+				return pi.PropertyType;
+			}
+
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
Hi,

MessageContract can have code wrappers that aren't represented in XML e.g.

```csharp
[MessageContract(IsWrapped = false)]
class FooRequest { 
   [MessageBodyMember(Order = 0)]
   public Foo Foo { get; set; }
}

class Foo {
    string FooValue { get; set; }
}
```

As I understand it, the XML that should work here is the following --

```
<Foo>
<FooValue>Test</FooValue>
</Foo>
```

Not:

```
<FooRequest>
<Foo>
<FooValue>Test</FooValue>
</Foo>
</FooRequest>
```

The wrapping complexity only manifests itself in C# code, not in the XML.

https://docs.microsoft.com/en-us/dotnet/framework/wcf/samples/unwrapped-messages

Update-- now does multiple parameters as per examples in linked MS WCF article