### PR TITLE
Features/throwing exception in messageinspectors

### DIFF
--- a/src/SoapCore.Tests/MessageInspectors/InspectorStyle.cs
+++ b/src/SoapCore.Tests/MessageInspectors/InspectorStyle.cs
@@ -1,0 +1,8 @@
+namespace SoapCore.Tests.MessageInspectors
+{
+	public enum InspectorStyle
+	{
+		MessageInspector,
+		MessageInspector2
+	}
+}

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector/MessageInspectorMock.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector/MessageInspectorMock.cs
@@ -1,0 +1,40 @@
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+
+namespace SoapCore.Tests.MessageInspectors.MessageInspector
+{
+	public class MessageInspectorMock : IMessageInspector
+	{
+		public static bool AfterReceivedRequestCalled { get; private set; }
+		public static bool BeforeSendReplyCalled { get; private set; }
+		public static Message LastReceivedMessage { get; private set; }
+
+		public static void Reset()
+		{
+			LastReceivedMessage = null;
+			AfterReceivedRequestCalled = false;
+			BeforeSendReplyCalled = false;
+		}
+
+		public object AfterReceiveRequest(ref Message message)
+		{
+			LastReceivedMessage = message;
+			AfterReceivedRequestCalled = true;
+
+			// Validate Message
+			ValidateMessage(ref message);
+
+			return null;
+		}
+
+		public void BeforeSendReply(ref Message reply, object correlationState)
+		{
+			BeforeSendReplyCalled = true;
+		}
+
+		private void ValidateMessage(ref Message message)
+		{
+			throw new FaultException(new FaultReason("Message is invalid."), new FaultCode("Sender"), null);
+		}
+	}
+}

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector/MessageInspectorTests.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector/MessageInspectorTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SoapCore.Tests.MessageInspectors.MessageInspector
+{
+	[TestClass]
+	public class MessageInspectorTests
+	{
+		[ClassInitialize]
+		public static void StartServer(TestContext testContext)
+		{
+			Task.Run(() =>
+			{
+				var host = new WebHostBuilder()
+					.UseKestrel()
+					.UseUrls("http://localhost:6051")
+					.UseStartup<Startup>()
+					.UseSetting("InspectorStyle", InspectorStyle.MessageInspector.ToString())
+					.Build();
+
+				host.Run();
+			}).Wait(1000);
+		}
+
+		[TestInitialize]
+		public void Reset()
+		{
+			MessageInspectorMock.Reset();
+		}
+
+		public ITestService CreateClient()
+		{
+			var binding = new BasicHttpBinding();
+			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:6051/Service.svc", "localhost")));
+			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);
+			var serviceClient = channelFactory.CreateChannel();
+			return serviceClient;
+		}
+
+		[TestMethod]
+		public void AfterReceivedRequestCalled()
+		{
+			Assert.IsFalse(MessageInspectorMock.AfterReceivedRequestCalled);
+			var client = CreateClient();
+			var result = client.Ping("Hello World");
+			Assert.IsTrue(MessageInspectorMock.AfterReceivedRequestCalled);
+		}
+
+		[TestMethod]
+		public void BeforeSendReplyShouldNotBeCalled()
+		{
+			Assert.IsFalse(MessageInspectorMock.BeforeSendReplyCalled);
+			var client = CreateClient();
+			var result = client.Ping("Hello World");
+			Assert.IsFalse(MessageInspectorMock.BeforeSendReplyCalled);
+		}
+
+		[TestMethod]
+		public void AfterReceivedThrowsException()
+		{
+			var client = CreateClient();
+			Assert.ThrowsException<FaultException>(() => client.Ping("Hello World"));
+		}
+	}
+}

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector/MessageInspectorTests.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector/MessageInspectorTests.cs
@@ -42,6 +42,7 @@ namespace SoapCore.Tests.MessageInspectors.MessageInspector
 		}
 
 		[TestMethod]
+		[ExpectedException(typeof(FaultException))]
 		public void AfterReceivedRequestCalled()
 		{
 			Assert.IsFalse(MessageInspectorMock.AfterReceivedRequestCalled);
@@ -51,6 +52,7 @@ namespace SoapCore.Tests.MessageInspectors.MessageInspector
 		}
 
 		[TestMethod]
+		[ExpectedException(typeof(FaultException))]
 		public void BeforeSendReplyShouldNotBeCalled()
 		{
 			Assert.IsFalse(MessageInspectorMock.BeforeSendReplyCalled);

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector2/MessageInspector2Mock.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector2/MessageInspector2Mock.cs
@@ -1,0 +1,40 @@
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+
+namespace SoapCore.Tests.MessageInspectors.MessageInspector2
+{
+	public class MessageInspector2Mock : IMessageInspector2
+	{
+		public static bool AfterReceivedRequestCalled { get; private set; }
+		public static bool BeforeSendReplyCalled { get; private set; }
+		public static Message LastReceivedMessage { get; private set; }
+
+		public static void Reset()
+		{
+			LastReceivedMessage = null;
+			AfterReceivedRequestCalled = false;
+			BeforeSendReplyCalled = false;
+		}
+
+		public object AfterReceiveRequest(ref Message message, ServiceDescription serviceDescription)
+		{
+			LastReceivedMessage = message;
+			AfterReceivedRequestCalled = true;
+
+			// validate message
+			ValidateMessage(ref message);
+
+			return null;
+		}
+
+		public void BeforeSendReply(ref Message reply, ServiceDescription serviceDescription, object correlationState)
+		{
+			BeforeSendReplyCalled = true;
+		}
+
+		private void ValidateMessage(ref Message message)
+		{
+			throw new FaultException(new FaultReason("Message is invalid."), new FaultCode("Sender"), null);
+		}
+	}
+}

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector2/MessageInspector2Tests.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector2/MessageInspector2Tests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SoapCore.Tests.MessageInspectors.MessageInspector2
+{
+	[TestClass]
+	public class MessageInspector2Tests
+	{
+		[ClassInitialize]
+		public static void StartServer(TestContext testContext)
+		{
+			Task.Run(() =>
+			{
+				var host = new WebHostBuilder()
+					.UseKestrel()
+					.UseUrls("http://localhost:7051")
+					.UseStartup<Startup>()
+					.UseSetting("InspectorStyle", InspectorStyle.MessageInspector2.ToString())
+					.Build();
+
+				host.Run();
+			}).Wait(1000);
+		}
+
+		[TestInitialize]
+		public void Reset()
+		{
+			MessageInspector2Mock.Reset();
+		}
+
+		public ITestService CreateClient()
+		{
+			var binding = new BasicHttpBinding();
+			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:7051/Service.svc", "localhost")));
+			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);
+			var serviceClient = channelFactory.CreateChannel();
+			return serviceClient;
+		}
+
+		[TestMethod]
+		public void AfterReceivedRequestCalled()
+		{
+			Assert.IsFalse(MessageInspector2Mock.AfterReceivedRequestCalled);
+			var client = CreateClient();
+			var result = client.Ping("Hello World");
+			Assert.IsTrue(MessageInspector2Mock.AfterReceivedRequestCalled);
+		}
+
+		[TestMethod]
+		public void BeforeSendReplyShouldNotBeCalled()
+		{
+			Assert.IsFalse(MessageInspector2Mock.BeforeSendReplyCalled);
+			var client = CreateClient();
+			var result = client.Ping("Hello World");
+			Assert.IsFalse(MessageInspector2Mock.BeforeSendReplyCalled);
+		}
+
+		[TestMethod]
+		public void AfterReceivedThrowsException()
+		{
+			var client = CreateClient();
+			Assert.ThrowsException<FaultException>(() => client.Ping("Hello World"));
+		}
+	}
+}

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector2/MessageInspector2Tests.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector2/MessageInspector2Tests.cs
@@ -42,6 +42,7 @@ namespace SoapCore.Tests.MessageInspectors.MessageInspector2
 		}
 
 		[TestMethod]
+		[ExpectedException(typeof(FaultException))]
 		public void AfterReceivedRequestCalled()
 		{
 			Assert.IsFalse(MessageInspector2Mock.AfterReceivedRequestCalled);
@@ -51,6 +52,7 @@ namespace SoapCore.Tests.MessageInspectors.MessageInspector2
 		}
 
 		[TestMethod]
+		[ExpectedException(typeof(FaultException))]
 		public void BeforeSendReplyShouldNotBeCalled()
 		{
 			Assert.IsFalse(MessageInspector2Mock.BeforeSendReplyCalled);

--- a/src/SoapCore.Tests/MessageInspectors/Startup.cs
+++ b/src/SoapCore.Tests/MessageInspectors/Startup.cs
@@ -1,0 +1,48 @@
+using System.ServiceModel;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using SoapCore.Tests.MessageInspectors.MessageInspector;
+using SoapCore.Tests.MessageInspectors.MessageInspector2;
+
+namespace SoapCore.Tests.MessageInspectors
+{
+	public class Startup
+	{
+		public Startup(IConfiguration configuration)
+		{
+			Configuration = configuration;
+			InspectorStyle = configuration.GetValue<InspectorStyle>("InspectorStyle");
+		}
+
+		public IConfiguration Configuration { get; }
+		public InspectorStyle InspectorStyle { get; }
+
+		public void ConfigureServices(IServiceCollection services)
+		{
+			services.AddSoapCore();
+			services.TryAddSingleton<TestService>();
+
+			switch (InspectorStyle)
+			{
+				case InspectorStyle.MessageInspector:
+					services.AddSoapMessageInspector(new MessageInspectorMock());
+					break;
+				case InspectorStyle.MessageInspector2:
+					services.AddSoapMessageInspector(new MessageInspector2Mock());
+					break;
+			}
+
+			services.AddMvc();
+		}
+
+		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+		{
+			app.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+			app.UseMvc();
+		}
+	}
+}


### PR DESCRIPTION
Hi, 

When validating the incoming request and concluding that the request doesn't validate with what is excepted. In that case it's valid to throw an exception to avoid the request continues into the service(s), which also would be nice to show a meaningfull faultmessage instead of returning a System.ServiceModel.CommunicationException. 

**Example showing the throwed exception**
 `System.ServiceModel.CommunicationException, but exception System.ServiceModel.FaultException was expected. Exception message: System.ServiceModel.CommunicationException: The server did not provide a meaningful reply; this might be caused by a contract mismatch, a premature session shutdown or an internal server error.
`

To support this behaviour a simple try/catch around invoking the MessageInspectors or MessageInspector2s in the SoapEndpointMiddleware.cs is all that's needed.