### PR TITLE
Improve performance

### DIFF
--- a/src/SoapCore/DefaultOperationInvoker.cs
+++ b/src/SoapCore/DefaultOperationInvoker.cs
@@ -1,33 +1,59 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using AspectCore.Extensions.Reflection;
 
 namespace SoapCore
 {
 	public class DefaultOperationInvoker : IOperationInvoker
 	{
-		public async Task<object> InvokeAsync(MethodInfo methodInfo, object serviceInstance, object[] arguments)
+		private static readonly List<Type> TaskTypes = new List<Type> { typeof(Task<>), typeof(ValueTask<>) };
+		private static readonly ConcurrentDictionary<Type, MethodReflector> TaskResultCache = new ConcurrentDictionary<Type, MethodReflector>();
+		private static readonly ConcurrentDictionary<Type, bool> IsTaskResult = new ConcurrentDictionary<Type, bool>();
+
+		private static readonly MethodInfo[] AsMethods = new[]
+        {
+			new Func<Task<object>, Task<object>>(As).Method.GetGenericMethodDefinition(),
+			new Func<ValueTask<object>, Task<object>>(As).Method.GetGenericMethodDefinition(),
+		};
+
+		public Task<object> InvokeAsync(MethodInfo methodInfo, object serviceInstance, object[] arguments)
 		{
-			// Invoke Operation method
-			var responseObject = methodInfo.Invoke(serviceInstance, arguments);
-			if (methodInfo.ReturnType.IsConstructedGenericType && methodInfo.ReturnType.GetGenericTypeDefinition() == typeof(Task<>))
+			if (!IsTaskResult.GetOrAdd(methodInfo.ReturnType, type =>
+				type.IsConstructedGenericType && TaskTypes.Contains(type.GetGenericTypeDefinition())))
 			{
-				var responseTask = (Task)responseObject;
-				await responseTask;
-				responseObject = responseTask.GetType().GetProperty("Result").GetValue(responseTask);
-			}
-			else if (responseObject is Task responseTask)
-			{
-				await responseTask;
+				// Invoke Operation method
+				var responseObject = methodInfo.Invoke(serviceInstance, arguments);
 
-				//VoidTaskResult
-				responseObject = null;
+				return responseObject is Task task ? As(task) : As(responseObject);
 			}
 
-			return responseObject;
+			return (Task<object>)TaskResultCache.GetOrAdd(methodInfo.ReturnType, type =>
+				   AsMethods[type.GetGenericTypeDefinition() == typeof(Task<>) ? 0 : 1]
+					   .MakeGenericMethod(type.GenericTypeArguments[0]).GetReflector())
+				.Invoke(null, methodInfo.Invoke(serviceInstance, arguments));
+
+			//return As((dynamic)methodInfo.Invoke(serviceInstance, arguments));
 		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private static Task<object> As(object result) => Task.FromResult(result);
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private static async Task<object> As(Task task)
+		{
+			await task;
+
+			return null;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private static async Task<object> As<T>(Task<T> task) => await task;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private static async Task<object> As<T>(ValueTask<T> task) => await task;
 	}
 }

--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -35,6 +35,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="AspectCore.Extensions.Reflection" Version="1.2.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />


### PR DESCRIPTION
Before:

|    Method | LoopNum |       Mean |      Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|---------- |-------- |-----------:|-----------:|----------:|------------:|------------:|------------:|--------------------:|
| EmptyTask |     100 |   5.574 ms |  0.5928 ms | 0.1539 ms |    242.1875 |           - |           - |             7.98 KB |
|      Echo |     100 |  16.646 ms |  2.9067 ms | 0.7549 ms |    843.7500 |           - |           - |             8.17 KB |
| EmptyTask |    1000 |  52.223 ms |  5.0958 ms | 1.3234 ms |   2363.6364 |           - |           - |             7.98 KB |
|      Echo |    1000 | 158.258 ms | 10.9308 ms | 2.8387 ms |   8000.0000 |           - |           - |             8.17 KB |

After:

|    Method | LoopNum |       Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|---------- |-------- |-----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
| EmptyTask |     100 |   5.559 ms | 0.9527 ms | 0.2474 ms |    242.1875 |           - |           - |             7.98 KB |
|      Echo |     100 |  12.640 ms | 1.1351 ms | 0.2948 ms |    781.2500 |           - |           - |             8.17 KB |
| EmptyTask |    1000 |  52.710 ms | 9.8790 ms | 2.5655 ms |   2400.0000 |           - |           - |             7.98 KB |
|      Echo |    1000 | 126.787 ms | 7.4302 ms | 1.9296 ms |   7750.0000 |           - |           - |             8.17 KB |