### PR TITLE
Add support for circular references in datacontract objects

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/CircularReferenceFirstObject.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/CircularReferenceFirstObject.cs
@@ -1,0 +1,11 @@
+using System.Runtime.Serialization;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+    [DataContract]
+    public class CircularReferenceFirstObject
+    {
+		[DataMember]
+        public CircularReferenceSecondObject SecondObject { get; set; }
+    }
+}

--- a/src/SoapCore.Tests/Wsdl/Services/CircularReferenceSecondObject.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/CircularReferenceSecondObject.cs
@@ -1,0 +1,11 @@
+using System.Runtime.Serialization;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+    [DataContract]
+    public class CircularReferenceSecondObject
+    {
+		[DataMember]
+        public CircularReferenceFirstObject FirstObject { get; set; }
+    }
+}

--- a/src/SoapCore.Tests/Wsdl/Services/IDataContractCircularReferenceService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IDataContractCircularReferenceService.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+    public interface IDataContractCircularReferenceService
+    {
+        [OperationContract]
+        CircularReferenceFirstObject GetFirstObject();
+    }
+
+    public class DataContractCircularReferenceService : IDataContractCircularReferenceService
+    {
+        public CircularReferenceFirstObject GetFirstObject()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -12,58 +12,68 @@ using SoapCore.Tests.Wsdl.Services;
 
 namespace SoapCore.Tests.Wsdl
 {
-	[TestClass]
-	public class WsdlTests
-	{
-		private const string ServiceUrl = "http://localhost:5052";
-		private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+    [TestClass]
+    public class WsdlTests
+    {
+        private const string ServiceUrl = "http://localhost:5052";
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
-		[TestMethod]
-		public void CheckTaskReturnMethod()
-		{
-			StartService(typeof(TaskNoReturnService));
-			var wsdl = GetWsdl();
-			Trace.TraceInformation(wsdl);
-			Assert.IsNotNull(wsdl);
-			StopServer();
-		}
+        [TestMethod]
+        public void CheckTaskReturnMethod()
+        {
+            StartService(typeof(TaskNoReturnService));
+            var wsdl = GetWsdl();
+            Trace.TraceInformation(wsdl);
+            Assert.IsNotNull(wsdl);
+            StopServer();
+        }
 
-		[TestMethod]
-		public void CheckDataContractContainsItself()
-		{
-			StartService(typeof(DataContractContainsItselfService));
-			var wsdl = GetWsdl();
-			Trace.TraceInformation(wsdl);
-			Assert.IsNotNull(wsdl);
-			StopServer();
-		}
+        [TestMethod]
+        public void CheckDataContractContainsItself()
+        {
+            StartService(typeof(DataContractContainsItselfService));
+            var wsdl = GetWsdl();
+            Trace.TraceInformation(wsdl);
+            Assert.IsNotNull(wsdl);
+            StopServer();
+        }
 
-		[TestCleanup]
-		public void StopServer()
-		{
-			_cancellationTokenSource.Cancel();
-		}
+        [TestMethod]
+        public void CheckDataContractCircularReference()
+        {
+            StartService(typeof(DataContractCircularReferenceService));
+            var wsdl = GetWsdl();
+            Trace.TraceInformation(wsdl);
+            Assert.IsNotNull(wsdl);
+            StopServer();
+        }
 
-		private string GetWsdl(string serviceName = "Service.svc")
-		{
-			using (var httpClient = new HttpClient())
-			{
-				return httpClient.GetStringAsync(string.Format("{0}/{1}?wsdl", ServiceUrl, serviceName)).Result;
-			}
-		}
+        [TestCleanup]
+        public void StopServer()
+        {
+            _cancellationTokenSource.Cancel();
+        }
 
-		private void StartService(Type serviceType)
-		{
-			Task.Run(async () =>
-			{
-				var host = new WebHostBuilder()
-					.UseKestrel()
-					.UseUrls(ServiceUrl)
-					.ConfigureServices(services => services.AddSingleton<IStartupConfiguration>(new StartupConfiguration(serviceType)))
-					.UseStartup<Startup>()
-					.Build();
-				await host.RunAsync(_cancellationTokenSource.Token);
-			}).Wait(1000);
-		}
-	}
+        private string GetWsdl(string serviceName = "Service.svc")
+        {
+            using (var httpClient = new HttpClient())
+            {
+                return httpClient.GetStringAsync(string.Format("{0}/{1}?wsdl", ServiceUrl, serviceName)).Result;
+            }
+        }
+
+        private void StartService(Type serviceType)
+        {
+            Task.Run(async () =>
+            {
+                var host = new WebHostBuilder()
+                    .UseKestrel()
+                    .UseUrls(ServiceUrl)
+                    .ConfigureServices(services => services.AddSingleton<IStartupConfiguration>(new StartupConfiguration(serviceType)))
+                    .UseStartup<Startup>()
+                    .Build();
+                await host.RunAsync(_cancellationTokenSource.Token);
+            }).Wait(1000);
+        }
+    }
 }

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -12,38 +12,39 @@ using SoapCore.Tests.Wsdl.Services;
 
 namespace SoapCore.Tests.Wsdl
 {
-	[TestClass]
-	public class WsdlTests
-	{
-		private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+    [TestClass]
+    public class WsdlTests
+    {
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
-		[TestMethod]
-		public void CheckTaskReturnMethod()
-		{
-			string serviceUrl = "http://localhost:5053";
-			StartService(typeof(TaskNoReturnService), serviceUrl);
-			var wsdl = GetWsdl(serviceUrl);
-			Trace.TraceInformation(wsdl);
-			Assert.IsNotNull(wsdl);
-			StopServer();
-		}
+        [TestMethod]
+        public void CheckTaskReturnMethod()
+        {
+            string serviceUrl = "http://localhost:5053";
+            StartService(typeof(TaskNoReturnService), serviceUrl);
+            var wsdl = GetWsdl(serviceUrl);
+            Trace.TraceInformation(wsdl);
+            Assert.IsNotNull(wsdl);
+            StopServer();
+        }
 
-		[TestMethod]
-		public void CheckDataContractContainsItself()
-		{
-			string serviceUrl = "http://localhost:5054";
-			StartService(typeof(DataContractContainsItselfService), serviceUrl);
-			var wsdl = GetWsdl(serviceUrl);
-			Trace.TraceInformation(wsdl);
-			Assert.IsNotNull(wsdl);
-			StopServer();
-		}
+        [TestMethod]
+        public void CheckDataContractContainsItself()
+        {
+            string serviceUrl = "http://localhost:5054";
+            StartService(typeof(DataContractContainsItselfService), serviceUrl);
+            var wsdl = GetWsdl(serviceUrl);
+            Trace.TraceInformation(wsdl);
+            Assert.IsNotNull(wsdl);
+            StopServer();
+        }
 
         [TestMethod]
         public void CheckDataContractCircularReference()
         {
-            StartService(typeof(DataContractCircularReferenceService));
-            var wsdl = GetWsdl();
+            string serviceUrl = "http://localhost:5055";
+            StartService(typeof(DataContractCircularReferenceService), serviceUrl);
+            var wsdl = GetWsdl(serviceUrl);
             Trace.TraceInformation(wsdl);
             Assert.IsNotNull(wsdl);
             StopServer();
@@ -55,26 +56,26 @@ namespace SoapCore.Tests.Wsdl
             _cancellationTokenSource.Cancel();
         }
 
-		private string GetWsdl(string serviceUrl, string serviceName = "Service.svc")
-		{
-			using (var httpClient = new HttpClient())
-			{
-				return httpClient.GetStringAsync(string.Format("{0}/{1}?wsdl", serviceUrl, serviceName)).Result;
-			}
-		}
+        private string GetWsdl(string serviceUrl, string serviceName = "Service.svc")
+        {
+            using (var httpClient = new HttpClient())
+            {
+                return httpClient.GetStringAsync(string.Format("{0}/{1}?wsdl", serviceUrl, serviceName)).Result;
+            }
+        }
 
-		private void StartService(Type serviceType, string serviceUrl)
-		{
-			Task.Run(async () =>
-			{
-				var host = new WebHostBuilder()
-					.UseKestrel()
-					.UseUrls(serviceUrl)
-					.ConfigureServices(services => services.AddSingleton<IStartupConfiguration>(new StartupConfiguration(serviceType)))
-					.UseStartup<Startup>()
-					.Build();
-				await host.RunAsync(_cancellationTokenSource.Token);
-			}).Wait(1000);
-		}
-	}
+        private void StartService(Type serviceType, string serviceUrl)
+        {
+            Task.Run(async () =>
+            {
+                var host = new WebHostBuilder()
+                    .UseKestrel()
+                    .UseUrls(serviceUrl)
+                    .ConfigureServices(services => services.AddSingleton<IStartupConfiguration>(new StartupConfiguration(serviceType)))
+                    .UseStartup<Startup>()
+                    .Build();
+                await host.RunAsync(_cancellationTokenSource.Token);
+            }).Wait(1000);
+        }
+    }
 }

--- a/src/SoapCore/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/MetaWCFBodyWriter.cs
@@ -57,6 +57,7 @@ namespace SoapCore
 		private readonly Binding _binding;
 
 		private readonly Dictionary<Type, string> _complexTypeToBuild = new Dictionary<Type, string>();
+		private readonly HashSet<Type> _complexTypeProcessed = new HashSet<Type>(); // Contains types that have been discovered
 		private readonly Queue<Type> _arrayToBuild;
 
 		private readonly HashSet<string> _builtEnumTypes;
@@ -538,6 +539,7 @@ namespace SoapCore
 		{
 			foreach (var type in _complexTypeToBuild.ToArray())
 			{
+				_complexTypeToBuild[type.Key] = GetDataContractNamespace(type.Key);
 				DiscoveryTypesByProperties(type.Key, true);
 			}
 
@@ -592,7 +594,9 @@ namespace SoapCore
 		private void DiscoveryTypesByProperties(Type type, bool isRootType)
 		{
 			//guard against infinity recursion
-			if (!isRootType && _complexTypeToBuild.ContainsKey(type))
+			//check is made against _complexTypeProcessed, which contains types that have been
+			//discovered by the current method
+			if (_complexTypeProcessed.Contains(type))
 			{
 				return;
 			}
@@ -601,6 +605,9 @@ namespace SoapCore
 			{
 				return;
 			}
+
+			//type will be processed, so can be added to _complexTypeProcessed
+			_complexTypeProcessed.Add(type);
 
 			if (HasBaseType(type) && type.BaseType != null)
 			{

--- a/src/SoapCore/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/MetaWCFBodyWriter.cs
@@ -604,8 +604,8 @@ namespace SoapCore
 
 			if (HasBaseType(type) && type.BaseType != null)
 			{
-				DiscoveryTypesByProperties(type.BaseType, false);
 				_complexTypeToBuild[type.BaseType] = GetDataContractNamespace(type.BaseType);
+				DiscoveryTypesByProperties(type.BaseType, false);
 			}
 
 			foreach (var property in type.GetProperties().Where(prop =>
@@ -641,8 +641,8 @@ namespace SoapCore
 						continue;
 					}
 
-					DiscoveryTypesByProperties(propertyType, false);
 					_complexTypeToBuild[propertyType] = GetDataContractNamespace(propertyType);
+					DiscoveryTypesByProperties(propertyType, false);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #302 

Solution : store type in dictionary before the recursive call