### PR TITLE
Remove BindingName post fix when binding name is explicitly defined

### DIFF
--- a/src/SoapCore/MetaBodyWriter.cs
+++ b/src/SoapCore/MetaBodyWriter.cs
@@ -47,8 +47,8 @@ namespace SoapCore
 
 			if (binding != null)
 			{
-				BindingName = $"{binding.Name}_{_service.Contracts.First().Name}";
-				PortName = $"{binding.Name}_{_service.Contracts.First().Name}";
+				BindingName = binding.Name;
+				PortName = binding.Name;
 			}
 			else
 			{

--- a/src/SoapCore/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/MetaWCFBodyWriter.cs
@@ -84,8 +84,8 @@ namespace SoapCore
 
 			if (binding != null)
 			{
-				BindingName = $"{binding.Name}_{_service.Contracts.First().Name}";
-				PortName = $"{binding.Name}_{_service.Contracts.First().Name}";
+				BindingName = binding.Name;
+				PortName = binding.Name;
 			}
 			else
 			{


### PR DESCRIPTION
I'm trying to get this to behave similar to wcf where if you explicitly define a binding name then that name get used for the binding name with no post fix.
#235 