### PR TITLE
Handle enums with no namespace

### DIFF
--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -668,7 +668,7 @@ namespace SoapCore.Meta
 			{
 				writer.WriteAttributeString("targetNamespace", @namespace);
 			}
-			else if (typeInfo.IsEnum || (typeInfo.IsValueType && typeInfo.Namespace.StartsWith("System"))
+			else if (typeInfo.IsEnum || (typeInfo.IsValueType && typeInfo.Namespace != null && typeInfo.Namespace.StartsWith("System"))
 				|| (type.Name == "String")
 				|| (type.Name == "Byte[]")
 				)


### PR DESCRIPTION
a little esoteric, but ran across a nullreference exception when one of my types was an enum with no namespace.