### PR TITLE
Make a default FaultExceptionTransformer

### DIFF
--- a/src/SoapCore/DefaultFaultExceptionTransformer.cs
+++ b/src/SoapCore/DefaultFaultExceptionTransformer.cs
@@ -3,6 +3,10 @@ using System.ServiceModel.Channels;
 
 namespace SoapCore
 {
+	/// <summary>
+	/// The default implementation of the fault provider when an unexpected exception occurs. This can be replaced or
+	/// extended by registering your own IFaultExceptionTransformer in the service collection on startup.
+	/// </summary>
 	public class DefaultFaultExceptionTransformer : IFaultExceptionTransformer
 	{
 		private readonly ExceptionTransformer _exceptionTransformer;

--- a/src/SoapCore/DefaultFaultExceptionTransformer.cs
+++ b/src/SoapCore/DefaultFaultExceptionTransformer.cs
@@ -1,0 +1,31 @@
+using System;
+using System.ServiceModel.Channels;
+
+namespace SoapCore
+{
+	public class DefaultFaultExceptionTransformer : IFaultExceptionTransformer
+	{
+		private readonly ExceptionTransformer _exceptionTransformer;
+
+		public DefaultFaultExceptionTransformer()
+		{
+			_exceptionTransformer = null;
+		}
+
+		public DefaultFaultExceptionTransformer(ExceptionTransformer exceptionTransformer)
+		{
+			_exceptionTransformer = exceptionTransformer;
+		}
+
+		public Message ProvideFault(Exception exception, MessageVersion messageVersion)
+		{
+			var bodyWriter = _exceptionTransformer == null ?
+				new FaultBodyWriter(exception, messageVersion) :
+				new FaultBodyWriter(exception, messageVersion, faultStringOverride: _exceptionTransformer.Transform(exception));
+
+			var soapCoreFaultMessage = Message.CreateMessage(messageVersion, null, bodyWriter);
+
+			return new CustomMessage(soapCoreFaultMessage);
+		}
+	}
+}

--- a/src/SoapCore/ExceptionTransformer.cs
+++ b/src/SoapCore/ExceptionTransformer.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using System;
 
 namespace SoapCore
 {
-	internal class ExceptionTransformer
+	public class ExceptionTransformer
 	{
 		private readonly Func<Exception, string> _transformer;
 

--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -59,6 +59,8 @@ namespace SoapCore
 		public static IServiceCollection AddSoapCore(this IServiceCollection serviceCollection)
 		{
 			serviceCollection.TryAddSingleton<IOperationInvoker, DefaultOperationInvoker>();
+			serviceCollection.TryAddSingleton<IFaultExceptionTransformer, DefaultFaultExceptionTransformer>();
+
 			return serviceCollection;
 		}
 

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -663,25 +663,8 @@ namespace SoapCore
 			MessageEncoder messageEncoder,
 			HttpContext httpContext)
 		{
-			Message faultMessage;
-
-			var faultExceptionTransformer = serviceProvider.GetService<IFaultExceptionTransformer>();
-
-			if (faultExceptionTransformer != null)
-			{
-				faultMessage = faultExceptionTransformer.ProvideFault(exception, messageEncoder.MessageVersion);
-			}
-			else
-			{
-				var transformer = serviceProvider.GetService<ExceptionTransformer>();
-
-				var bodyWriter = transformer == null ?
-					new FaultBodyWriter(exception, messageEncoder.MessageVersion) :
-					new FaultBodyWriter(exception, messageEncoder.MessageVersion, faultStringOverride: transformer.Transform(exception));
-
-				var soapCoreFaultMessage = Message.CreateMessage(messageEncoder.MessageVersion, null, bodyWriter);
-				faultMessage = new CustomMessage(soapCoreFaultMessage);
-			}
+			var faultExceptionTransformer = serviceProvider.GetRequiredService<IFaultExceptionTransformer>();
+			var faultMessage = faultExceptionTransformer.ProvideFault(exception, messageEncoder.MessageVersion);
 
 			httpContext.Response.ContentType = httpContext.Request.ContentType;
 			httpContext.Response.Headers["SOAPAction"] = faultMessage.Headers.Action;


### PR DESCRIPTION
## Summary
Pulling the existing fault logic which creates faults for unhandled exceptions into a `DefaultFaultExceptionTransformer`. 

This is useful if you want SOAP Core to figure out the "standard" SOAP fault logic, but want to decorate the response with your own non-standard things (without copying logic around)

## Example:

### CustomFaultExceptionTransformer.cs
```csharp
    public class CustomFaultExceptionTransformer : IFaultExceptionTransformer
    {
        private readonly DefaultFaultExceptionTransformer _base;
        private readonly IHttpContextAccessor _httpContextAccessor;

        public CustomFaultExceptionTransformer(DefaultFaultExceptionTransformer @base, IHttpContextAccessor httpContextAccessor)
        {
            _httpContextAccessor = httpContextAccessor;
            _base = @base;
        }

        public Message ProvideFault(Exception exception, MessageVersion messageVersion)
        {
            var baseFault = _base.ProvideFault(exception, messageVersion);
            var httpContext = _httpContextAccessor.HttpContext;

            baseFault.Headers.Add(MessageHeader.CreateHeader("TraceIdentifier", "http://tempuri.org", httpContext?.TraceIdentifier ?? "None"));

            return baseFault;
        }
    }
```

### Startup.cs
```csharp
            services.AddHttpContextAccessor();
            services.AddScoped<DefaultFaultExceptionTransformer>();
            services.AddScoped<IFaultExceptionTransformer, CustomFaultExceptionTransformer>();
```

I am utilising it to add my own custom headers derived from the inbound request and took it as an opportunity to simplify the conditional code in SoapEndpointMiddleware.cs