### PR TITLE
XmlSerializer: Implement MessageContract(IsWrapped=false) for return results

### DIFF
--- a/src/SoapCore.Tests/RawRequestSoap12Tests.cs
+++ b/src/SoapCore.Tests/RawRequestSoap12Tests.cs
@@ -47,6 +47,33 @@ namespace SoapCore.Tests
 		}
 
 		[TestMethod]
+		public void Soap12PingWithActionInEnvelopeHeader()
+		{
+			var body = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<soap12:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:soap12=""http://www.w3.org/2003/05/soap-envelope"" xmlns:wsa=""http://www.w3.org/2005/08/addressing"">
+  <soap12:Header>
+	<wsa:Action>Ping</wsa:Action>
+  </soap12:Header>
+  <soap12:Body>
+    <Ping xmlns=""http://tempuri.org/"">
+      <s>abc</s>
+    </Ping>
+  </soap12:Body>
+</soap12:Envelope>
+";
+			var bodyBytes = Encoding.UTF8.GetBytes(body);
+			using (var host = CreateTestHost())
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body, Encoding.UTF8, "application/soap+xml"))
+			{
+				using (var res = host.CreateRequest("/Service.svc").And(msg => msg.Content = content).PostAsync().Result)
+				{
+					res.EnsureSuccessStatusCode();
+				}
+			}
+		}
+
+		[TestMethod]
 		public void Soap12PingNoActionInHeader()
 		{
 			var body = @"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/src/SoapCore.Tests/Serialization/Models.Xml/BasicMessageContractPayload.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/BasicMessageContractPayload.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Text;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[MessageContract]
+	public class BasicMessageContractPayload
+	{
+	}
+}

--- a/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
@@ -59,6 +59,10 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 		NotWrappedFieldComplexInputResponse NotWrappedFieldDoubleComplexInputRequestMethod(
 			NotWrappedFieldDoubleComplexInputRequest request);
 
+		[OperationContract(Action = ServiceNamespace.Value + nameof(TestUnwrappedMessageBodyMember), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
+		UnwrappedMessageBodyMemberResponse TestUnwrappedMessageBodyMember();
+
 		[OperationContract(Action = ServiceNamespace.Value + nameof(EnumMethod), ReplyAction = "*")]
 		[XmlSerializerFormat(SupportFaults = true)]
 		bool EnumMethod(out SampleEnum e);

--- a/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
@@ -59,14 +59,14 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 		NotWrappedFieldComplexInputResponse NotWrappedFieldDoubleComplexInputRequestMethod(
 			NotWrappedFieldDoubleComplexInputRequest request);
 
-		// Ideally, this would be void however the WCF client requires that if you have a MessageContract
-		// response you *must* have a MessageContract
+		// Ideally this would be void however the WCF client requires that if you have a MessageContract
+		// response you *must* have a MessageContract input
 		[OperationContract(Action = ServiceNamespace.Value + nameof(TestUnwrappedMultipleMessageBodyMember), ReplyAction = "*")]
 		[XmlSerializerFormat(SupportFaults = true)]
 		UnwrappedMultipleMessageBodyMemberResponse TestUnwrappedMultipleMessageBodyMember(BasicMessageContractPayload x);
 
-		// Ideally, this would be void however WCF client requires that if you have a MessageContract
-		// response you *must* have a MessageContract
+		// Ideally this would be void however WCF client requires that if you have a MessageContract
+		// response you *must* have a MessageContract input
 		[OperationContract(Action = ServiceNamespace.Value + nameof(TestUnwrappedStringMessageBodyMember), ReplyAction = "*")]
 		[XmlSerializerFormat(SupportFaults = true)]
 		UnwrappedStringMessageBodyMemberResponse TestUnwrappedStringMessageBodyMember(BasicMessageContractPayload x);

--- a/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
@@ -59,9 +59,17 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 		NotWrappedFieldComplexInputResponse NotWrappedFieldDoubleComplexInputRequestMethod(
 			NotWrappedFieldDoubleComplexInputRequest request);
 
-		[OperationContract(Action = ServiceNamespace.Value + nameof(TestUnwrappedMessageBodyMember), ReplyAction = "*")]
+		// Ideally, this would be void however the WCF client requires that if you have a MessageContract
+		// response you *must* have a MessageContract
+		[OperationContract(Action = ServiceNamespace.Value + nameof(TestUnwrappedMultipleMessageBodyMember), ReplyAction = "*")]
 		[XmlSerializerFormat(SupportFaults = true)]
-		UnwrappedMessageBodyMemberResponse TestUnwrappedMessageBodyMember();
+		UnwrappedMultipleMessageBodyMemberResponse TestUnwrappedMultipleMessageBodyMember(BasicMessageContractPayload x);
+
+		// Ideally, this would be void however WCF client requires that if you have a MessageContract
+		// response you *must* have a MessageContract
+		[OperationContract(Action = ServiceNamespace.Value + nameof(TestUnwrappedStringMessageBodyMember), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
+		UnwrappedStringMessageBodyMemberResponse TestUnwrappedStringMessageBodyMember(BasicMessageContractPayload x);
 
 		[OperationContract(Action = ServiceNamespace.Value + nameof(EnumMethod), ReplyAction = "*")]
 		[XmlSerializerFormat(SupportFaults = true)]

--- a/src/SoapCore.Tests/Serialization/Models.Xml/UnwrappedMessageBodyMemberResponse.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/UnwrappedMessageBodyMemberResponse.cs
@@ -1,0 +1,14 @@
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[MessageContract(IsWrapped = false)]
+	public class UnwrappedMessageBodyMemberResponse
+	{
+		[MessageBodyMember(Name = "foo1", Namespace = "http://tempuri.org/NotWrappedPropertyComplexInput")]
+		public NotWrappedPropertyComplexInput NotWrappedComplexInput1 { get; set; }
+
+		[MessageBodyMember(Name = "foo2", Namespace = "http://tempuri.org/NotWrappedPropertyComplexInput")]
+		public NotWrappedPropertyComplexInput NotWrappedComplexInput2 { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Serialization/Models.Xml/UnwrappedMultipleMessageBodyMemberResponse.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/UnwrappedMultipleMessageBodyMemberResponse.cs
@@ -3,7 +3,7 @@ using System.ServiceModel;
 namespace SoapCore.Tests.Serialization.Models.Xml
 {
 	[MessageContract(IsWrapped = false)]
-	public class UnwrappedMessageBodyMemberResponse
+	public class UnwrappedMultipleMessageBodyMemberResponse
 	{
 		[MessageBodyMember(Name = "foo1", Namespace = "http://tempuri.org/NotWrappedPropertyComplexInput")]
 		public NotWrappedPropertyComplexInput NotWrappedComplexInput1 { get; set; }

--- a/src/SoapCore.Tests/Serialization/Models.Xml/UnwrappedStringMessageBodyMemberResponse.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/UnwrappedStringMessageBodyMemberResponse.cs
@@ -1,0 +1,11 @@
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[MessageContract(IsWrapped = false)]
+	public class UnwrappedStringMessageBodyMemberResponse
+	{
+		[MessageBodyMember]
+		public string StringProperty { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
+++ b/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
@@ -348,10 +348,48 @@ namespace SoapCore.Tests.Serialization
 
 			clientResponse.ShouldNotBeNull();
 
-			// The client does not support unpacking these message contracts, so further assertions have been
-			// commented
-			//	clientResponse.NotWrappedComplexInput.ShouldNotBeNull();
-			//	clientResponse.NotWrappedComplexInput.StringProperty.ShouldBe("z");
+			clientResponse.NotWrappedComplexInput.ShouldNotBeNull();
+			clientResponse.NotWrappedComplexInput.StringProperty.ShouldBe("z");
+		}
+
+		//not compatible with DataContractSerializer
+		[Theory(Skip = "Multiple MessageBodyMember and MessageContract(IsWrapped = false) is not supported")]
+		[InlineData(SoapSerializer.XmlSerializer)]
+		public void TestUnwrappedMessageBodyMemberResponse(SoapSerializer soapSerializer)
+		{
+			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
+			var called = false;
+
+			_fixture.ServiceMock
+				.Setup(x => x.TestUnwrappedMessageBodyMember())
+				.Callback(() =>
+				{
+					called = true;
+				})
+				.Returns(new UnwrappedMessageBodyMemberResponse
+				{
+					NotWrappedComplexInput1 = new NotWrappedPropertyComplexInput
+					{
+						StringProperty = "one"
+					},
+
+					NotWrappedComplexInput2 = new NotWrappedPropertyComplexInput
+					{
+						StringProperty = "two"
+					}
+				});
+
+			var clientResponse = sampleServiceClient.TestUnwrappedMessageBodyMember();
+
+			Assert.True(called);
+
+			clientResponse.ShouldNotBeNull();
+
+			clientResponse.NotWrappedComplexInput1.ShouldNotBeNull();
+			clientResponse.NotWrappedComplexInput1.StringProperty.ShouldBe("one");
+
+			clientResponse.NotWrappedComplexInput2.ShouldNotBeNull();
+			clientResponse.NotWrappedComplexInput2.StringProperty.ShouldBe("two");
 		}
 
 		//not compatible with DataContractSerializer
@@ -387,10 +425,8 @@ namespace SoapCore.Tests.Serialization
 
 			clientResponse.ShouldNotBeNull();
 
-			// The client does not support unpacking these message contracts, so further assertions have been
-			// commented
-			//	clientResponse.NotWrappedComplexInput.ShouldNotBeNull();
-			//	clientResponse.NotWrappedComplexInput.StringProperty.ShouldBe("z");
+			clientResponse.NotWrappedComplexInput.ShouldNotBeNull();
+			clientResponse.NotWrappedComplexInput.StringProperty.ShouldBe("z");
 		}
 
 		//not compatible with DataContractSerializer
@@ -434,10 +470,8 @@ namespace SoapCore.Tests.Serialization
 
 			clientResponse.ShouldNotBeNull();
 
-			// The client does not support unpacking these message contracts, so further assertions have been
-			// commented
-			//	clientResponse.NotWrappedComplexInput.ShouldNotBeNull();
-			//	clientResponse.NotWrappedComplexInput.StringProperty.ShouldBe("z");
+			clientResponse.NotWrappedComplexInput.ShouldNotBeNull();
+			clientResponse.NotWrappedComplexInput.StringProperty.ShouldBe("z");
 		}
 
 		//not compatible with DataContractSerializer

--- a/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
+++ b/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
@@ -352,21 +352,34 @@ namespace SoapCore.Tests.Serialization
 			clientResponse.NotWrappedComplexInput.StringProperty.ShouldBe("z");
 		}
 
-		//not compatible with DataContractSerializer
-		[Theory(Skip = "Multiple MessageBodyMember and MessageContract(IsWrapped = false) is not supported")]
+		[Theory]
 		[InlineData(SoapSerializer.XmlSerializer)]
-		public void TestUnwrappedMessageBodyMemberResponse(SoapSerializer soapSerializer)
+		public void TestUnwrappedSimpleMessageBodyMemberResponse(SoapSerializer soapSerializer)
 		{
 			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
-			var called = false;
 
 			_fixture.ServiceMock
-				.Setup(x => x.TestUnwrappedMessageBodyMember())
-				.Callback(() =>
+				.Setup(x => x.TestUnwrappedStringMessageBodyMember(It.IsAny<BasicMessageContractPayload>()))
+				.Returns(() => new UnwrappedStringMessageBodyMemberResponse
 				{
-					called = true;
-				})
-				.Returns(new UnwrappedMessageBodyMemberResponse
+					StringProperty = "one"
+				});
+
+			var clientResponse = sampleServiceClient.TestUnwrappedStringMessageBodyMember(new BasicMessageContractPayload());
+
+			clientResponse.ShouldNotBeNull();
+			clientResponse.StringProperty.ShouldBe("one");
+		}
+
+		[Theory]
+		[InlineData(SoapSerializer.XmlSerializer)]
+		public void TestUnwrappedMultipleMessageBodyMemberResponse(SoapSerializer soapSerializer)
+		{
+			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
+
+			_fixture.ServiceMock
+				.Setup(x => x.TestUnwrappedMultipleMessageBodyMember(It.IsAny<BasicMessageContractPayload>()))
+				.Returns(new UnwrappedMultipleMessageBodyMemberResponse
 				{
 					NotWrappedComplexInput1 = new NotWrappedPropertyComplexInput
 					{
@@ -379,9 +392,7 @@ namespace SoapCore.Tests.Serialization
 					}
 				});
 
-			var clientResponse = sampleServiceClient.TestUnwrappedMessageBodyMember();
-
-			Assert.True(called);
+			var clientResponse = sampleServiceClient.TestUnwrappedMultipleMessageBodyMember(new BasicMessageContractPayload());
 
 			clientResponse.ShouldNotBeNull();
 

--- a/src/SoapCore.Tests/SoapCore.Tests.csproj
+++ b/src/SoapCore.Tests/SoapCore.Tests.csproj
@@ -46,7 +46,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Folder Include="Serialization\" />
 		<Folder Include="Serialization\Models.DataContract\" />
 		<Folder Include="Serialization\Models.Models.Xml\" />
 	</ItemGroup>

--- a/src/SoapCore/ReflectionExtensions.cs
+++ b/src/SoapCore/ReflectionExtensions.cs
@@ -103,5 +103,20 @@ namespace SoapCore
 
 			return null;
 		}
+
+		internal static object GetPropertyOrFieldValue(this MemberInfo memberInfo, object obj)
+		{
+			if (memberInfo is FieldInfo fi)
+			{
+				return fi.GetValue(obj);
+			}
+
+			if (memberInfo is PropertyInfo pi)
+			{
+				return pi.GetValue(obj);
+			}
+
+			throw new NotImplementedException($"Unable to get value out of member with type {memberInfo.GetType()}");
+		}
 	}
 }

--- a/src/SoapCore/ServiceBodyWriter.cs
+++ b/src/SoapCore/ServiceBodyWriter.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Xml;
 using System.Xml.Serialization;
@@ -20,151 +22,173 @@ namespace SoapCore
 		private readonly object _result;
 		private readonly Dictionary<string, object> _outResults;
 
-		public ServiceBodyWriter(SoapSerializer serializer, OperationDescription operation, string resultName, object result, Dictionary<string, object> outResults) : base(isBuffered: true)
+		public ServiceBodyWriter(SoapSerializer serializer, OperationDescription operation, object result, Dictionary<string, object> outResults) : base(isBuffered: true)
 		{
 			_serializer = serializer;
 			_operation = operation;
 			_serviceNamespace = operation.Contract.Namespace;
 			_envelopeName = operation.Name + "Response";
-			_resultName = resultName;
+			_resultName = operation.ReturnName;
 			_result = result;
-			_outResults = outResults;
+			_outResults = outResults ?? new Dictionary<string, object>();
 		}
 
 		protected override void OnWriteBodyContents(XmlDictionaryWriter writer)
 		{
-			// do not wrap old-style single element response into additional xml element for xml serializer
-			var needResponseEnvelope = _serializer != SoapSerializer.XmlSerializer || _result == null || (_outResults != null && _outResults.Count > 0) || !_operation.IsMessageContractResponse;
+			switch (_serializer)
+			{
+				case SoapSerializer.XmlSerializer:
+					OnWriteXmlSerializerBodyContents(writer);
+					break;
+				case SoapSerializer.DataContractSerializer:
+					OnWriteDataContractSerializerBodyContents(writer);
+					break;
+				default:
+					throw new NotImplementedException($"Unknown serializer {_serializer}");
+			}
+		}
+
+		private void OnWriteXmlSerializerBodyContents(XmlDictionaryWriter writer)
+		{
+			Debug.Assert(_outResults != null, "Object should set empty out results");
+
+			// Do not wrap old-style single element response into additional xml element for xml serializer
+			var needResponseEnvelope = _result == null || (_outResults.Count > 0) || !_operation.IsMessageContractResponse;
 
 			if (needResponseEnvelope)
 			{
 				writer.WriteStartElement(_envelopeName, _serviceNamespace);
 			}
 
-			if (_outResults != null)
+			foreach (var outResult in _outResults)
 			{
-				foreach (var outResult in _outResults)
+				string value = null;
+				if (outResult.Value is Guid)
 				{
-					string value = null;
-					if (outResult.Value is Guid)
-					{
-						value = outResult.Value.ToString();
-					}
-					else if (outResult.Value is bool)
-					{
-						value = outResult.Value.ToString().ToLower();
-					}
-					else if (outResult.Value is string)
-					{
-						value = System.Security.SecurityElement.Escape(outResult.Value.ToString());
-					}
-					else if (outResult.Value is Enum)
-					{
-						value = outResult.Value.ToString();
-					}
-					else if (outResult.Value == null)
-					{
-						value = null;
-					}
-
+					value = outResult.Value.ToString();
+				}
+				else if (outResult.Value is bool)
+				{
+					value = outResult.Value.ToString().ToLower();
+				}
+				else if (outResult.Value is string)
+				{
+					value = System.Security.SecurityElement.Escape(outResult.Value.ToString());
+				}
+				else if (outResult.Value is Enum)
+				{
+					value = outResult.Value.ToString();
+				}
+				else if (outResult.Value == null)
+				{
+					value = null;
+				}
+				else
+				{
 					//for complex types
-					else
+					using (var ms = new MemoryStream())
+					using (var stream = new BufferedStream(ms))
 					{
-						using (var ms = new MemoryStream())
-						using (var stream = new BufferedStream(ms))
+						// write element with name as outResult.Key and type information as outResultType
+						// i.e. <outResult.Key xsi:type="outResultType" ... />
+						var outResultType = outResult.Value.GetType();
+						var serializer = CachedXmlSerializer.GetXmlSerializer(outResultType, outResult.Key, _serviceNamespace);
+						lock (serializer)
 						{
-							switch (_serializer)
-							{
-								case SoapSerializer.XmlSerializer:
-									// write element with name as outResult.Key and type information as outResultType
-									// i.e. <outResult.Key xsi:type="outResultType" ... />
-									var outResultType = outResult.Value.GetType();
-									var serializer = CachedXmlSerializer.GetXmlSerializer(outResultType, outResult.Key, _serviceNamespace);
-									lock (serializer)
-									{
-										serializer.Serialize(stream, outResult.Value);
-									}
-
-									//add outResultType. ugly, but working
-									stream.Position = 0;
-									XmlDocument xdoc = new XmlDocument();
-									xdoc.Load(stream);
-									var attr = xdoc.CreateAttribute("xsi", "type", "http://www.w3.org/2001/XMLSchema-instance");
-									attr.Value = outResultType.Name;
-									xdoc.DocumentElement.Attributes.Prepend(attr);
-									writer.WriteRaw(xdoc.DocumentElement.OuterXml);
-									break;
-								case SoapSerializer.DataContractSerializer:
-									new DataContractSerializer(outResult.Value.GetType()).WriteObject(ms, outResult.Value);
-									stream.Position = 0;
-									using (var reader = XmlReader.Create(stream))
-									{
-										reader.MoveToContent();
-										value = reader.ReadInnerXml();
-									}
-
-									break;
-								default: throw new NotImplementedException();
-							}
+							serializer.Serialize(stream, outResult.Value);
 						}
-					}
 
-					if (value != null)
-					{
-						writer.WriteRaw(string.Format("<{0}>{1}</{0}>", outResult.Key, value));
+						//add outResultType. ugly, but working
+						stream.Position = 0;
+						XmlDocument xdoc = new XmlDocument();
+						xdoc.Load(stream);
+						var attr = xdoc.CreateAttribute("xsi", "type", "http://www.w3.org/2001/XMLSchema-instance");
+						attr.Value = outResultType.Name;
+						xdoc.DocumentElement.Attributes.Prepend(attr);
+						writer.WriteRaw(xdoc.DocumentElement.OuterXml);
 					}
+				}
+
+				if (value != null)
+				{
+					writer.WriteRaw(string.Format("<{0}>{1}</{0}>", outResult.Key, value));
 				}
 			}
 
 			if (_result != null)
 			{
-				switch (_serializer)
+				// see https://referencesource.microsoft.com/System.Xml/System/Xml/Serialization/XmlSerializer.cs.html#c97688a6c07294d5
+				var resultType = _result.GetType();
+
+				var xmlRootAttr = resultType.GetTypeInfo().GetCustomAttributes<XmlRootAttribute>().FirstOrDefault();
+
+				var xmlName = _operation.ReturnElementName
+					?? (needResponseEnvelope
+					? _resultName
+					: (string.IsNullOrWhiteSpace(xmlRootAttr?.ElementName)
+					? resultType.Name
+					: xmlRootAttr.ElementName));
+
+				var xmlNs = _operation.ReturnNamespace
+					?? (string.IsNullOrWhiteSpace(xmlRootAttr?.Namespace)
+					? _serviceNamespace
+					: xmlRootAttr.Namespace);
+
+				var xmlArrayAttr = _operation.DispatchMethod.GetCustomAttribute<XmlArrayAttribute>();
+
+				if (xmlArrayAttr != null && resultType.IsArray)
 				{
-					case SoapSerializer.XmlSerializer:
+					var serializer = CachedXmlSerializer.GetXmlSerializer(resultType.GetElementType(), xmlName, xmlNs);
+
+					lock (serializer)
+					{
+						serializer.SerializeArray(writer, (object[])_result);
+					}
+				}
+				else
+				{
+					var messageContractAttribute = resultType.GetCustomAttribute<MessageContractAttribute>();
+
+					// This behavior is opt-in i.e. you have to explicitly have a [MessageContract(IsWrapped=false)]
+					// to have the message body members inlined.
+					var shouldInline = messageContractAttribute != null && messageContractAttribute.IsWrapped == false;
+
+					if (shouldInline)
+					{
+						var memberInformation = resultType
+							.GetPropertyOrFieldMembers()
+							.Select(mi => new
+							{
+								Member = mi,
+								MessageBodyMemberAttribute = mi.GetCustomAttribute<MessageBodyMemberAttribute>()
+							})
+							.OrderBy(x => x.MessageBodyMemberAttribute?.Order ?? 0);
+
+						foreach (var memberInfo in memberInformation)
 						{
-							// see https://referencesource.microsoft.com/System.Xml/System/Xml/Serialization/XmlSerializer.cs.html#c97688a6c07294d5
-							var resultType = _result.GetType();
+							var memberType = memberInfo.Member.GetPropertyOrFieldType();
+							var memberValue = memberInfo.Member.GetPropertyOrFieldValue(_result);
 
-							var xmlRootAttr = resultType.GetTypeInfo().GetCustomAttributes<XmlRootAttribute>().FirstOrDefault();
-							var xmlName = _operation.ReturnElementName
-								?? (needResponseEnvelope
-								? _resultName
-								: (string.IsNullOrWhiteSpace(xmlRootAttr?.ElementName)
-								? resultType.Name
-								: xmlRootAttr.ElementName));
-							var xmlNs = _operation.ReturnNamespace
-								?? (string.IsNullOrWhiteSpace(xmlRootAttr?.Namespace)
-								? _serviceNamespace
-								: xmlRootAttr.Namespace);
+							var memberName = memberInfo.MessageBodyMemberAttribute?.Name ?? memberInfo.Member.Name;
+							var memberNamespace = memberInfo.MessageBodyMemberAttribute?.Namespace ?? xmlNs;
 
-							var xmlArrayAttr = _operation.DispatchMethod.GetCustomAttribute<XmlArrayAttribute>();
-							if (xmlArrayAttr != null && resultType.IsArray)
+							var serializer = CachedXmlSerializer.GetXmlSerializer(memberType, memberName, memberNamespace);
+
+							lock (serializer)
 							{
-								var serializer = CachedXmlSerializer.GetXmlSerializer(resultType.GetElementType(), xmlName, xmlNs);
-								lock (serializer)
-								{
-									serializer.SerializeArray(writer, (object[])_result);
-								}
-							}
-							else
-							{
-								var serializer = CachedXmlSerializer.GetXmlSerializer(resultType, xmlName, xmlNs);
-								lock (serializer)
-								{
-									serializer.Serialize(writer, _result);
-								}
+								serializer.Serialize(writer, memberValue);
 							}
 						}
+					}
+					else
+					{
+						var serializer = CachedXmlSerializer.GetXmlSerializer(resultType, xmlName, xmlNs);
 
-						break;
-					case SoapSerializer.DataContractSerializer:
+						lock (serializer)
 						{
-							var serializer = new DataContractSerializer(_result.GetType(), _resultName, _serviceNamespace);
-							serializer.WriteObject(writer, _result);
+							serializer.Serialize(writer, _result);
 						}
-
-						break;
-					default: throw new NotImplementedException();
+					}
 				}
 			}
 
@@ -172,6 +196,67 @@ namespace SoapCore
 			{
 				writer.WriteEndElement();
 			}
+		}
+
+		private void OnWriteDataContractSerializerBodyContents(XmlDictionaryWriter writer)
+		{
+			Debug.Assert(_outResults != null, "Object should set empty out results");
+
+			writer.WriteStartElement(_envelopeName, _serviceNamespace);
+
+			foreach (var outResult in _outResults)
+			{
+				string value = null;
+
+				if (outResult.Value is Guid)
+				{
+					value = outResult.Value.ToString();
+				}
+				else if (outResult.Value is bool)
+				{
+					value = outResult.Value.ToString().ToLower();
+				}
+				else if (outResult.Value is string)
+				{
+					value = System.Security.SecurityElement.Escape(outResult.Value.ToString());
+				}
+				else if (outResult.Value is Enum)
+				{
+					value = outResult.Value.ToString();
+				}
+				else if (outResult.Value == null)
+				{
+					value = null;
+				}
+				else
+				{
+					//for complex types
+					using (var ms = new MemoryStream())
+					using (var stream = new BufferedStream(ms))
+					{
+						new DataContractSerializer(outResult.Value.GetType()).WriteObject(ms, outResult.Value);
+						stream.Position = 0;
+						using (var reader = XmlReader.Create(stream))
+						{
+							reader.MoveToContent();
+							value = reader.ReadInnerXml();
+						}
+					}
+				}
+
+				if (value != null)
+				{
+					writer.WriteRaw(string.Format("<{0}>{1}</{0}>", outResult.Key, value));
+				}
+			}
+
+			if (_result != null)
+			{
+				var serializer = new DataContractSerializer(_result.GetType(), _resultName, _serviceNamespace);
+				serializer.WriteObject(writer, _result);
+			}
+
+			writer.WriteEndElement();
 		}
 	}
 }

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -350,8 +350,7 @@ namespace SoapCore
 					}
 
 					// Create response message
-					var resultName = operation.ReturnName;
-					var bodyWriter = new ServiceBodyWriter(_serializer, operation, resultName, responseObject, resultOutDictionary);
+					var bodyWriter = new ServiceBodyWriter(_serializer, operation, responseObject, resultOutDictionary);
 
 					if (messageEncoder.MessageVersion.Addressing == AddressingVersion.WSAddressing10)
 					{


### PR DESCRIPTION
This follows up the PR where I implemented IsWrapped=false for input parameters (#260). This PR implements it for return parameters. It follows the documentation outlined here.

https://docs.microsoft.com/en-us/dotnet/framework/wcf/samples/unwrapped-messages
