### PR TITLE
WIP: Add support for overriding namespace prefixes and handle XmlType attribute

### DIFF
--- a/src/SoapCore.Tests/FaultExceptionTransformer/TestFaultExceptionTransformer.cs
+++ b/src/SoapCore.Tests/FaultExceptionTransformer/TestFaultExceptionTransformer.cs
@@ -2,13 +2,14 @@ using System;
 using System.Net;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using System.Xml;
 using SoapCore.Extensibility;
 
 namespace SoapCore.Tests.FaultExceptionTransformer
 {
 	public class TestFaultExceptionTransformer : IFaultExceptionTransformer
 	{
-		public Message ProvideFault(Exception exception, MessageVersion messageVersion)
+		public Message ProvideFault(Exception exception, MessageVersion messageVersion, XmlNamespaceManager xmlNamespaceManager)
 		{
 			var fault = new TestFault
 			{

--- a/src/SoapCore.Tests/Wsdl/Services/ITestMultipleTypesService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ITestMultipleTypesService.cs
@@ -18,6 +18,12 @@ namespace SoapCore.Tests.Wsdl.Services
 		DateTimeOffset GetDateTimeOffset(DateTimeOffset input);
 
 		[OperationContract]
+		int GetInt(int input);
+
+		[OperationContract]
+		byte[] GetBytes(byte[] input);
+
+		[OperationContract]
 		string GetString(string input);
 
 		[OperationContract]
@@ -36,6 +42,11 @@ namespace SoapCore.Tests.Wsdl.Services
 			throw new NotImplementedException();
 		}
 
+		public int GetInt(int input)
+		{
+			throw new NotImplementedException();
+		}
+
 		public string GetString(string input)
 		{
 			throw new NotImplementedException();
@@ -49,6 +60,11 @@ namespace SoapCore.Tests.Wsdl.Services
 		public MyClass GetMyClass(MyClass input)
 		{
 			return input;
+		}
+
+		public byte[] GetBytes(byte[] input)
+		{
+			throw new NotImplementedException();
 		}
 	}
 }

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -252,10 +252,11 @@ namespace SoapCore.Tests.Wsdl
 		{
 			var service = new ServiceDescription(typeof(T));
 			var baseUrl = "http://tempuri.org/";
-			var bodyWriter = new MetaBodyWriter(service, baseUrl, null);
+			var xmlNamespaceManager = Namespaces.CreateDefaultXmlNamespaceManager();
+			var bodyWriter = new MetaBodyWriter(service, baseUrl, null, xmlNamespaceManager);
 			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, System.Text.Encoding.UTF8, XmlDictionaryReaderQuotas.Max, false, true);
 			var responseMessage = Message.CreateMessage(encoder.MessageVersion, null, bodyWriter);
-			responseMessage = new MetaMessage(responseMessage, service, null);
+			responseMessage = new MetaMessage(responseMessage, service, null, xmlNamespaceManager);
 
 			var memoryStream = new MemoryStream();
 			await encoder.WriteMessageAsync(responseMessage, memoryStream);

--- a/src/SoapCore/CustomMessage.cs
+++ b/src/SoapCore/CustomMessage.cs
@@ -17,7 +17,7 @@ namespace SoapCore
 
 		public Message Message { get; internal set; }
 
-		public XmlNamespaceManager NamespaceManager { get; internal set; }
+		public XmlNamespaceManager NamespaceManager { get; internal set; } = Namespaces.CreateDefaultXmlNamespaceManager();
 
 		public override MessageHeaders Headers
 		{

--- a/src/SoapCore/CustomMessage.cs
+++ b/src/SoapCore/CustomMessage.cs
@@ -16,6 +16,9 @@ namespace SoapCore
 		}
 
 		public Message Message { get; internal set; }
+
+		public XmlNamespaceManager NamespaceManager { get; internal set; }
+
 		public override MessageHeaders Headers
 		{
 			get { return Message.Headers; }
@@ -33,18 +36,22 @@ namespace SoapCore
 
 		protected override void OnWriteStartEnvelope(XmlDictionaryWriter writer)
 		{
+			var namespaces = NamespaceManager ?? Namespaces.CreateDefaultXmlNamespaceManager();
 			writer.WriteStartDocument();
-			if (Message.Version.Envelope == EnvelopeVersion.Soap11)
-			{
-				writer.WriteStartElement("s", "Envelope", Namespaces.SOAP11_ENVELOPE_NS);
-			}
-			else
-			{
-				writer.WriteStartElement("s", "Envelope", Namespaces.SOAP12_ENVELOPE_NS);
-			}
+			var prefix = Version.Envelope.NamespacePrefix(namespaces);
+			writer.WriteStartElement(prefix, "Envelope", Version.Envelope.Namespace());
+			writer.WriteXmlnsAttribute(prefix, Version.Envelope.Namespace());
 
-			writer.WriteXmlnsAttribute("xsd", Namespaces.XMLNS_XSD);
-			writer.WriteXmlnsAttribute("xsi", Namespaces.XMLNS_XSI);
+			var xsdPrefix = Namespaces.AddNamespaceIfNotAlreadyPresentAndGetPrefix(namespaces, "xsd", Namespaces.XMLNS_XSD);
+			writer.WriteXmlnsAttribute(xsdPrefix, Namespaces.XMLNS_XSD);
+
+			var xsiPrefix = Namespaces.AddNamespaceIfNotAlreadyPresentAndGetPrefix(namespaces, "xsi", Namespaces.XMLNS_XSI);
+			writer.WriteXmlnsAttribute(xsiPrefix, Namespaces.XMLNS_XSI);
+		}
+
+		protected override void OnWriteStartBody(XmlDictionaryWriter writer)
+		{
+			writer.WriteStartElement(Version.Envelope.NamespacePrefix(NamespaceManager), "Body", Version.Envelope.Namespace());
 		}
 
 		protected override void OnWriteBodyContents(XmlDictionaryWriter writer)

--- a/src/SoapCore/DefaultFaultExceptionTransformer.cs
+++ b/src/SoapCore/DefaultFaultExceptionTransformer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ServiceModel.Channels;
+using System.Xml;
 using SoapCore.Extensibility;
 
 namespace SoapCore
@@ -23,7 +24,7 @@ namespace SoapCore
 			_exceptionTransformer = exceptionTransformer;
 		}
 
-		public Message ProvideFault(Exception exception, MessageVersion messageVersion)
+		public Message ProvideFault(Exception exception, MessageVersion messageVersion, XmlNamespaceManager xmlNamespaceManager)
 		{
 			var bodyWriter = _exceptionTransformer == null ?
 				new FaultBodyWriter(exception, messageVersion) :
@@ -33,7 +34,8 @@ namespace SoapCore
 
 			T_MESSAGE customMessage = new T_MESSAGE
 			{
-				Message = soapCoreFaultMessage
+				Message = soapCoreFaultMessage,
+				NamespaceManager = xmlNamespaceManager
 			};
 
 			return customMessage;

--- a/src/SoapCore/EnvelopeVersionExtentions.cs
+++ b/src/SoapCore/EnvelopeVersionExtentions.cs
@@ -1,0 +1,31 @@
+using System.ServiceModel;
+using System.Xml;
+
+namespace SoapCore
+{
+	public static class EnvelopeVersionExtentions
+	{
+		public static string Namespace(this EnvelopeVersion envelopeVersion)
+		{
+			if (envelopeVersion == EnvelopeVersion.Soap11)
+			{
+				return Namespaces.SOAP11_ENVELOPE_NS;
+			}
+
+			return Namespaces.SOAP12_ENVELOPE_NS;
+		}
+
+		public static string NamespacePrefix(this EnvelopeVersion envelopeVersion, XmlNamespaceManager namespaces)
+		{
+			string prefix;
+			if (envelopeVersion == EnvelopeVersion.Soap11)
+			{
+				prefix = Namespaces.AddNamespaceIfNotAlreadyPresentAndGetPrefix(namespaces, "s", Namespaces.SOAP11_ENVELOPE_NS);
+				return prefix;
+			}
+
+			prefix = Namespaces.AddNamespaceIfNotAlreadyPresentAndGetPrefix(namespaces, "s", Namespaces.SOAP12_ENVELOPE_NS);
+			return prefix;
+		}
+	}
+}

--- a/src/SoapCore/Extensibility/IFaultExceptionTransformer.cs
+++ b/src/SoapCore/Extensibility/IFaultExceptionTransformer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ServiceModel.Channels;
+using System.Xml;
 
 namespace SoapCore.Extensibility
 {
@@ -17,8 +18,9 @@ namespace SoapCore.Extensibility
 		/// </summary>
 		/// <param name="exception">Exception to transform</param>
 		/// <param name="messageVersion">SOAP message version</param>
+		/// <param name="xmlNamespaceManager">Namespace manager</param>
 		/// <returns>Fully formatted SOAP Message</returns>
 		/// <seealso cref="MessageFaultBodyWriter"/>
-		Message ProvideFault(Exception exception, MessageVersion messageVersion);
+		Message ProvideFault(Exception exception, MessageVersion messageVersion, XmlNamespaceManager xmlNamespaceManager);
 	}
 }

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -681,7 +681,7 @@ namespace SoapCore.Meta
 						name = typeName;
 					}
 
-					Namespaces.AddNamespaceIfNotAlreadyPresent(_xmlNamespaceManager, "nsdto", Namespaces.SYSTEM_NS);
+					Namespaces.AddNamespaceIfNotAlreadyPresentAndGetPrefix(_xmlNamespaceManager, "nsdto", Namespaces.SYSTEM_NS);
 					xsTypename = new XmlQualifiedName(typeName, Namespaces.SYSTEM_NS);
 
 					_buildDateTimeOffset = true;

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -541,7 +541,7 @@ namespace SoapCore.Meta
 						returnType = returnType.GetGenericArguments().First();
 					}
 
-					if (!IsWrappedMessageContractType(returnType))
+					if (operation.IsMessageContractResponse && !IsWrappedMessageContractType(returnType))
 					{
 						responseTypeName = GetMessageContractBodyType(returnType).Name;
 					}

--- a/src/SoapCore/Meta/MetaMessage.cs
+++ b/src/SoapCore/Meta/MetaMessage.cs
@@ -11,9 +11,11 @@ namespace SoapCore.Meta
 		private readonly Message _message;
 		private readonly ServiceDescription _service;
 		private readonly Binding _binding;
+		private readonly XmlNamespaceManager _xmlNamespaceManager;
 
-		public MetaMessage(Message message, ServiceDescription service, Binding binding)
+		public MetaMessage(Message message, ServiceDescription service, Binding binding, XmlNamespaceManager xmlNamespaceManager)
 		{
+			_xmlNamespaceManager = xmlNamespaceManager;
 			_message = message;
 			_service = service;
 			_binding = binding;
@@ -36,45 +38,43 @@ namespace SoapCore.Meta
 
 		protected override void OnWriteStartEnvelope(XmlDictionaryWriter writer)
 		{
-			const string WSP_NS = Namespaces.WSP_NS;
-			const string HTTP_NS = "http://schemas.microsoft.com/ws/06/2004/policy/http";
-
-			writer.WriteStartElement("wsdl", "definitions", Namespaces.WSDL_NS);
-			writer.WriteXmlnsAttribute("wsdl", Namespaces.WSDL_NS);
-			writer.WriteXmlnsAttribute("xsd", Namespaces.XMLNS_XSD);
-			writer.WriteXmlnsAttribute("msc", "http://schemas.microsoft.com/ws/2005/12/wsdl/contract");
-			writer.WriteXmlnsAttribute("wsp", WSP_NS);
-			writer.WriteXmlnsAttribute("wsu", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
-			writer.WriteXmlnsAttribute("http", HTTP_NS);
+			writer.WriteStartElement(_xmlNamespaceManager.LookupPrefix(Namespaces.WSDL_NS), "definitions", Namespaces.WSDL_NS);
 
 			// Soap11
 			if (Version == MessageVersion.Soap11 || Version == MessageVersion.Soap11WSAddressingAugust2004 || Version == MessageVersion.Soap11WSAddressingAugust2004)
 			{
-				writer.WriteXmlnsAttribute("soap", Namespaces.SOAP11_NS);
+				WriteXmlnsAttribute(writer, Namespaces.SOAP11_NS);
 			}
 
 			// Soap12
 			else if (Version == MessageVersion.Soap12WSAddressing10 || Version == MessageVersion.Soap12WSAddressingAugust2004)
 			{
-				writer.WriteXmlnsAttribute("soap12", Namespaces.SOAP12_NS);
+				WriteXmlnsAttribute(writer, Namespaces.SOAP12_NS);
 			}
 			else
 			{
 				throw new ArgumentOutOfRangeException(nameof(Version), "Unsupported MessageVersion encountered while writing envelope.");
 			}
 
-			writer.WriteXmlnsAttribute("tns", _service.Contracts.First().Namespace);
-			writer.WriteXmlnsAttribute("wsam", Namespaces.WSAM_NS);
+			_xmlNamespaceManager.AddNamespace("tns", _service.Contracts.First().Namespace);
+			WriteXmlnsAttribute(writer, _service.Contracts.First().Namespace);
+			WriteXmlnsAttribute(writer, Namespaces.XMLNS_XSD);
+			WriteXmlnsAttribute(writer, Namespaces.HTTP_NS);
+			WriteXmlnsAttribute(writer, Namespaces.MSC_NS);
+			WriteXmlnsAttribute(writer, Namespaces.WSP_NS);
+			WriteXmlnsAttribute(writer, Namespaces.WSU_NS);
+			WriteXmlnsAttribute(writer, Namespaces.WSAM_NS);
 			writer.WriteAttributeString("targetNamespace", _service.Contracts.First().Namespace);
 			writer.WriteAttributeString("name", _service.ServiceType.Name);
+			WriteXmlnsAttribute(writer, Namespaces.WSDL_NS);
 
 			if (_binding != null && _binding.HasBasicAuth())
 			{
-				writer.WriteStartElement("wsp", "Policy", WSP_NS);
-				writer.WriteAttributeString("Id", "wsu", $"{_binding.Name}_{_service.Contracts.First().Name}_policy");
-				writer.WriteStartElement("wsp", "ExactlyOne", WSP_NS);
-				writer.WriteStartElement("wsp", "All", WSP_NS);
-				writer.WriteStartElement("http", "BasicAuthentication", HTTP_NS);
+				writer.WriteStartElement("Policy", Namespaces.WSP_NS);
+				writer.WriteAttributeString("Id", _xmlNamespaceManager.LookupPrefix(Namespaces.WSU_NS), $"{_binding.Name}_{_service.Contracts.First().Name}_policy");
+				writer.WriteStartElement("ExactlyOne", Namespaces.WSP_NS);
+				writer.WriteStartElement("All", Namespaces.WSP_NS);
+				writer.WriteStartElement("BasicAuthentication", Namespaces.HTTP_NS);
 				writer.WriteEndElement();
 				writer.WriteEndElement();
 				writer.WriteEndElement();
@@ -89,6 +89,12 @@ namespace SoapCore.Meta
 		protected override void OnWriteBodyContents(XmlDictionaryWriter writer)
 		{
 			_message.WriteBodyContents(writer);
+		}
+
+		private void WriteXmlnsAttribute(XmlDictionaryWriter writer, string namespaceUri)
+		{
+			string prefix = _xmlNamespaceManager.LookupPrefix(namespaceUri);
+			writer.WriteXmlnsAttribute(prefix, namespaceUri);
 		}
 	}
 }

--- a/src/SoapCore/Namespaces.cs
+++ b/src/SoapCore/Namespaces.cs
@@ -29,26 +29,38 @@ namespace SoapCore
 
 		public static void AddDefaultNamespaces(XmlNamespaceManager xmlNamespaceManager)
 		{
-			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "xsd", Namespaces.XMLNS_XSD);
-			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "wsdl", Namespaces.WSDL_NS);
-			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "msc", Namespaces.MSC_NS);
-			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "wsp", Namespaces.WSP_NS);
-			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "wsu", Namespaces.WSU_NS);
-			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "http", Namespaces.HTTP_NS);
-			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "http", Namespaces.TRANSPORT_SCHEMA);
-			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "soap", Namespaces.SOAP11_NS);
-			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "soap12", Namespaces.SOAP12_NS);
-			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "ser", Namespaces.SERIALIZATION_NS);
-			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "wsam", Namespaces.WSAM_NS);
+			AddNamespaceIfNotAlreadyPresentAndGetPrefix(xmlNamespaceManager, "xsd", Namespaces.XMLNS_XSD);
+			AddNamespaceIfNotAlreadyPresentAndGetPrefix(xmlNamespaceManager, "wsdl", Namespaces.WSDL_NS);
+			AddNamespaceIfNotAlreadyPresentAndGetPrefix(xmlNamespaceManager, "msc", Namespaces.MSC_NS);
+			AddNamespaceIfNotAlreadyPresentAndGetPrefix(xmlNamespaceManager, "wsp", Namespaces.WSP_NS);
+			AddNamespaceIfNotAlreadyPresentAndGetPrefix(xmlNamespaceManager, "wsu", Namespaces.WSU_NS);
+			AddNamespaceIfNotAlreadyPresentAndGetPrefix(xmlNamespaceManager, "http", Namespaces.HTTP_NS);
+			AddNamespaceIfNotAlreadyPresentAndGetPrefix(xmlNamespaceManager, "http", Namespaces.TRANSPORT_SCHEMA);
+			AddNamespaceIfNotAlreadyPresentAndGetPrefix(xmlNamespaceManager, "soap", Namespaces.SOAP11_NS);
+			AddNamespaceIfNotAlreadyPresentAndGetPrefix(xmlNamespaceManager, "soap12", Namespaces.SOAP12_NS);
+			AddNamespaceIfNotAlreadyPresentAndGetPrefix(xmlNamespaceManager, "ser", Namespaces.SERIALIZATION_NS);
+			AddNamespaceIfNotAlreadyPresentAndGetPrefix(xmlNamespaceManager, "wsam", Namespaces.WSAM_NS);
 		}
 
-		public static string AddNamespaceIfNotAlreadyPresent(XmlNamespaceManager xmlNamespaceManager, string prefix, string uri)
+		public static string AddNamespaceIfNotAlreadyPresentAndGetPrefix(XmlNamespaceManager xmlNamespaceManager, string preferredPrefix, string uri)
 		{
 			var existingPrefix = xmlNamespaceManager.LookupPrefix(uri);
 			if (existingPrefix == null)
 			{
-				xmlNamespaceManager.AddNamespace(prefix, uri);
-				return prefix;
+				var localPrefix = preferredPrefix;
+				for (int i = 1; ; i++)
+				{
+					var existingNamespace = xmlNamespaceManager.LookupNamespace(localPrefix);
+					if (existingNamespace == null)
+					{
+						break;
+					}
+
+					localPrefix = $"prefix{i}";
+				}
+
+				xmlNamespaceManager.AddNamespace(localPrefix, uri);
+				return localPrefix;
 			}
 
 			return existingPrefix;

--- a/src/SoapCore/Namespaces.cs
+++ b/src/SoapCore/Namespaces.cs
@@ -1,6 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Xml;
 using System.Xml.Schema;
 
 namespace SoapCore
@@ -10,13 +9,9 @@ namespace SoapCore
 #pragma warning disable SA1310 // Field names must not contain underscore
 		public const string XMLNS_XSD = XmlSchema.Namespace;
 		public const string XMLNS_XSI = XmlSchema.InstanceNamespace;
-		public const string TRANSPORT_SCHEMA = "http://schemas.xmlsoap.org/soap/http";
 		public const string WSDL_NS = "http://schemas.xmlsoap.org/wsdl/";
 		public const string SOAP11_NS = "http://schemas.xmlsoap.org/wsdl/soap/";
 		public const string SOAP12_NS = "http://schemas.xmlsoap.org/wsdl/soap12/";
-		public const string SOAP11_ENVELOPE_NS = "http://schemas.xmlsoap.org/soap/envelope/";
-		public const string SOAP12_ENVELOPE_NS = "http://www.w3.org/2003/05/soap-envelope";
-
 		public const string ARRAYS_NS = "http://schemas.microsoft.com/2003/10/Serialization/Arrays";
 		public const string SYSTEM_NS = "http://schemas.datacontract.org/2004/07/System";
 		public const string DataContractNamespace = "http://schemas.datacontract.org/2004/07/";
@@ -24,7 +19,46 @@ namespace SoapCore
 		public const string WSP_NS = "http://schemas.xmlsoap.org/ws/2004/09/policy";
 		public const string WSAM_NS = "http://www.w3.org/2007/05/addressing/metadata";
 		public const string SystemData_NS = "http://schemas.datacontract.org/2004/07/System.Data";
-
+		public const string MSC_NS = "http://schemas.microsoft.com/ws/2005/12/wsdl/contract";
+		public const string WSU_NS = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
+		public const string HTTP_NS = "http://schemas.microsoft.com/ws/06/2004/policy/http";
+		public const string TRANSPORT_SCHEMA = "http://schemas.xmlsoap.org/soap/http";
+		public const string SOAP11_ENVELOPE_NS = "http://schemas.xmlsoap.org/soap/envelope/";
+		public const string SOAP12_ENVELOPE_NS = "http://www.w3.org/2003/05/soap-envelope";
 #pragma warning restore SA1310 // Field names must not contain underscore
+
+		public static void AddDefaultNamespaces(XmlNamespaceManager xmlNamespaceManager)
+		{
+			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "xsd", Namespaces.XMLNS_XSD);
+			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "wsdl", Namespaces.WSDL_NS);
+			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "msc", Namespaces.MSC_NS);
+			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "wsp", Namespaces.WSP_NS);
+			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "wsu", Namespaces.WSU_NS);
+			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "http", Namespaces.HTTP_NS);
+			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "http", Namespaces.TRANSPORT_SCHEMA);
+			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "soap", Namespaces.SOAP11_NS);
+			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "soap12", Namespaces.SOAP12_NS);
+			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "ser", Namespaces.SERIALIZATION_NS);
+			AddNamespaceIfNotAlreadyPresent(xmlNamespaceManager, "wsam", Namespaces.WSAM_NS);
+		}
+
+		public static string AddNamespaceIfNotAlreadyPresent(XmlNamespaceManager xmlNamespaceManager, string prefix, string uri)
+		{
+			var existingPrefix = xmlNamespaceManager.LookupPrefix(uri);
+			if (existingPrefix == null)
+			{
+				xmlNamespaceManager.AddNamespace(prefix, uri);
+				return prefix;
+			}
+
+			return existingPrefix;
+		}
+
+		public static XmlNamespaceManager CreateDefaultXmlNamespaceManager()
+		{
+			var xmlNamespaceManager = new XmlNamespaceManager(new NameTable());
+			AddDefaultNamespaces(xmlNamespaceManager);
+			return xmlNamespaceManager;
+		}
 	}
 }

--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -1,4 +1,5 @@
 using System.ServiceModel.Channels;
+using System.Xml;
 using SoapCore.Extensibility;
 
 namespace SoapCore
@@ -74,5 +75,10 @@ namespace SoapCore
 		/// <para>Defaults to true</para>
 		/// </summary>
 		public bool IndentXml { get; set; } = true;
+
+		/// <summary>
+		/// Gets or sets an collection of Xml Namespaces to override the default prefix for.
+		/// </summary>
+		public XmlNamespaceManager XmlNamespacePrefixOverrides { get; set; } = new XmlNamespaceManager(new NameTable());
 	}
 }

--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -150,22 +150,7 @@ namespace SoapCore
 				opt.EncoderOptions = encoderOptions;
 			}
 
-			var soapOptions = new SoapOptions
-			{
-				ServiceType = typeof(T),
-				Path = opt.Path,
-				HttpsGetEnabled = opt.HttpsGetEnabled,
-				HttpGetEnabled = opt.HttpGetEnabled,
-				Binding = opt.Binding,
-				CaseInsensitivePath = opt.CaseInsensitivePath,
-				EncoderOptions = opt.EncoderOptions,
-				SoapModelBounder = opt.SoapModelBounder,
-				SoapSerializer = opt.SoapSerializer,
-				BufferThreshold = opt.BufferThreshold,
-				BufferLimit = opt.BufferLimit,
-				OmitXmlDeclaration = opt.OmitXmlDeclaration,
-				IndentXml = opt.IndentXml
-			};
+			var soapOptions = SoapOptions.FromSoapCoreOptions<T>(opt);
 
 			return builder.UseMiddleware<SoapEndpointMiddleware<T_MESSAGE>>(soapOptions);
 		}
@@ -308,22 +293,7 @@ namespace SoapCore
 				opt.EncoderOptions = encoderOptions;
 			}
 
-			var soapOptions = new SoapOptions
-			{
-				ServiceType = typeof(T),
-				Path = opt.Path,
-				HttpsGetEnabled = opt.HttpsGetEnabled,
-				HttpGetEnabled = opt.HttpGetEnabled,
-				Binding = opt.Binding,
-				CaseInsensitivePath = opt.CaseInsensitivePath,
-				EncoderOptions = opt.EncoderOptions,
-				SoapModelBounder = opt.SoapModelBounder,
-				SoapSerializer = opt.SoapSerializer,
-				BufferLimit = opt.BufferLimit,
-				BufferThreshold = opt.BufferThreshold,
-				OmitXmlDeclaration = opt.OmitXmlDeclaration,
-				IndentXml = opt.IndentXml
-			};
+			var soapOptions = SoapOptions.FromSoapCoreOptions<T>(opt);
 
 			var pipeline = routes
 				.CreateApplicationBuilder()

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Threading.Tasks;
+using System.Xml;
 using System.Xml.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -37,6 +38,7 @@ namespace SoapCore
 		private readonly bool _httpsGetEnabled;
 		private readonly SoapMessageEncoder[] _messageEncoders;
 		private readonly SerializerHelper _serializerHelper;
+		private readonly XmlNamespaceManager _xmlNamespaceManager;
 
 		[Obsolete]
 		public SoapEndpointMiddleware(ILogger<SoapEndpointMiddleware<T_MESSAGE>> logger, RequestDelegate next, Type serviceType, string path, SoapEncoderOptions[] encoderOptions, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, Binding binding, bool httpGetEnabled, bool httpsGetEnabled)
@@ -75,6 +77,8 @@ namespace SoapCore
 			_binding = options.Binding;
 			_httpGetEnabled = options.HttpGetEnabled;
 			_httpsGetEnabled = options.HttpsGetEnabled;
+			_xmlNamespaceManager = options.XmlNamespacePrefixOverrides;
+			Namespaces.AddDefaultNamespaces(_xmlNamespaceManager);
 
 			_messageEncoders = new SoapMessageEncoder[options.EncoderOptions.Length];
 
@@ -176,11 +180,9 @@ namespace SoapCore
 		private async Task ProcessMeta(HttpContext httpContext)
 		{
 			var baseUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host + httpContext.Request.PathBase + httpContext.Request.Path;
-
-			var bodyWriter = _serializer == SoapSerializer.XmlSerializer ? new MetaBodyWriter(_service, baseUrl, _binding) : (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, _binding);
-
+			var bodyWriter = _serializer == SoapSerializer.XmlSerializer ? new MetaBodyWriter(_service, baseUrl, _binding, _xmlNamespaceManager) : (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, _binding);
 			var responseMessage = Message.CreateMessage(_messageEncoders[0].MessageVersion, null, bodyWriter);
-			responseMessage = new MetaMessage(responseMessage, _service, _binding);
+			responseMessage = new MetaMessage(responseMessage, _service, _binding, _xmlNamespaceManager);
 
 			httpContext.Response.ContentType = _messageEncoders[0].ContentType;
 

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -77,7 +77,7 @@ namespace SoapCore
 			_binding = options.Binding;
 			_httpGetEnabled = options.HttpGetEnabled;
 			_httpsGetEnabled = options.HttpsGetEnabled;
-			_xmlNamespaceManager = options.XmlNamespacePrefixOverrides;
+			_xmlNamespaceManager = options.XmlNamespacePrefixOverrides ?? Namespaces.CreateDefaultXmlNamespaceManager();
 			Namespaces.AddDefaultNamespaces(_xmlNamespaceManager);
 
 			_messageEncoders = new SoapMessageEncoder[options.EncoderOptions.Length];

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -645,7 +645,7 @@ namespace SoapCore
 			HttpContext httpContext)
 		{
 			var faultExceptionTransformer = serviceProvider.GetRequiredService<IFaultExceptionTransformer>();
-			var faultMessage = faultExceptionTransformer.ProvideFault(exception, _messageEncoders[0].MessageVersion);
+			var faultMessage = faultExceptionTransformer.ProvideFault(exception, _messageEncoders[0].MessageVersion, _xmlNamespaceManager);
 
 			httpContext.Response.ContentType = httpContext.Request.ContentType;
 			httpContext.Response.Headers["SOAPAction"] = faultMessage.Headers.Action;

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -369,7 +369,8 @@ namespace SoapCore
 				responseMessage = Message.CreateMessage(_messageEncoders[0].MessageVersion, soapAction, bodyWriter);
 				T_MESSAGE customMessage = new T_MESSAGE
 				{
-					Message = responseMessage
+					Message = responseMessage,
+					NamespaceManager = _xmlNamespaceManager
 				};
 				responseMessage = customMessage;
 				//responseMessage.Message = responseMessage;
@@ -382,7 +383,8 @@ namespace SoapCore
 				responseMessage = Message.CreateMessage(_messageEncoders[0].MessageVersion, null, bodyWriter);
 				T_MESSAGE customMessage = new T_MESSAGE
 				{
-					Message = responseMessage
+					Message = responseMessage,
+					NamespaceManager = _xmlNamespaceManager
 				};
 				responseMessage = customMessage;
 

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ServiceModel.Channels;
+using System.Xml;
 using SoapCore.Extensibility;
 
 namespace SoapCore
@@ -31,5 +32,30 @@ namespace SoapCore
 		public bool OmitXmlDeclaration { get; set; } = true;
 
 		public bool IndentXml { get; set; } = true;
+
+		public XmlNamespaceManager XmlNamespacePrefixOverrides { get; set; }
+
+		public static SoapOptions FromSoapCoreOptions<T>(SoapCoreOptions opt)
+		{
+			var soapOptions = new SoapOptions
+			{
+				ServiceType = typeof(T),
+				Path = opt.Path,
+				EncoderOptions = opt.EncoderOptions,
+				SoapSerializer = opt.SoapSerializer,
+				CaseInsensitivePath = opt.CaseInsensitivePath,
+				SoapModelBounder = opt.SoapModelBounder,
+				Binding = opt.Binding,
+				BufferThreshold = opt.BufferThreshold,
+				BufferLimit = opt.BufferLimit,
+				HttpsGetEnabled = opt.HttpsGetEnabled,
+				HttpGetEnabled = opt.HttpGetEnabled,
+				OmitXmlDeclaration = opt.OmitXmlDeclaration,
+				IndentXml = opt.IndentXml,
+				XmlNamespacePrefixOverrides = opt.XmlNamespacePrefixOverrides
+			};
+
+			return soapOptions;
+		}
 	}
 }


### PR DESCRIPTION
Moving towards a more strongly typed Xml creation for meta data.  Cleans up the namespace code a bit before I can better refactor the hand rolled XmlWriter statements into a more robust implementation using XmlSchema types.

With this commit, my new soap service generates near identical WSDL to an old WebService implementation, significantly closer than it used to.