### PR TITLE
Fix for false test failures due to port collision

### DIFF
--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -15,14 +15,14 @@ namespace SoapCore.Tests.Wsdl
 	[TestClass]
 	public class WsdlTests
 	{
-		private const string ServiceUrl = "http://localhost:5052";
 		private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
 		[TestMethod]
 		public void CheckTaskReturnMethod()
 		{
-			StartService(typeof(TaskNoReturnService));
-			var wsdl = GetWsdl();
+			string serviceUrl = "http://localhost:5053";
+			StartService(typeof(TaskNoReturnService), serviceUrl);
+			var wsdl = GetWsdl(serviceUrl);
 			Trace.TraceInformation(wsdl);
 			Assert.IsNotNull(wsdl);
 			StopServer();
@@ -31,8 +31,9 @@ namespace SoapCore.Tests.Wsdl
 		[TestMethod]
 		public void CheckDataContractContainsItself()
 		{
-			StartService(typeof(DataContractContainsItselfService));
-			var wsdl = GetWsdl();
+			string serviceUrl = "http://localhost:5054";
+			StartService(typeof(DataContractContainsItselfService), serviceUrl);
+			var wsdl = GetWsdl(serviceUrl);
 			Trace.TraceInformation(wsdl);
 			Assert.IsNotNull(wsdl);
 			StopServer();
@@ -44,21 +45,21 @@ namespace SoapCore.Tests.Wsdl
 			_cancellationTokenSource.Cancel();
 		}
 
-		private string GetWsdl(string serviceName = "Service.svc")
+		private string GetWsdl(string serviceUrl, string serviceName = "Service.svc")
 		{
 			using (var httpClient = new HttpClient())
 			{
-				return httpClient.GetStringAsync(string.Format("{0}/{1}?wsdl", ServiceUrl, serviceName)).Result;
+				return httpClient.GetStringAsync(string.Format("{0}/{1}?wsdl", serviceUrl, serviceName)).Result;
 			}
 		}
 
-		private void StartService(Type serviceType)
+		private void StartService(Type serviceType, string serviceUrl)
 		{
 			Task.Run(async () =>
 			{
 				var host = new WebHostBuilder()
 					.UseKestrel()
-					.UseUrls(ServiceUrl)
+					.UseUrls(serviceUrl)
 					.ConfigureServices(services => services.AddSingleton<IStartupConfiguration>(new StartupConfiguration(serviceType)))
 					.UseStartup<Startup>()
 					.Build();


### PR DESCRIPTION
This is the fix for https://github.com/DigDes/SoapCore/issues/306
Three unit tests use http://localhost:5052 and when run together in a batch can interfere with each other can cause a false test failure.

This change moves two of the three tests to different ports so there will be no collision.