### PR TITLE
Support netcoreapp2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ mono: none
 dotnet: 2.2
 script:
  - dotnet restore src
- - dotnet build src
- - dotnet test src/SoapCore.Tests
+ - dotnet build -f netcoreapp2.0 src
+ - dotnet test -f netcoreapp2.0 src/SoapCore.Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 mono: none
-dotnet: 2.1
+dotnet: 2.2
 script:
  - dotnet restore src
- - dotnet build -f netcoreapp2.0 src
- - dotnet test -f netcoreapp2.0 src/SoapCore.Tests
+ - dotnet build src
+ - dotnet test src/SoapCore.Tests

--- a/src/SoapCore.Tests/SoapCore.Tests.csproj
+++ b/src/SoapCore.Tests/SoapCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+		<TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
 		<CodeAnalysisRuleSet>..\SoapCore.ruleset</CodeAnalysisRuleSet>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -4,7 +4,7 @@
 		<Description>SOAP protocol middleware for ASP.NET Core</Description>
 		<VersionPrefix>0.9.9.1</VersionPrefix>
 		<Authors>Digital Design</Authors>
-		<TargetFrameworks>net461;netstandard2.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+		<TargetFrameworks>net461;netstandard2.0;netcoreapp2.0;netcoreapp2.2</TargetFrameworks>
 		<AssemblyName>SoapCore</AssemblyName>
 		<PackageId>SoapCore</PackageId>
 		<PackageTags>SOAP;ASP.NET Core</PackageTags>


### PR DESCRIPTION
I noticed the latest nuget package only had netcoreapp 2.1 support and I couldn't add it to my 2.2 app.

It might be useful for a lot of people to get 2.2 out there before going to 3.0 if you are planning that.

Thanks!
