### PR TITLE
Custom HttpResponse [Originally #288 by @pengweiqhca]

### DIFF
--- a/src/SoapCore.Tests/FaultExceptionTransformer/TestFaultExceptionTransformer.cs
+++ b/src/SoapCore.Tests/FaultExceptionTransformer/TestFaultExceptionTransformer.cs
@@ -1,8 +1,7 @@
 using System;
-using System.Collections.Generic;
+using System.Net;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
-using System.Text;
 
 namespace SoapCore.Tests.FaultExceptionTransformer
 {
@@ -21,6 +20,8 @@ namespace SoapCore.Tests.FaultExceptionTransformer
 			var messageFault = faultException.CreateMessageFault();
 			var bodyWriter = new MessageFaultBodyWriter(messageFault, messageVersion);
 			var faultMessage = Message.CreateMessage(messageVersion, null, bodyWriter);
+
+			faultMessage.Properties.Add(HttpResponseMessageProperty.Name, new HttpResponseMessageProperty { StatusCode = HttpStatusCode.OK, StatusDescription = "test description" });
 
 			return faultMessage;
 		}

--- a/src/SoapCore.Tests/ITestService.cs
+++ b/src/SoapCore.Tests/ITestService.cs
@@ -50,6 +50,9 @@ namespace SoapCore.Tests
 		[OperationContract]
 		void ThrowException();
 
+		[OperationContract(Name = "ThrowExceptionAsync")]
+		Task ThrowExceptionAsync();
+
 		[OperationContract]
 		void ThrowExceptionWithMessage(string message);
 

--- a/src/SoapCore.Tests/TestService.cs
+++ b/src/SoapCore.Tests/TestService.cs
@@ -42,6 +42,11 @@ namespace SoapCore.Tests
 			throw new Exception();
 		}
 
+		public async Task ThrowExceptionAsync()
+		{
+			await Task.Run(() => throw new Exception());
+		}
+
 		public void ThrowExceptionWithMessage(string message)
 		{
 			throw new Exception(message);


### PR DESCRIPTION
This PR allows you to customise the HTTP response e.g. so you don't always return 500 status code for errors (sometimes you may want to 403)

It is derived from #288 but strips out the merge from master (which polluted the PR with some unnecessary changes and confused the history). 

I have reviewed this and consider it ready for merge.

cc @pengweiqhca