### PR TITLE
Feature to add an alternate Namespace at runtime.

### DIFF
--- a/src/SoapCore/ServiceBodyWriter.cs
+++ b/src/SoapCore/ServiceBodyWriter.cs
@@ -27,7 +27,7 @@ namespace SoapCore
 		{
 			_serializer = serializer;
 			_operation = operation;
-			_serviceNamespace = operation.Contract.Namespace;
+			_serviceNamespace = !string.IsNullOrEmpty(operation.Contract.AlternateNamespace) ? operation.Contract.AlternateNamespace : operation.Contract.Namespace;
 			_envelopeName = operation.Name + "Response";
 			_resultName = operation.ReturnName;
 			_result = result;

--- a/src/SoapCore/ServiceModel/ContractDescription.cs
+++ b/src/SoapCore/ServiceModel/ContractDescription.cs
@@ -29,6 +29,7 @@ namespace SoapCore.ServiceModel
 		public ServiceDescription Service { get; private set; }
 		public string Name { get; private set; }
 		public string Namespace { get; private set; }
+		public string AlternateNamespace { get; set; }
 		public Type ContractType { get; private set; }
 		public IEnumerable<OperationDescription> Operations { get; private set; }
 	}

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -298,6 +298,14 @@ namespace SoapCore
 						resultOutDictionary[parameterInfo.Name] = arguments[parameterInfo.Index];
 					}
 
+					// Get Alternate Namespace
+					var alternateNamespace = httpContext.Items["AlternateNamespace"] as string;
+
+					if (!string.IsNullOrEmpty(alternateNamespace))
+					{
+						operation.Contract.AlternateNamespace = alternateNamespace;
+					}
+					
 					responseMessage = CreateResponseMessage(operation, responseObject, resultOutDictionary, soapAction, requestMessage);
 
 					httpContext.Response.ContentType = httpContext.Request.ContentType;


### PR DESCRIPTION
I know that using httpContext.Items[] is not the most elegant solution, but I did not find any other ways to pass the alternate namespace value.
I am open to suggestions.