### PR TITLE
Return empty body with void return (Help Needed)

### DIFF
--- a/src/SoapCore.Tests/ITestService.cs
+++ b/src/SoapCore.Tests/ITestService.cs
@@ -11,6 +11,12 @@ namespace SoapCore.Tests
 		[OperationContract]
 		string Ping(string s);
 
+		[OperationContract(IsOneWay = false)] // explicitly IsOneWay = false (synchronous)
+		void VoidAll();
+
+		[OperationContract(IsOneWay = false)] // explicitly IsOneWay = false (synchronous)
+		void VoidString(string s);
+
 		[OperationContract]
 		string EmptyArgs();
 

--- a/src/SoapCore.Tests/IntegrationTests.cs
+++ b/src/SoapCore.Tests/IntegrationTests.cs
@@ -41,8 +41,6 @@ namespace SoapCore.Tests
 
 			var client = CreateSoap12Client();
 
-			// We don't actually want an exception to be thrown but are asserting so
-			// that the behaviour change can be monitored.
 			client.VoidAll();
 		}
 

--- a/src/SoapCore.Tests/IntegrationTests.cs
+++ b/src/SoapCore.Tests/IntegrationTests.cs
@@ -35,6 +35,28 @@ namespace SoapCore.Tests
 		}
 
 		[TestMethod]
+		public void VoidAllMethod()
+		{
+			Assert.Inconclusive("The .NET WCF client does not appear to support empty messages");
+
+			var client = CreateSoap12Client();
+
+			// We don't actually want an exception to be thrown but are asserting so
+			// that the behaviour change can be monitored.
+			client.VoidAll();
+		}
+
+		[TestMethod]
+		public void VoidStringMethod()
+		{
+			Assert.Inconclusive("The .NET WCF client does not appear to support empty messages");
+
+			var client = CreateSoap12Client();
+
+			client.VoidString("hello, world");
+		}
+
+		[TestMethod]
 		public void PingSoap12()
 		{
 			var client = CreateSoap12Client();

--- a/src/SoapCore.Tests/RawRequestSoap12Tests.cs
+++ b/src/SoapCore.Tests/RawRequestSoap12Tests.cs
@@ -174,6 +174,37 @@ namespace SoapCore.Tests
 		}
 
 		[TestMethod]
+		public async Task Soap12VoidAll()
+		{
+			var body = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<soap12:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:soap12=""http://www.w3.org/2003/05/soap-envelope"">
+  <soap12:Body>
+    <VoidAll xmlns=""http://tempuri.org/"" />
+  </soap12:Body>
+</soap12:Envelope>
+";
+
+			using (var host = CreateTestHost())
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body, Encoding.UTF8, "application/soap+xml"))
+			using (var response = await host.CreateRequest("/Service.svc").And(msg => msg.Content = content).PostAsync())
+			{
+				response.EnsureSuccessStatusCode();
+
+				var responseBodyStream = await response.Content.ReadAsStreamAsync();
+				var document = XDocument.Load(responseBodyStream);
+
+				var envelopeBody =
+					document
+						.Element(XName.Get("Envelope", "http://www.w3.org/2003/05/soap-envelope"))
+						.Element(XName.Get("Body", "http://www.w3.org/2003/05/soap-envelope"));
+
+				Assert.IsNotNull(envelopeBody);
+				Assert.IsTrue(envelopeBody.IsEmpty);
+			}
+		}
+
+		[TestMethod]
 		public async Task Soap12DetailedFault()
 		{
 			var body = @"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/src/SoapCore.Tests/TestService.cs
+++ b/src/SoapCore.Tests/TestService.cs
@@ -107,5 +107,13 @@ namespace SoapCore.Tests
 		{
 			return _pingResultValue.Value;
 		}
+
+		public void VoidAll()
+		{
+		}
+
+		public void VoidString(string s)
+		{
+		}
 	}
 }

--- a/src/SoapCore/ServiceBodyWriter.cs
+++ b/src/SoapCore/ServiceBodyWriter.cs
@@ -33,6 +33,13 @@ namespace SoapCore
 
 		protected override void OnWriteBodyContents(XmlDictionaryWriter writer)
 		{
+			if (_operation.OutParameters.Length == 0 && _operation.DispatchMethod.ReturnType == typeof(void))
+			{
+				// Let's bail early because there is nothing to write! This can occur when a method
+				// returns void and has no "out" parameters.
+				return;
+			}
+
 			// do not wrap old-style single element response into additional xml element for xml serializer
 			var needResponseEnvelope = _serializer != SoapSerializer.XmlSerializer || _result == null || (_outResults != null && _outResults.Count > 0) || !_operation.IsMessageContractResponse;
 


### PR DESCRIPTION
## Summary
This change makes it so that an empty SOAP body (no generated wrapper) is returned with a void method e.g.

```
<s:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:s="http://www.w3.org/2003/05/soap-envelope">
  <s:Body />
</s:Envelope>
```

The current behaviour is to add an unnecessary response envelope which is derived from the operation name e.g.

```
<s:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:s="http://www.w3.org/2003/05/soap-envelope">
  <s:Body>
    <FooResponse xmlns="http://foo.namespace" />
  </s:Body>
</s:Envelope>
```

In my particular application use-case there are some additional SOAP headers added to all messages, but there is no content in the body.

## .NET Core WCF Client (Help)
I am having some issues getting the .NET Core WCF client to work with empty responses. It is used in the tests but is not happy about empty messages.  

What am I missing in able to get this to work? Is it a bug in that library or is something wrong with what I am trying to achieve?

This is the stack trace details from one of the skipped VoidAllMethod test in IntegrationTests.cs:

```
System.ServiceModel.CommunicationException
  HResult=0x80131500
  Message=Error in deserializing body of reply message for operation 'VoidAll'. The OperationFormatter could not deserialize any information from the Message because the Message is empty (IsEmpty = true).
  Source=System.Private.ServiceModel
  StackTrace:
   at System.ServiceModel.Dispatcher.PrimitiveOperationFormatter.DeserializeReply(Message message, Object[] parameters)
   at System.ServiceModel.Dispatcher.ProxyOperationRuntime.AfterReply(ProxyRpc& rpc)
   at System.ServiceModel.Channels.ServiceChannel.HandleReply(ProxyOperationRuntime operation, ProxyRpc& rpc)
   at System.ServiceModel.Channels.ServiceChannel.Call(String action, Boolean oneway, ProxyOperationRuntime operation, Object[] ins, Object[] outs, TimeSpan timeout)
   at System.ServiceModel.Channels.ServiceChannelProxy.InvokeService(MethodCall methodCall, ProxyOperationRuntime operation)
   at System.ServiceModel.Channels.ServiceChannelProxy.Invoke(MethodInfo targetMethod, Object[] args)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Reflection.DispatchProxyGenerator.Invoke(Object[] args)
   at SoapCore.Tests.IntegrationTests.VoidAllMethod() in C:\Users\CampbellS.DRC\dev\SoapCore\src\SoapCore.Tests\IntegrationTests.cs:line 44

Inner Exception 1:
SerializationException: The OperationFormatter could not deserialize any information from the Message because the Message is empty (IsEmpty = true).
```