### PR TITLE
Fix DataContract containing Array[] produces invalid WSDL

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/IObjectWithArrayService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IObjectWithArrayService.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Text;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface IObjectWithArrayService
+	{
+		[OperationContract]
+		void Method(MyClassWithArray model);
+	}
+
+	public class ObjectWithArrayService : IObjectWithArrayService
+	{
+		public void Method(MyClassWithArray model)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/MyClassWithArray.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/MyClassWithArray.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	public class MyClassWithArray
+	{
+		public MyClass[] TestArrayModel { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -229,6 +229,28 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 		}
 
+		[TestMethod]
+		public void CheckSchemaObjectWithArrayService()
+		{
+			StartService(typeof(ObjectWithArrayService));
+			var wsdl = GetWsdl();
+			StopServer();
+			var root = XElement.Parse(wsdl);
+			var elementsWithEmptyName = GetElements(root, _xmlSchema + "element").Where(x => x.Attribute("name")?.Value == string.Empty);
+			elementsWithEmptyName.ShouldBeEmpty();
+
+			var elementsWithEmptyType = GetElements(root, _xmlSchema + "element").Where(x => x.Attribute("type")?.Value == "xs:");
+			elementsWithEmptyType.ShouldBeEmpty();
+
+			var elementsWithEmptyComplexType = GetElements(root, _xmlSchema + "element").Where(x => x.Attribute("type")?.Value == "tns:");
+			elementsWithEmptyComplexType.ShouldBeEmpty();
+
+			var typeWithArrayElement = GetElements(root, _xmlSchema + "complexType").Single(x => x.Attribute("name")?.Value == "ArrayOfMyClass");
+			var typeDescriptionElements = GetElements(root, _xmlSchema + "element").Where(x => x.Attribute("name")?.Value == "MyClass");
+			Assert.IsNotNull(typeWithArrayElement);
+			Assert.AreEqual(typeDescriptionElements.Count(), 2);
+		}
+
 		[TestCleanup]
 		public void StopServer()
 		{

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -830,17 +830,14 @@ namespace SoapCore.Meta
 				typeName = xmlTypeAttribute.TypeName;
 			}
 
-			if (isArrayPropertyDeclaration == false)
+			if (type.IsArray && isArrayPropertyDeclaration == false)
 			{
-				if (type.IsArray)
-				{
-					typeName = "ArrayOf" + typeName.Replace("[]", string.Empty);
-				}
+				typeName = "ArrayOf" + typeName.Replace("[]", string.Empty);
+			}
 
-				if (typeof(IEnumerable).IsAssignableFrom(type) && type.IsGenericType)
-				{
-					typeName = "ArrayOf" + typeName;
-				}
+			if (typeof(IEnumerable).IsAssignableFrom(type) && type.IsGenericType && isArrayPropertyDeclaration == false)
+			{
+				typeName = "ArrayOf" + typeName;
 			}
 
 			return typeName;

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -654,7 +654,7 @@ namespace SoapCore.Meta
 				type = typeInfo.GetElementType();
 			}
 
-			var typeName = GetSerialsedTypeName(type);
+			var typeName = GetSerialsedTypeName(type, true);
 
 			if (writer.TryAddSchemaTypeFromXmlSchemaProviderAttribute(type, name, SoapSerializer.XmlSerializer, _xmlNamespaceManager))
 			{
@@ -811,7 +811,7 @@ namespace SoapCore.Meta
 			writer.WriteEndElement(); // element
 		}
 
-		private static string GetSerialsedTypeName(Type type)
+		private static string GetSerialsedTypeName(Type type, bool isArrayPropertyDeclaration = false)
 		{
 			var namedType = type;
 			if (type.IsArray)
@@ -830,14 +830,17 @@ namespace SoapCore.Meta
 				typeName = xmlTypeAttribute.TypeName;
 			}
 
-			if (type.IsArray)
+			if (isArrayPropertyDeclaration == false)
 			{
-				typeName = "ArrayOf" + typeName.Replace("[]", string.Empty);
-			}
+				if (type.IsArray)
+				{
+					typeName = "ArrayOf" + typeName.Replace("[]", string.Empty);
+				}
 
-			if (typeof(IEnumerable).IsAssignableFrom(type) && type.IsGenericType)
-			{
-				typeName = "ArrayOf" + typeName;
+				if (typeof(IEnumerable).IsAssignableFrom(type) && type.IsGenericType)
+				{
+					typeName = "ArrayOf" + typeName;
+				}
 			}
 
 			return typeName;


### PR DESCRIPTION
https://github.com/DigDes/SoapCore/issues/401

Current realization not provide array by wsdl standard. I found this earlies and sent examples.

Now this is correct.