### PR TITLE
Basic SOAP 1.2 + WSA 1.0 response (MessageID correlation)

### DIFF
--- a/src/SoapCore.Tests/RawRequestSoap12Tests.cs
+++ b/src/SoapCore.Tests/RawRequestSoap12Tests.cs
@@ -71,6 +71,109 @@ namespace SoapCore.Tests
 		}
 
 		[TestMethod]
+		public async Task Soap12Wsa10Header()
+		{
+			var requestBody = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<soap12:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:soap12=""http://www.w3.org/2003/05/soap-envelope"" xmlns:wsa=""http://www.w3.org/2005/08/addressing"">
+  <soap12:Header>
+	<wsa:MessageID>uuid:7673868d-231e-490d-9c4f-19288e7e668d</wsa:MessageID>
+	<wsa:To>http://wsa10example</wsa:To>
+    <wsa:ReplyTo>
+		<wsa:Address>http://business456.example/client1</wsa:Address>
+    </wsa:ReplyTo>
+	<wsa:Action>Ping</wsa:Action>
+  </soap12:Header>
+  <soap12:Body>
+    <Ping xmlns=""http://tempuri.org/"">
+      <s>abc</s>
+    </Ping>
+  </soap12:Body>
+</soap12:Envelope>
+";
+
+			using (var host = CreateTestHost())
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(requestBody, Encoding.UTF8, "application/soap+xml"))
+			using (var response = await host.CreateRequest("/WSA10Service.svc").And(msg => msg.Content = content).PostAsync())
+			{
+				response.EnsureSuccessStatusCode();
+
+				var responseBodyStream = await response.Content.ReadAsStreamAsync();
+				var document = XDocument.Load(responseBodyStream);
+
+				Assert.IsNotNull(document, "The XML should be properly formed");
+
+				var headerElement = document
+					.Element(XName.Get("Envelope", "http://www.w3.org/2003/05/soap-envelope"))
+					.Element(XName.Get("Header", "http://www.w3.org/2003/05/soap-envelope"));
+
+				Assert.IsNotNull(headerElement, "There should be a SOAP header");
+
+				var header = new
+				{
+					Action = headerElement.Element(XName.Get("Action", "http://www.w3.org/2005/08/addressing"))?.Value,
+					RelatesTo = headerElement.Element(XName.Get("RelatesTo", "http://www.w3.org/2005/08/addressing"))?.Value,
+					To = headerElement.Element(XName.Get("To", "http://www.w3.org/2005/08/addressing"))?.Value,
+				};
+
+				header.ShouldDeepEqual(new
+				{
+					Action = "http://tempuri.org/ITestService/PingResponse",
+					RelatesTo = "uuid:7673868d-231e-490d-9c4f-19288e7e668d",
+					To = "http://business456.example/client1"
+				});
+			}
+		}
+
+		[TestMethod]
+		public async Task Soap12Wsa10FaultHeader()
+		{
+			var requestBody = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<soap12:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:soap12=""http://www.w3.org/2003/05/soap-envelope"" xmlns:wsa=""http://www.w3.org/2005/08/addressing"">
+  <soap12:Header>
+	<wsa:MessageID>uuid:7673868d-231e-490d-9c4f-19288e7e668e</wsa:MessageID>
+	<wsa:To>http://wsa10example</wsa:To>
+	<wsa:Action>ThrowDetailedFault</wsa:Action>
+  </soap12:Header>
+  <soap12:Body>
+    <ThrowDetailedFault xmlns=""http://tempuri.org/"">
+      <detailMessage>Detail message</detailMessage>
+    </ThrowDetailedFault>
+  </soap12:Body>
+</soap12:Envelope>
+";
+
+			using (var host = CreateTestHost())
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(requestBody, Encoding.UTF8, "application/soap+xml"))
+			using (var response = await host.CreateRequest("/WSA10Service.svc").And(msg => msg.Content = content).PostAsync())
+			{
+				Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+
+				var responseBodyStream = await response.Content.ReadAsStreamAsync();
+				var document = XDocument.Load(responseBodyStream);
+
+				Assert.IsNotNull(document, "The XML should be properly formed");
+
+				var headerElement = document
+					.Element(XName.Get("Envelope", "http://www.w3.org/2003/05/soap-envelope"))
+					.Element(XName.Get("Header", "http://www.w3.org/2003/05/soap-envelope"));
+
+				Assert.IsNotNull(headerElement, "There should be a SOAP header");
+
+				var header = new
+				{
+					RelatesTo = headerElement.Element(XName.Get("RelatesTo", "http://www.w3.org/2005/08/addressing"))?.Value
+				};
+
+				header.ShouldDeepEqual(new
+				{
+					RelatesTo = "uuid:7673868d-231e-490d-9c4f-19288e7e668e"
+				});
+			}
+		}
+
+		[TestMethod]
 		public async Task Soap12DetailedFault()
 		{
 			var body = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -82,49 +185,46 @@ namespace SoapCore.Tests
   </soap12:Body>
 </soap12:Envelope>
 ";
-			var bodyBytes = Encoding.UTF8.GetBytes(body);
 			using (var host = CreateTestHost())
 			using (var client = host.CreateClient())
 			using (var content = new StringContent(body, Encoding.UTF8, "application/soap+xml"))
+			using (var response = await host.CreateRequest("/Service.svc").And(msg => msg.Content = content).PostAsync())
 			{
-				using (var response = host.CreateRequest("/Service.svc").And(msg => msg.Content = content).PostAsync().Result)
+				Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+
+				var responseBodyStream = await response.Content.ReadAsStreamAsync();
+				var document = XDocument.Load(responseBodyStream);
+
+				var faultElement = document
+					.Element(XName.Get("Envelope", "http://www.w3.org/2003/05/soap-envelope"))
+					.Element(XName.Get("Body", "http://www.w3.org/2003/05/soap-envelope"))
+					.Element(XName.Get("Fault", "http://www.w3.org/2003/05/soap-envelope"));
+
+				var codeElement =
+					faultElement.Element(XName.Get("Code", "http://www.w3.org/2003/05/soap-envelope"));
+
+				Assert.IsNotNull(codeElement);
+				Assert.AreEqual("s:Sender", codeElement.Value);
+
+				var reasonElementText =
+					faultElement
+						.Element(XName.Get("Reason", "http://www.w3.org/2003/05/soap-envelope"))
+						.Elements(XName.Get("Text", "http://www.w3.org/2003/05/soap-envelope"));
+
+				Assert.IsNotNull(reasonElementText);
+				Assert.AreEqual(1, reasonElementText.Count());
+				Assert.AreEqual("test", reasonElementText.First().Value);
+
+				var detailElement =
+					faultElement.Element(XName.Get("Detail", "http://www.w3.org/2003/05/soap-envelope"));
+
+				Assert.IsNotNull(detailElement);
+				var faultDetail = detailElement.DeserializeInnerElementAs<FaultDetail>();
+
+				faultDetail.ShouldDeepEqual(new FaultDetail
 				{
-					Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
-
-					var responseBodyStream = await response.Content.ReadAsStreamAsync();
-					var document = XDocument.Load(responseBodyStream);
-
-					var faultElement = document
-						.Element(XName.Get("Envelope", "http://www.w3.org/2003/05/soap-envelope"))
-						.Element(XName.Get("Body", "http://www.w3.org/2003/05/soap-envelope"))
-						.Element(XName.Get("Fault", "http://www.w3.org/2003/05/soap-envelope"));
-
-					var codeElement =
-						faultElement.Element(XName.Get("Code", "http://www.w3.org/2003/05/soap-envelope"));
-
-					Assert.IsNotNull(codeElement);
-					Assert.AreEqual("s:Sender", codeElement.Value);
-
-					var reasonElementText =
-						faultElement
-							.Element(XName.Get("Reason", "http://www.w3.org/2003/05/soap-envelope"))
-							.Elements(XName.Get("Text", "http://www.w3.org/2003/05/soap-envelope"));
-
-					Assert.IsNotNull(reasonElementText);
-					Assert.AreEqual(1, reasonElementText.Count());
-					Assert.AreEqual("test", reasonElementText.First().Value);
-
-					var detailElement =
-						faultElement.Element(XName.Get("Detail", "http://www.w3.org/2003/05/soap-envelope"));
-
-					Assert.IsNotNull(detailElement);
-					var faultDetail = detailElement.DeserializeInnerElementAs<FaultDetail>();
-
-					faultDetail.ShouldDeepEqual(new FaultDetail
-					{
-						ExceptionProperty = "Detail message"
-					});
-				}
+					ExceptionProperty = "Detail message"
+				});
 			}
 		}
 

--- a/src/SoapCore.Tests/Startup.cs
+++ b/src/SoapCore.Tests/Startup.cs
@@ -47,6 +47,14 @@ namespace SoapCore.Tests
 				app2.UseSoapEndpoint<TestService>("/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
 			});
 
+			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("/WSA10Service.svc"), app2 =>
+			{
+				var transportBinding = new HttpTransportBindingElement();
+				var textEncodingBinding = new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, System.Text.Encoding.UTF8);
+
+				app.UseSoapEndpoint<TestService>("/WSA10Service.svc", new CustomBinding(transportBinding, textEncodingBinding), SoapSerializer.DataContractSerializer);
+			});
+
 			app.UseMvc();
 		}
 	}

--- a/src/SoapCore/OperationDescription.cs
+++ b/src/SoapCore/OperationDescription.cs
@@ -16,7 +16,6 @@ namespace SoapCore
 			Name = contractAttribute.Name ?? GetNameByAction(contractAttribute.Action) ?? GetNameByMethod(operationMethod);
 			SoapAction = contractAttribute.Action ?? $"{contract.Namespace.TrimEnd('/')}/{contract.Name}/{Name}";
 			IsOneWay = contractAttribute.IsOneWay;
-			ReplyAction = contractAttribute.ReplyAction;
 			DispatchMethod = operationMethod;
 
 			var returnType = operationMethod.ReturnType;
@@ -50,6 +49,8 @@ namespace SoapCore
 			ReturnName = operationMethod.ReturnParameter.GetCustomAttribute<MessageParameterAttribute>()?.Name ?? Name + "Result";
 			ReturnElementName = elementAttribute?.ElementName;
 			ReturnNamespace = elementAttribute?.Form == XmlSchemaForm.Unqualified ? string.Empty : elementAttribute?.Namespace;
+
+			ReplyAction = contractAttribute.ReplyAction ?? $"{Contract.Namespace.TrimEnd('/')}/{contract.Name}/{Name + "Response"}";
 
 			var faultContractAttributes = operationMethod.GetCustomAttributes<FaultContractAttribute>();
 			Faults = faultContractAttributes

--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -38,7 +38,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+		<PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
## Summary
This PR gets some basic WSA 1.0 functionality implemented, the focus has been on the ability to link incoming MessageID to the output mesages RelatesTo.

The key thing for me was the ability to correlate request message IDs with their reply message IDs.

## Notes
- The scope of the WSA 1.0 implementation is quite limited (WSA has a lot of capabilities that me or my API clients aren't using so have severely narrowed scope)
- I **downgraded** the StyleCop rules to the last known version on this repository. The 1.1.x introduced some picky and opinionated rules which the project has not been updated to conform to (builds fail on the latest VS)

## Useful References
https://www.w3.org/Submission/ws-addressing/
https://www.w3.org/TR/2006/REC-ws-addr-soap-20060509/#id2270287
https://www.w3.org/TR/2006/REC-ws-addr-core-20060509/