### PR TITLE
[WIP] Fix for issue #326: MessageBodyMemberAttribute.Name is being ignored.

### DIFF
--- a/src/SoapCore/ServiceBodyWriter.cs
+++ b/src/SoapCore/ServiceBodyWriter.cs
@@ -148,13 +148,15 @@ namespace SoapCore
 				else
 				{
 					var messageContractAttribute = resultType.GetCustomAttribute<MessageContractAttribute>();
-
-					// This behavior is opt-in i.e. you have to explicitly have a [MessageContract(IsWrapped=false)]
-					// to have the message body members inlined.
-					var shouldInline = messageContractAttribute != null && messageContractAttribute.IsWrapped == false;
-
-					if (shouldInline)
+					if (messageContractAttribute != null)
 					{
+						// This behavior is opt-in i.e. you have to explicitly have a [MessageContract(IsWrapped=false)]
+						// to have the message body members inlined.
+						if (messageContractAttribute.IsWrapped)
+						{
+							writer.WriteStartElement(xmlName, xmlNs);
+						}
+
 						var memberInformation = resultType
 							.GetPropertyOrFieldMembers()
 							.Select(mi => new
@@ -178,6 +180,11 @@ namespace SoapCore
 							{
 								serializer.Serialize(writer, memberValue);
 							}
+						}
+
+						if (messageContractAttribute.IsWrapped)
+						{
+							writer.WriteEndElement();
 						}
 					}
 					else


### PR DESCRIPTION
I have made a simple addition to MessageBodyMemberAttribute is handled always if the parent object has a MessageContractAttribute. Before it was only handled if that attribute was set to "IsWrapped = false".

I have manually verified it works, but, as per contributing guidelines, I want to add relevent unit-tests. But I have no idea where to start. I saw existing serialization tests, but these are not helpful because this is about the XML being generated. A class can perfectly serialize data wrong and deserialze that same wrong output back again. We need to know the serialization is not wrong.
The raw SOAP 1.2 tests seem more like the thing I need, but then I would have to write the necessary plumbing to make those tests possible. Just adding them to the existing SOAP 1.2 tests seem incorrect as this has nothing the to with SOAP 1.2 specifically.

Any guidance?