### PR TITLE
Fix SOAP 1.2 WSDL

### DIFF
--- a/src/SoapCore/Meta/MetaMessage.cs
+++ b/src/SoapCore/Meta/MetaMessage.cs
@@ -56,7 +56,7 @@ namespace SoapCore.Meta
 			// Soap12
 			else if (Version == MessageVersion.Soap12WSAddressing10 || Version == MessageVersion.Soap12WSAddressingAugust2004)
 			{
-				writer.WriteXmlnsAttribute("soap", Namespaces.SOAP12_NS);
+				writer.WriteXmlnsAttribute("soap12", Namespaces.SOAP12_NS);
 			}
 			else
 			{


### PR DESCRIPTION
# Fix SOAP 1.2 WSDL
In SOAP 1.2 the WSDL namespace element names should be soap12 instead of soap as it's indicated in [WSDL Binding for SOAP 1.2](http://schemas.xmlsoap.org/wsdl/soap12/soap12WSDL.htm).

**Update**
```soap: -> soap12:```

```xml
<binding name="HelloWorldSoap12" type="tns:HelloWorldSoap">
  <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="document" />
  <operation name="SayHelloWorld">
    <soap12:operation soapAction="http://tempuri.org/SayHelloWorld" soapActionRequired="true" style="rpc" />
    <input>
      <soap12:body use="encoded" namespace="http://tempuri.org/" encodingStyle="http://www.w3.org/2001/12/soap-encoding" />
    </input>
    <output>
      <soap12:body use="encoded" namespace="http://tempuri.org/" encodingStyle="http://www.w3.org/2001/12/soap-encoding" />
    </output>
  </operation>
</binding>
```