### PR TITLE
Add support for DataSet/DataTable and any other type  that has XmlSchemaProviderAttribute

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/IDatetimeOffsetService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IDatetimeOffsetService.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface IDatetimeOffsetService
+	{
+		[OperationContract]
+		DateTimeOffset Method(DateTimeOffset model);
+	}
+
+	public class DateTimeOffsetService : IDatetimeOffsetService
+	{
+		public DateTimeOffset Method(DateTimeOffset model)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/ITestMultipleTypesService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ITestMultipleTypesService.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Data;
+using System.ServiceModel;
+using System.Xml.Linq;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface ITestMultipleTypesService
+	{
+		[OperationContract]
+		DataTable GetDataTable(DataTable input);
+
+		[OperationContract]
+		System.Xml.Linq.XElement GetXElement(System.Xml.Linq.XElement input);
+
+		[OperationContract]
+		DateTimeOffset GetDateTimeOffset(DateTimeOffset input);
+
+		[OperationContract]
+		string GetString(string input);
+
+		[OperationContract]
+		MyClass GetMyClass(MyClass input);
+	}
+
+	public class TestMultipleTypesService : ITestMultipleTypesService
+	{
+		public DataTable GetDataTable(DataTable input)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DateTimeOffset GetDateTimeOffset(DateTimeOffset input)
+		{
+			throw new NotImplementedException();
+		}
+
+		public string GetString(string input)
+		{
+			throw new NotImplementedException();
+		}
+
+		public XElement GetXElement(XElement input)
+		{
+			throw new NotImplementedException();
+		}
+
+		public MyClass GetMyClass(MyClass input)
+		{
+			return input;
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/IXmlSchemaProviderTypeService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IXmlSchemaProviderTypeService.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Data;
+using System.ServiceModel;
+using System.Xml.Linq;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface IXmlSchemaProviderTypeService
+	{
+		[OperationContract]
+		DataTable GetDataTable(DataTable input);
+
+		[OperationContract]
+		System.Xml.Linq.XElement GetXElement(System.Xml.Linq.XElement input);
+	}
+
+	public class XmlSchemaProviderTypeService : IXmlSchemaProviderTypeService
+	{
+		public DataTable GetDataTable(DataTable input)
+		{
+			throw new NotImplementedException();
+		}
+
+		public XElement GetXElement(XElement input)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/MyClass.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/MyClass.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Data;
+using System.ServiceModel;
+using System.Xml.Linq;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	public class MyClass
+	{
+		public string StringProperty { get; set; }
+		public int IntProperty { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.ServiceModel.Channels;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -12,6 +14,9 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
+using SoapCore.MessageEncoder;
+using SoapCore.Meta;
+using SoapCore.ServiceModel;
 using SoapCore.Tests.Wsdl.Services;
 
 namespace SoapCore.Tests.Wsdl
@@ -168,10 +173,34 @@ namespace SoapCore.Tests.Wsdl
 			Assert.AreEqual("unbounded", element.Attribute("maxOccurs").Value);
 		}
 
+		[TestMethod]
+		public async Task CheckDateTimeOffsetServiceWsdl()
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<DateTimeOffsetService>();
+			Trace.TraceInformation(wsdl);
+			Assert.IsNotNull(wsdl);
+		}
+
+		[TestMethod]
+		public async Task CheckXmlSchemaProviderTypeServiceWsdl()
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<XmlSchemaProviderTypeService>();
+			Trace.TraceInformation(wsdl);
+			Assert.IsNotNull(wsdl);
+		}
+
+		[TestMethod]
+		public async Task CheckTestMultipleTypesServiceWsdl()
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<TestMultipleTypesService>();
+			Trace.TraceInformation(wsdl);
+			Assert.IsNotNull(wsdl);
+		}
+
 		[TestCleanup]
 		public void StopServer()
 		{
-			_host.StopAsync();
+			_host?.StopAsync();
 		}
 
 		private string GetWsdl()
@@ -185,6 +214,24 @@ namespace SoapCore.Tests.Wsdl
 			{
 				return httpClient.GetStringAsync(string.Format("{0}/{1}?wsdl", address, serviceName)).Result;
 			}
+		}
+
+		private async Task<string> GetWsdlFromMetaBodyWriter<T>()
+		{
+			var service = new ServiceDescription(typeof(T));
+			var baseUrl = "http://tempuri.org/";
+			var bodyWriter = new MetaBodyWriter(service, baseUrl, null);
+			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, System.Text.Encoding.UTF8, XmlDictionaryReaderQuotas.Max, false, true);
+			var responseMessage = Message.CreateMessage(encoder.MessageVersion, null, bodyWriter);
+			responseMessage = new MetaMessage(responseMessage, service, null);
+
+			var memoryStream = new MemoryStream();
+			await encoder.WriteMessageAsync(responseMessage, memoryStream);
+			memoryStream.Position = 0;
+
+			var streamReader = new StreamReader(memoryStream);
+			var result = streamReader.ReadToEnd();
+			return result;
 		}
 
 		private void StartService(Type serviceType)

--- a/src/SoapCore/Meta/BodyWriterExtensions.cs
+++ b/src/SoapCore/Meta/BodyWriterExtensions.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+
+namespace SoapCore.Meta
+{
+	public static class BodyWriterExtensions
+	{
+		//switches to easily revert to previous behaviour if there is a problem
+		private static bool useXmlSchemaProvider = true;
+		private static bool useXmlReflectionImporter = false;
+		public static bool TryAddSchemaTypeFromXmlSchemaProviderAttribute(this XmlDictionaryWriter writer, Type type, string name, SoapSerializer serializer)
+		{
+			if (!useXmlSchemaProvider && !useXmlReflectionImporter)
+			{
+				return false;
+			}
+
+			if (useXmlReflectionImporter)
+			{
+				var schemas = new XmlSchemas();
+				var xmlImporter = new XmlReflectionImporter();
+				var exporter = new XmlSchemaExporter(schemas);
+
+				var xmlTypeMapping = xmlImporter.ImportTypeMapping(type, new XmlRootAttribute() { ElementName = name });
+				exporter.ExportTypeMapping(xmlTypeMapping);
+				schemas.Compile(null, true);
+
+				var memoryStream = new MemoryStream();
+				foreach (XmlSchema schema in schemas)
+				{
+					schema.Write(memoryStream);
+				}
+				memoryStream.Position = 0;
+
+				var streamReader = new StreamReader(memoryStream);
+				var result = streamReader.ReadToEnd();
+
+				var doc = new XmlDocument();
+				doc.LoadXml(result);
+				doc.DocumentElement.WriteContentTo(writer);
+
+				return true;
+			}
+
+			var xmlSchemaSet = new XmlSchemaSet();
+			var xmlSchemaProviderAttribute = type.GetCustomAttribute<XmlSchemaProviderAttribute>(true);
+			if (xmlSchemaProviderAttribute != null && true)
+			{
+				XmlSchema schema = new XmlSchema();
+				if (xmlSchemaProviderAttribute.IsAny)
+				{
+					//MetaWCFBodyWriter usage....
+					//writer.WriteAttributeString("name", name);
+					//writer.WriteAttributeString("nillable", "true");
+					//writer.WriteStartElement("xs", "complexType", Namespaces.XMLNS_XSD);
+					//writer.WriteStartElement("xs", "sequence", Namespaces.XMLNS_XSD);
+					//writer.WriteStartElement("xs", "any", Namespaces.XMLNS_XSD);
+					//writer.WriteAttributeString("minOccurs", "0");
+					//writer.WriteAttributeString("processContents", "lax");
+					//writer.WriteEndElement();
+					//writer.WriteEndElement();
+					//writer.WriteEndElement();
+					var sequence = new XmlSchemaSequence();
+					sequence.Items.Add(new XmlSchemaAny() { ProcessContents = XmlSchemaContentProcessing.Lax });
+					var complex = new XmlSchemaComplexType()
+					{
+						Particle = sequence
+					};
+					var element = new XmlSchemaElement()
+					{
+						MinOccurs = 0,
+						MaxOccurs = 1,
+						Name = name,
+						IsNillable = serializer == SoapSerializer.DataContractSerializer ? true : false,
+						SchemaType = complex
+					};
+					schema.Items.Add(element);
+				}
+				else
+				{
+					var methodInfo = type.GetMethod(xmlSchemaProviderAttribute.MethodName, BindingFlags.Static | BindingFlags.Public);
+					var xmlSchemaType = (XmlSchemaType)methodInfo.Invoke(null, new object[] { xmlSchemaSet });
+					var element = new XmlSchemaElement()
+					{
+						MinOccurs = 0,
+						MaxOccurs = 1,
+						Name = name,
+						SchemaType = xmlSchemaType
+					};
+					schema.Items.Add(element);
+				}
+
+				var memoryStream = new MemoryStream();
+				schema.Write(memoryStream);
+				memoryStream.Position = 0;
+
+				var streamReader = new StreamReader(memoryStream);
+				var result = streamReader.ReadToEnd();
+
+				var doc = new XmlDocument();
+				doc.LoadXml(result);
+				doc.DocumentElement.WriteContentTo(writer);
+
+				return true;
+			}
+
+			return false;
+		}
+
+	}
+}

--- a/src/SoapCore/Meta/MetaMessage.cs
+++ b/src/SoapCore/Meta/MetaMessage.cs
@@ -6,7 +6,7 @@ using SoapCore.ServiceModel;
 
 namespace SoapCore.Meta
 {
-	internal class MetaMessage : Message
+	public class MetaMessage : Message
 	{
 		private readonly Message _message;
 		private readonly ServiceDescription _service;

--- a/src/SoapCore/Meta/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaWCFBodyWriter.cs
@@ -983,6 +983,11 @@ namespace SoapCore.Meta
 				type = typeInfo.GetElementType();
 			}
 
+			if (writer.TryAddSchemaTypeFromXmlSchemaProviderAttribute(type, name, SoapSerializer.DataContractSerializer))
+			{
+				return;
+			}
+
 			writer.WriteStartElement("xs", "element", Namespaces.XMLNS_XSD);
 
 			if (objectNamespace == null)
@@ -1080,19 +1085,6 @@ namespace SoapCore.Meta
 				{
 					writer.WriteAttributeString("name", "anyType");
 					writer.WriteAttributeString("type", "xs:anyType");
-				}
-				else if (type == typeof(System.Xml.Linq.XElement))
-				{
-					writer.WriteAttributeString("name", name);
-					writer.WriteAttributeString("nillable", "true");
-					writer.WriteStartElement("xs", "complexType", Namespaces.XMLNS_XSD);
-					writer.WriteStartElement("xs", "sequence", Namespaces.XMLNS_XSD);
-					writer.WriteStartElement("xs", "any", Namespaces.XMLNS_XSD);
-					writer.WriteAttributeString("minOccurs", "0");
-					writer.WriteAttributeString("processContents", "lax");
-					writer.WriteEndElement();
-					writer.WriteEndElement();
-					writer.WriteEndElement();
 				}
 				else if (type == typeof(DataTable))
 				{
@@ -1303,8 +1295,6 @@ namespace SoapCore.Meta
 			return type.Name;
 		}
 
-#pragma warning disable SA1009 // Closing parenthesis must be spaced correctly
-#pragma warning disable SA1008 // Opening parenthesis must be spaced correctly
 		private (string name, string ns) ResolveSystemType(Type type)
 		{
 			if (SysTypeDic.ContainsKey(type.FullName))
@@ -1314,8 +1304,6 @@ namespace SoapCore.Meta
 
 			return (null, null);
 		}
-#pragma warning restore SA1008 // Opening parenthesis must be spaced correctly
-#pragma warning restore SA1009 // Closing parenthesis must be spaced correctly
 
 		private bool HasBaseType(Type type)
 		{

--- a/src/SoapCore/Namespaces.cs
+++ b/src/SoapCore/Namespaces.cs
@@ -1,14 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Xml.Schema;
 
 namespace SoapCore
 {
 	public static class Namespaces
 	{
 #pragma warning disable SA1310 // Field names must not contain underscore
-		public const string XMLNS_XSD = "http://www.w3.org/2001/XMLSchema";
-		public const string XMLNS_XSI = "http://www.w3.org/2001/XMLSchema-instance";
+		public const string XMLNS_XSD = XmlSchema.Namespace;
+		public const string XMLNS_XSI = XmlSchema.InstanceNamespace;
 		public const string TRANSPORT_SCHEMA = "http://schemas.xmlsoap.org/soap/http";
 		public const string WSDL_NS = "http://schemas.xmlsoap.org/wsdl/";
 		public const string SOAP11_NS = "http://schemas.xmlsoap.org/wsdl/soap/";


### PR DESCRIPTION
...this includes removing specific code to support System.Xml.Linq.XElement which also happens to have the XmlSchemaProviderAttribute on it.

Would like to do a bigger refactor on the MetaBodyWriter and MetaWCFBodyWriter to use the XmlSchema objects rather than raw xmlWriter instructions as time permits....