### PR TITLE
Fix null issue when there is a namespace on DataContractAttribute for a request argument

### DIFF
--- a/src/SoapCore.Tests/Serialization/DataContractSerializationTests.cs
+++ b/src/SoapCore.Tests/Serialization/DataContractSerializationTests.cs
@@ -149,12 +149,12 @@ namespace SoapCore.Tests.Serialization
 		//not compatible with XmlSerializer
 		[Theory]
 		[InlineData(SoapSerializer.DataContractSerializer)]
-		public void TestPingComplexModelSerialization(SoapSerializer soapSerializer)
+		public void TestPingComplexModelSerializationWithNameSpace(SoapSerializer soapSerializer)
 		{
 			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
 
 			_fixture.ServiceMock
-				.Setup(x => x.PingComplexModel(It.IsAny<ComplexModel2>()))
+				.Setup(x => x.PingComplexModel2(It.IsAny<ComplexModel2>()))
 				.Callback(
 					(ComplexModel2 inputModel_service) =>
 					{
@@ -165,10 +165,35 @@ namespace SoapCore.Tests.Serialization
 
 			var pingComplexModelResult_client =
 				sampleServiceClient
-					.PingComplexModel(ComplexModel2.CreateSample2());
+					.PingComplexModel2(ComplexModel2.CreateSample2());
 
 			// check output paremeters serialization
 			pingComplexModelResult_client.ShouldDeepEqual(ComplexModel1.CreateSample3());
+		}
+
+		//not compatible with XmlSerializer
+		[Theory]
+		[InlineData(SoapSerializer.DataContractSerializer)]
+		public void TestPingComplexModelSerializationWithNoNameSpace(SoapSerializer soapSerializer)
+		{
+			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
+
+			_fixture.ServiceMock
+				.Setup(x => x.PingComplexModel1(It.IsAny<ComplexModel1>()))
+				.Callback(
+					(ComplexModel1 inputModel_service) =>
+					{
+						// check input paremeters serialization
+						inputModel_service.ShouldDeepEqual(ComplexModel1.CreateSample3());
+					})
+				.Returns(ComplexModel2.CreateSample2);
+
+			var pingComplexModelResult_client =
+				sampleServiceClient
+					.PingComplexModel1(ComplexModel1.CreateSample3());
+
+			// check output paremeters serialization
+			pingComplexModelResult_client.ShouldDeepEqual(ComplexModel2.CreateSample2());
 		}
 
 		[Theory(Skip = "incompatible with all serializers")]

--- a/src/SoapCore.Tests/Serialization/Models.DataContract/ComplexModel2.cs
+++ b/src/SoapCore.Tests/Serialization/Models.DataContract/ComplexModel2.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace SoapCore.Tests.Serialization.Models.DataContract
 {
 	// same as ComplexModel1, just for testing
-	[DataContract]
+	[DataContract(Namespace = "http://SoapCore.Tests.Serialization.Models.DataContract.ComplexModel2")]
 	public class ComplexModel2
 	{
 		[DataMember]

--- a/src/SoapCore.Tests/Serialization/Models.DataContract/ISampleService.cs
+++ b/src/SoapCore.Tests/Serialization/Models.DataContract/ISampleService.cs
@@ -12,7 +12,12 @@ namespace SoapCore.Tests.Serialization.Models.DataContract
 		// if enabled, can handle XmlSerializer, but not DataContractSerializer
 		// [XmlSerializerFormat]
 		[OperationContract]
-		ComplexModel1 PingComplexModel(ComplexModel2 inputModel);
+		ComplexModel2 PingComplexModel1(ComplexModel1 inputModel);
+
+		// if enabled, can handle XmlSerializer, but not DataContractSerializer
+		// [XmlSerializerFormat]
+		[OperationContract]
+		ComplexModel1 PingComplexModel2(ComplexModel2 inputModel);
 
 		// if enabled, can handle XmlSerializer, but not DataContractSerializer
 		// [XmlSerializerFormat]

--- a/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
@@ -11,9 +11,13 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 		[XmlSerializerFormat(SupportFaults = true)]
 		string Ping(string s);
 
-		[OperationContract(Action = ServiceNamespace.Value + nameof(PingComplexModel), ReplyAction = "*")]
+		[OperationContract(Action = ServiceNamespace.Value + nameof(PingComplexModel1), ReplyAction = "*")]
 		[XmlSerializerFormat(SupportFaults = true)]
-		ComplexModel1 PingComplexModel(ComplexModel2 inputModel);
+		ComplexModel2 PingComplexModel1(ComplexModel1 inputModel);
+
+		[OperationContract(Action = ServiceNamespace.Value + nameof(PingComplexModel2), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
+		ComplexModel1 PingComplexModel2(ComplexModel2 inputModel);
 
 		// new style call with multiple out/ref/value params
 		//   instead of packing them into single request/response class

--- a/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
+++ b/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
@@ -151,12 +151,12 @@ namespace SoapCore.Tests.Serialization
 		// not compatible with DataContractSerializer
 		[Theory]
 		[InlineData(SoapSerializer.XmlSerializer)]
-		public void TestPingComplexModelSerialization(SoapSerializer soapSerializer)
+		public void TestPingComplexModelSerializationWithNameSpace(SoapSerializer soapSerializer)
 		{
 			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
 
 			_fixture.ServiceMock
-				.Setup(x => x.PingComplexModel(It.IsAny<ComplexModel2>()))
+				.Setup(x => x.PingComplexModel2(It.IsAny<ComplexModel2>()))
 				.Callback(
 					(ComplexModel2 inputModel_service) =>
 					{
@@ -167,10 +167,35 @@ namespace SoapCore.Tests.Serialization
 
 			var pingComplexModelResult_client =
 				sampleServiceClient
-					.PingComplexModel(ComplexModel2.CreateSample2());
+					.PingComplexModel2(ComplexModel2.CreateSample2());
 
 			// check output paremeters serialization
 			pingComplexModelResult_client.ShouldDeepEqual(ComplexModel1.CreateSample3());
+		}
+
+		// not compatible with DataContractSerializer
+		[Theory]
+		[InlineData(SoapSerializer.XmlSerializer)]
+		public void TestPingComplexModelSerializationWithNoNameSpace(SoapSerializer soapSerializer)
+		{
+			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
+
+			_fixture.ServiceMock
+				.Setup(x => x.PingComplexModel1(It.IsAny<ComplexModel1>()))
+				.Callback(
+					(ComplexModel1 inputModel_service) =>
+					{
+						// check input paremeters serialization
+						inputModel_service.ShouldDeepEqual(ComplexModel1.CreateSample3());
+					})
+				.Returns(ComplexModel2.CreateSample2);
+
+			var pingComplexModelResult_client =
+				sampleServiceClient
+					.PingComplexModel1(ComplexModel1.CreateSample3());
+
+			// check output paremeters serialization
+			pingComplexModelResult_client.ShouldDeepEqual(ComplexModel2.CreateSample2());
 		}
 
 		[Theory]

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -437,7 +437,6 @@ namespace SoapCore
 
 				foreach (var parameterInfo in operation.InParameters)
 				{
-					var @namespace = parameterInfo.Namespace ?? operation.Contract.Namespace;
 					var parameterType = parameterInfo.Parameter.ParameterType;
 
 					if (parameterType == typeof(HttpContext))
@@ -446,7 +445,7 @@ namespace SoapCore
 					}
 					else
 					{
-						arguments[parameterInfo.Index] = DeserializeInputParameter(xmlReader, parameterType, parameterInfo.Name, @namespace, parameterInfo);
+						arguments[parameterInfo.Index] = DeserializeInputParameter(xmlReader, parameterType, parameterInfo.Name, operation.Contract.Namespace, parameterInfo);
 					}
 				}
 			}


### PR DESCRIPTION
This is the fix for issue https://github.com/DigDes/SoapCore/issues/304

The namespace being passed into DeserializeInputParameter is the namespace of the members of the input rather than the input object itself.

This change fixes the above and adds a namespace to the unit test class ComplexModel2 to catch this in the fuiture.