### PR TITLE
Add password digest type authentification WS-Security

### DIFF
--- a/src/SoapCore.Tests/MessageFilter/RawMessageFilterTests.cs
+++ b/src/SoapCore.Tests/MessageFilter/RawMessageFilterTests.cs
@@ -13,13 +13,13 @@ namespace SoapCore.Tests.MessageFilter
 	[TestClass]
 	public class RawMessageFilterTests
 	{
-		private static TestServer host;
+		private static TestServer _host;
 
 		[ClassInitialize]
 		public static void StartServer(TestContext testContext)
 		{
 			var host = new WebHostBuilder().UseStartup<Startup>();
-			RawMessageFilterTests.host = new TestServer(host);
+			RawMessageFilterTests._host = new TestServer(host);
 		}
 
 		public ITestService CreateClient(Dictionary<string, object> headers = null)
@@ -43,11 +43,11 @@ namespace SoapCore.Tests.MessageFilter
   </soapenv:Body>
 </soapenv:Envelope>
 ";
-			using (var client = host.CreateClient())
+			using (var client = _host.CreateClient())
 			using (var content = new StringContent(body, Encoding.UTF8, "application/soap+xml"))
 			{
 				content.Headers.ContentType.Parameters.Add(new System.Net.Http.Headers.NameValueHeaderValue("action", "\"http://tempuri.org/ITestService/Ping\""));
-				using (var res = host.CreateRequest("/Service.svc").And(msg => msg.Content = content).PostAsync().Result)
+				using (var res = _host.CreateRequest("/Service.svc").And(msg => msg.Content = content).PostAsync().Result)
 				{
 					Assert.IsFalse(res.IsSuccessStatusCode);
 					Task.Run(async () =>
@@ -69,7 +69,7 @@ namespace SoapCore.Tests.MessageFilter
     <wsse:Security xmlns:wsse=""http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"">
       <wsse:UsernameToken>
         <wsse:Username>yourusername</wsse:Username>
-        <wsse:Password Type=""wsse:PasswordText"">yourpassword</wsse:Password>
+        <wsse:Password Type=""http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"">yourpassword</wsse:Password>
       </wsse:UsernameToken>
     </wsse:Security>
   </soapenv:Header>
@@ -80,11 +80,11 @@ namespace SoapCore.Tests.MessageFilter
   </soapenv:Body>
 </soapenv:Envelope>
 ";
-			using (var client = host.CreateClient())
+			using (var client = _host.CreateClient())
 			using (var content = new StringContent(body, Encoding.UTF8, "application/soap+xml"))
 			{
 				content.Headers.ContentType.Parameters.Add(new System.Net.Http.Headers.NameValueHeaderValue("action", "\"http://tempuri.org/ITestService/Ping\""));
-				using (var res = host.CreateRequest("/Service.svc").And(msg => msg.Content = content).PostAsync().Result)
+				using (var res = _host.CreateRequest("/Service.svc").And(msg => msg.Content = content).PostAsync().Result)
 				{
 					Assert.IsTrue(res.IsSuccessStatusCode);
 					Task.Run(async () =>
@@ -106,7 +106,7 @@ namespace SoapCore.Tests.MessageFilter
     <wsse:Security xmlns:wsse=""http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"">
       <wsse:UsernameToken>
         <wsse:Username>INVALID_USERNAME</wsse:Username>
-        <wsse:Password Type=""wsse:PasswordText"">INAVLID_PASSWORD</wsse:Password>
+        <wsse:Password Type=""http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"">INVALID_PASSWORD</wsse:Password>
       </wsse:UsernameToken>
     </wsse:Security>
   </soapenv:Header>
@@ -117,11 +117,11 @@ namespace SoapCore.Tests.MessageFilter
   </soapenv:Body>
 </soapenv:Envelope>
 ";
-			using (var client = host.CreateClient())
+			using (var client = _host.CreateClient())
 			using (var content = new StringContent(body, Encoding.UTF8, "application/soap+xml"))
 			{
 				content.Headers.ContentType.Parameters.Add(new System.Net.Http.Headers.NameValueHeaderValue("action", "\"http://tempuri.org/ITestService/Ping\""));
-				using (var res = host.CreateRequest("/Service.svc").And(msg => msg.Content = content).PostAsync().Result)
+				using (var res = _host.CreateRequest("/Service.svc").And(msg => msg.Content = content).PostAsync().Result)
 				{
 					Assert.IsFalse(res.IsSuccessStatusCode);
 					Task.Run(async () =>

--- a/src/SoapCore.Tests/MessageFilter/WsMessageFilterTests.cs
+++ b/src/SoapCore.Tests/MessageFilter/WsMessageFilterTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.ServiceModel.Channels;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static System.Convert;
+using static System.Text.Encoding;
+
+namespace SoapCore.Tests.MessageFilter
+{
+	[TestClass]
+	public class WsMessageFilterTests
+	{
+		private const string _passwordDigest = @"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest";
+		private const string _passwordText = @"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText";
+
+		private static readonly XNamespace _soapenv11 = "http://schemas.xmlsoap.org/soap/envelope/";
+		private static readonly XNamespace _wsse = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd";
+		private static readonly XNamespace _wsu = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
+
+		[TestMethod]
+		[ExpectedException(typeof(InvalidCredentialException))]
+		public void IncorrectCredentialsNotAuthrorized()
+		{
+			var usernameToken = new XElement(
+				_wsse + "UsernameToken",
+				new XElement(_wsse + "Username", "INVALID_USERNAME"),
+				new XElement(_wsse + "Password", "INAVLID_PASSWORD"));
+
+			var filter = new WsMessageFilter("yourusername", "yourpassword");
+			filter.OnRequestExecuting(CreateMessage(usernameToken));
+		}
+
+		[TestMethod]
+		public void PasswordIsOptional()
+		{
+			var usernameToken = new XElement(
+				_wsse + "UsernameToken",
+				new XElement(_wsse + "Username", "yourusername"));
+
+			var filter = new WsMessageFilter("yourusername", null);
+			filter.OnRequestExecuting(CreateMessage(usernameToken));
+		}
+
+		[TestMethod]
+		public void PasswordTypeTextIsComparedAsIs()
+		{
+			var usernameToken = new XElement(
+				_wsse + "UsernameToken",
+				new XElement(_wsse + "Username", "yourusername"),
+				new XElement(_wsse + "Password", new XAttribute("Type", _passwordText), "yourpassword"));
+
+			var filter = new WsMessageFilter("yourusername", "yourpassword");
+			filter.OnRequestExecuting(CreateMessage(usernameToken));
+		}
+
+		[TestMethod]
+		public void PasswordInDigestIsDecoded()
+		{
+			var clearTextPassword = "yourpassword";
+			var passwordDigest = ToBase64String(SHA1.Create().ComputeHash(UTF8.GetBytes(clearTextPassword)));
+			var usernameToken = new XElement(
+				_wsse + "UsernameToken",
+				new XElement(_wsse + "Username", "yourusername"),
+				new XElement(
+					_wsse + "Password",
+					new XAttribute("Type", _passwordDigest),
+					new XText(passwordDigest)));
+
+			var filter = new WsMessageFilter("yourusername", clearTextPassword);
+			filter.OnRequestExecuting(CreateMessage(usernameToken));
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(AuthenticationException))]
+		public void NonceCantBePresentWithoutCreated()
+		{
+			var usernameToken = new XElement(
+				_wsse + "UsernameToken",
+				new XElement(_wsse + "Username", "yourusername"),
+				new XElement(_wsse + "Password", "yourpassword"),
+				new XElement(_wsse + "Nonce", ToBase64String(Guid.NewGuid().ToByteArray())));
+
+			var filter = new WsMessageFilter("yourusername", "yourpassword");
+			filter.OnRequestExecuting(CreateMessage(usernameToken));
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(AuthenticationException))]
+		public void CreatedCantBePresentWithoutNonce()
+		{
+			var usernameToken = new XElement(
+				_wsse + "UsernameToken",
+				new XElement(_wsse + "Username", "yourusername"),
+				new XElement(_wsse + "Password", "yourpassword"),
+				new XElement(_wsu + "Created", "2003-07-16T01:24:32Z"));
+
+			var filter = new WsMessageFilter("yourusername", "yourpassword");
+			filter.OnRequestExecuting(CreateMessage(usernameToken));
+		}
+
+		[TestMethod]
+		public void UseNonceAndCreatedInDigestAgainstReplayAttack()
+		{
+			var usernameToken = new XElement(
+				_wsse + "UsernameToken",
+				new XElement(_wsse + "Username", "yourusername"),
+				new XElement(_wsse + "Password", new XAttribute("Type", _passwordDigest), "U1GjAqli//AHdFxRZUbVeJYz6GA="),
+				new XElement(_wsse + "Nonce", "l//4xNUs0LzslTkEA/Ch1Q=="),
+				new XElement(_wsu + "Created", "2020-03-06T19:58:28.134Z"));
+
+			var filter = new WsMessageFilter("yourusername", "Password");
+			filter.OnRequestExecuting(CreateMessage(usernameToken));
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(InvalidCredentialException))]
+		public void IncorrectPasswordNotAuthorizedAgainstDigest()
+		{
+			var usernameToken = new XElement(
+				_wsse + "UsernameToken",
+				new XElement(_wsse + "Username", "yourusername"),
+				new XElement(_wsse + "Password", new XAttribute("Type", _passwordDigest), "U1GjAqli//AHdFxRZUbVeJYz6GA="),
+				new XElement(_wsse + "Nonce", "l//4xNUs0LzslTkEA/Ch1Q=="),
+				new XElement(_wsu + "Created", "2020-03-06T19:58:28.134Z"));
+
+			var filter = new WsMessageFilter("yourusername", "IncorrectPassword");
+			filter.OnRequestExecuting(CreateMessage(usernameToken));
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(AuthenticationException))]
+		public void InvalidNonceIsNotAuthorizedEvenInCleartext()
+		{
+			var notBase64Encoded = "!@#$%^&*()_+";
+			var usernameToken = new XElement(
+				_wsse + "UsernameToken",
+				new XElement(_wsse + "Username", "yourusername"),
+				new XElement(_wsse + "Password", "yourpassword"),
+				new XElement(_wsse + "Nonce", notBase64Encoded),
+				new XElement(_wsu + "Created", "2020-03-06T19:58:28.134Z"));
+
+			var filter = new WsMessageFilter("yourusername", "yourpassword");
+			filter.OnRequestExecuting(CreateMessage(usernameToken));
+		}
+
+		private static Message CreateMessage(XNode usernameToken)
+		{
+			var envelope = new XElement(
+				_soapenv11 + "Envelope",
+				new XAttribute(XNamespace.Xmlns + "wsse", _wsse.NamespaceName),
+				new XAttribute(XNamespace.Xmlns + "soap", _soapenv11.NamespaceName),
+				new XElement(
+					_soapenv11 + "Header",
+					new XElement(
+						_wsse + "Security",
+						usernameToken)),
+				new XElement(
+					_soapenv11 + "Body",
+					new XElement(
+						XName.Get("Ping", "http://tempuri.org/"),
+						"abc")));
+
+			var doc = new XDocument(envelope);
+			return Message.CreateMessage(doc.CreateReader(), int.MaxValue, MessageVersion.Soap11);
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -126,7 +126,7 @@ namespace SoapCore.Tests.Wsdl
 			var root = new XmlDocument();
 			root.LoadXml(wsdl);
 
-			XmlNamespaceManager nsmgr = new XmlNamespaceManager(root.NameTable);
+			var nsmgr = new XmlNamespaceManager(root.NameTable);
 			nsmgr.AddNamespace("wsdl", "http://schemas.xmlsoap.org/wsdl/");
 			nsmgr.AddNamespace("xs", "http://www.w3.org/2001/XMLSchema");
 

--- a/src/SoapCore/WsMessageFilter.cs
+++ b/src/SoapCore/WsMessageFilter.cs
@@ -1,15 +1,19 @@
 using System;
-using System.Runtime.Serialization;
 using System.Security.Authentication;
+using System.Security.Cryptography;
 using System.ServiceModel.Channels;
+using System.Xml.Serialization;
 using SoapCore.Extensibility;
+using static System.Convert;
+using static System.Text.Encoding;
 
 namespace SoapCore
 {
 	public class WsMessageFilter : IMessageFilter
 	{
-		private static string _username;
-		private static string _password;
+		private const string _passwordTextType = @"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText";
+		private readonly string _username;
+		private readonly string _password;
 		private readonly string _authMissingErrorMessage = "Referenced security token could not be retrieved";
 		private readonly string _authInvalidErrorMessage = "Authentication error: Authentication failed: the supplied credential is not right";
 
@@ -29,8 +33,7 @@ namespace SoapCore
 
 		public void OnRequestExecuting(Message message)
 		{
-			WsUsernameToken wsUsernameToken = null;
-
+			WsUsernameToken wsUsernameToken;
 			try
 			{
 				wsUsernameToken = GetWsUsernameToken(message);
@@ -58,15 +61,19 @@ namespace SoapCore
 			{
 				if (message.Headers[i].Name.ToLower() == "security")
 				{
-					var reader = message.Headers.GetReaderAtHeader(i);
+					using var reader = message.Headers.GetReaderAtHeader(i);
 					reader.Read();
-					DataContractSerializer serializer = new DataContractSerializer(typeof(WsUsernameToken));
-					wsUsernameToken = (WsUsernameToken)serializer.ReadObject(reader, true);
-					reader.Close();
+					var serializer = new XmlSerializer(typeof(WsUsernameToken));
+					wsUsernameToken = (WsUsernameToken)serializer.Deserialize(reader);
 				}
 			}
 
 			if (wsUsernameToken == null)
+			{
+				throw new Exception();
+			}
+
+			if (wsUsernameToken.Nonce != null ^ wsUsernameToken.Created != null)
 			{
 				throw new Exception();
 			}
@@ -76,7 +83,30 @@ namespace SoapCore
 
 		private bool ValidateWsUsernameToken(WsUsernameToken wsUsernameToken)
 		{
-			return wsUsernameToken.Username == _username && wsUsernameToken.Password == _password;
+			if (wsUsernameToken.Username != _username)
+			{
+				return false;
+			}
+
+			var isClearText = wsUsernameToken.Password?.Type == null || wsUsernameToken.Password.Type == _passwordTextType;
+			if (isClearText)
+			{
+				return wsUsernameToken.Password?.Value == _password;
+			}
+
+			var nonceArray = wsUsernameToken.Nonce != null ? wsUsernameToken.Nonce : Array.Empty<byte>();
+			var createdArray = wsUsernameToken.Created != null ? UTF8.GetBytes(wsUsernameToken.Created) : Array.Empty<byte>();
+			var passwordArray = _password != null ? UTF8.GetBytes(_password) : Array.Empty<byte>();
+			var hashArray = new byte[nonceArray.Length + createdArray.Length + passwordArray.Length];
+			Array.Copy(nonceArray, 0, hashArray, 0, nonceArray.Length);
+			Array.Copy(createdArray, 0, hashArray, nonceArray.Length, createdArray.Length);
+			Array.Copy(passwordArray, 0, hashArray, nonceArray.Length + createdArray.Length, passwordArray.Length);
+
+			var hash = SHA1.Create().ComputeHash(hashArray);
+			var serverPasswordDigest = ToBase64String(hash);
+
+			var clientPasswordDigest = wsUsernameToken.Password?.Value;
+			return serverPasswordDigest == clientPasswordDigest;
 		}
 	}
 }

--- a/src/SoapCore/WsUsernameToken.cs
+++ b/src/SoapCore/WsUsernameToken.cs
@@ -1,13 +1,30 @@
-using System.Runtime.Serialization;
+using System.Xml;
+using System.Xml.Serialization;
 
 namespace SoapCore
 {
-	[DataContract(Name = "UsernameToken", Namespace = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd")]
+	[XmlRoot("UsernameToken", Namespace = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd")]
 	public class WsUsernameToken
 	{
-		[DataMember(Name = "Username", Order = 1, IsRequired = true)]
+		[XmlElement("Username")]
 		public string Username { get; set; }
-		[DataMember(Name = "Password", Order = 2, IsRequired = true)]
-		public string Password { get; set; }
+
+		[XmlElement("Password")]
+		public PasswordString Password { get; set; }
+
+		[XmlElement("Nonce", DataType = "base64Binary")]
+		public byte[] Nonce { get; set; }
+
+		[XmlElement("Created", Namespace = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd")]
+		public string Created { get; set; }
+
+		public class PasswordString
+		{
+			[XmlText]
+			public string Value { get; set; }
+
+			[XmlAttribute("Type")]
+			public string Type { get; set; }
+		}
 	}
 }


### PR DESCRIPTION
Currently, the SoapCore has a WS-Security filter that authorized only works with PasswordText type. 

The pull request adds a possibility to use PasswordDigest type.

I have changed the unit tests in the RawMessageFilterTests.cs because

1. the "namespace_prefix:Something is either error or a syntax unknown to me. 
2. The Type URL should point to wss-username-token-profile URL, not wss-wssecurity-secext

Done using [Web Services Security 2 UsernameToken Profile 1.1](https://www.oasis-open.org/committees/download.php/16782/wss-v1.1-spec-os-UsernameTokenProfile.pdf)
