### PR TITLE
Passed request message to FaultException provider

### DIFF
--- a/src/SoapCore.Tests/FaultExceptionTransformer/TestFaultExceptionTransformer.cs
+++ b/src/SoapCore.Tests/FaultExceptionTransformer/TestFaultExceptionTransformer.cs
@@ -9,7 +9,7 @@ namespace SoapCore.Tests.FaultExceptionTransformer
 {
 	public class TestFaultExceptionTransformer : IFaultExceptionTransformer
 	{
-		public Message ProvideFault(Exception exception, MessageVersion messageVersion, XmlNamespaceManager xmlNamespaceManager)
+		public Message ProvideFault(Exception exception, MessageVersion messageVersion, Message requestMessage, XmlNamespaceManager xmlNamespaceManager)
 		{
 			var fault = new TestFault
 			{

--- a/src/SoapCore/DefaultFaultExceptionTransformer.cs
+++ b/src/SoapCore/DefaultFaultExceptionTransformer.cs
@@ -24,7 +24,7 @@ namespace SoapCore
 			_exceptionTransformer = exceptionTransformer;
 		}
 
-		public Message ProvideFault(Exception exception, MessageVersion messageVersion, XmlNamespaceManager xmlNamespaceManager)
+		public Message ProvideFault(Exception exception, MessageVersion messageVersion, Message requestMessage, XmlNamespaceManager xmlNamespaceManager)
 		{
 			var bodyWriter = _exceptionTransformer == null ?
 				new FaultBodyWriter(exception, messageVersion) :

--- a/src/SoapCore/Extensibility/IFaultExceptionTransformer.cs
+++ b/src/SoapCore/Extensibility/IFaultExceptionTransformer.cs
@@ -18,9 +18,10 @@ namespace SoapCore.Extensibility
 		/// </summary>
 		/// <param name="exception">Exception to transform</param>
 		/// <param name="messageVersion">SOAP message version</param>
+		/// <param name="requestMessage">SOAP requestMessage</param>
 		/// <param name="xmlNamespaceManager">Namespace manager</param>
 		/// <returns>Fully formatted SOAP Message</returns>
 		/// <seealso cref="MessageFaultBodyWriter"/>
-		Message ProvideFault(Exception exception, MessageVersion messageVersion, XmlNamespaceManager xmlNamespaceManager);
+		Message ProvideFault(Exception exception, MessageVersion messageVersion, Message requestMessage, XmlNamespaceManager xmlNamespaceManager);
 	}
 }

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -661,7 +661,7 @@ namespace SoapCore
 			HttpContext httpContext)
 		{
 			var faultExceptionTransformer = serviceProvider.GetRequiredService<IFaultExceptionTransformer>();
-			var faultMessage = faultExceptionTransformer.ProvideFault(exception, messageEncoder.MessageVersion, _xmlNamespaceManager);
+			var faultMessage = faultExceptionTransformer.ProvideFault(exception, messageEncoder.MessageVersion, requestMessage, _xmlNamespaceManager);
 
 			httpContext.Response.ContentType = httpContext.Request.ContentType;
 			httpContext.Response.Headers["SOAPAction"] = faultMessage.Headers.Action;


### PR DESCRIPTION
It's is useful to have original message in provide FaultExceptionProvider. For example we can find out what method of WS was invoked from requestMessage Headers. It's very useful, otherwise we need to iterate stack trace of exception 