### PR TITLE
Bugfix for nullable value types in wsdl

### DIFF
--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -677,7 +677,7 @@ namespace SoapCore.Meta
 			{
 				writer.WriteAttributeString("targetNamespace", @namespace);
 			}
-			else if (typeInfo.IsEnum
+			else if (typeInfo.IsEnum || underlyingType?.IsEnum == true
 				|| (typeInfo.IsValueType && typeInfo.Namespace != null && (typeInfo.Namespace == "System" || typeInfo.Namespace.StartsWith("System.")))
 				|| (type.Name == "String")
 				|| (type.Name == "Byte[]")
@@ -700,6 +700,11 @@ namespace SoapCore.Meta
 				{
 					xsTypename = new XmlQualifiedName(typeName, _xmlNamespaceManager.LookupNamespace("tns"));
 					_enumToBuild.Enqueue(type);
+				}
+				else if (underlyingType?.IsEnum == true)
+				{
+					xsTypename = new XmlQualifiedName(GetSerialsedTypeName(underlyingType), _xmlNamespaceManager.LookupNamespace("tns"));
+					_enumToBuild.Enqueue(underlyingType);
 				}
 				else
 				{

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -661,6 +661,15 @@ namespace SoapCore.Meta
 				return;
 			}
 
+			var underlyingType = Nullable.GetUnderlyingType(type);
+
+			//if type is a nullable non-system struct
+			if (underlyingType?.IsValueType == true && !underlyingType.IsEnum && underlyingType.Namespace != null && underlyingType.Namespace != "System" && !underlyingType.Namespace.StartsWith("System."))
+			{
+				AddSchemaType(writer, underlyingType, name, isArray, @namespace);
+				return;
+			}
+
 			writer.WriteStartElement("element", Namespaces.XMLNS_XSD);
 
 			// Check for null, since we may use empty NS
@@ -668,7 +677,8 @@ namespace SoapCore.Meta
 			{
 				writer.WriteAttributeString("targetNamespace", @namespace);
 			}
-			else if (typeInfo.IsEnum || (typeInfo.IsValueType && typeInfo.Namespace != null && typeInfo.Namespace.StartsWith("System"))
+			else if (typeInfo.IsEnum
+				|| (typeInfo.IsValueType && typeInfo.Namespace != null && (typeInfo.Namespace == "System" || typeInfo.Namespace.StartsWith("System.")))
 				|| (type.Name == "String")
 				|| (type.Name == "Byte[]")
 				)
@@ -693,7 +703,6 @@ namespace SoapCore.Meta
 				}
 				else
 				{
-					var underlyingType = Nullable.GetUnderlyingType(type);
 					if (underlyingType != null)
 					{
 						xsTypename = ResolveType(underlyingType);

--- a/src/SoapCore/Meta/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaWCFBodyWriter.cs
@@ -880,7 +880,7 @@ namespace SoapCore.Meta
 				writer.WriteAttributeString("name", "detail");
 				var ns = $"q{_namespaceCounter++}";
 				writer.WriteAttributeString("element", $"{ns}:{fault.Name}");
-				writer.WriteAttributeString("xmlns", ns, null, GetDataContractNamespace(fault));
+				writer.WriteAttributeString(ns, "xmlns", GetDataContractNamespace(fault));
 				writer.WriteEndElement(); // wsdl:part
 				writer.WriteEndElement(); // wsdl:message
 			}

--- a/src/SoapCore/Meta/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaWCFBodyWriter.cs
@@ -729,7 +729,7 @@ namespace SoapCore.Meta
 
 			writer.WriteStartElement("xs", "complexType", Namespaces.XMLNS_XSD);
 			writer.WriteAttributeString("name", toBuildName);
-			writer.WriteAttributeString("ser", "xmlns", Namespaces.SERIALIZATION_NS);
+			writer.WriteAttributeString("xmlns", "ser", null, Namespaces.SERIALIZATION_NS);
 
 			if (type.IsValueType && ResolveSystemType(type).name == null)
 			{
@@ -760,7 +760,7 @@ namespace SoapCore.Meta
 				{
 					var ns = $"q{_namespaceCounter++}";
 					writer.WriteAttributeString("base", $"{ns}:{typeName}");
-					writer.WriteAttributeString($"{ns}", "xmlns", modelNamespace);
+					writer.WriteAttributeString("xmlns", ns, null, modelNamespace);
 				}
 				else
 				{
@@ -880,7 +880,7 @@ namespace SoapCore.Meta
 				writer.WriteAttributeString("name", "detail");
 				var ns = $"q{_namespaceCounter++}";
 				writer.WriteAttributeString("element", $"{ns}:{fault.Name}");
-				writer.WriteAttributeString(ns, "xmlns", GetDataContractNamespace(fault));
+				writer.WriteAttributeString("xmlns", ns, null, GetDataContractNamespace(fault));
 				writer.WriteEndElement(); // wsdl:part
 				writer.WriteEndElement(); // wsdl:message
 			}

--- a/src/SoapCore/Meta/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaWCFBodyWriter.cs
@@ -880,7 +880,7 @@ namespace SoapCore.Meta
 				writer.WriteAttributeString("name", "detail");
 				var ns = $"q{_namespaceCounter++}";
 				writer.WriteAttributeString("element", $"{ns}:{fault.Name}");
-				writer.WriteAttributeString($"xmlns:{ns}", GetDataContractNamespace(fault));
+				writer.WriteAttributeString("xmlns", ns, null, GetDataContractNamespace(fault));
 				writer.WriteEndElement(); // wsdl:part
 				writer.WriteEndElement(); // wsdl:message
 			}

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -184,7 +184,8 @@ namespace SoapCore
 			var responseMessage = Message.CreateMessage(_messageEncoders[0].MessageVersion, null, bodyWriter);
 			responseMessage = new MetaMessage(responseMessage, _service, _binding, _xmlNamespaceManager);
 
-			httpContext.Response.ContentType = _messageEncoders[0].ContentType;
+			//we should use text/xml in wsdl page for browser compability.
+			httpContext.Response.ContentType = "text/xml;charset=UTF-8";// _messageEncoders[0].ContentType;
 
 			await WriteMessageAsync(_messageEncoders[0], responseMessage, httpContext);
 		}


### PR DESCRIPTION
Hi,
Nullable non-system structs and enums are generiting as "Nullable`1" in wsdl with XmlSerializer. I've fixed these situations in this PR. It fixes also wrong ns attribute for message faults in MetaWCFBodyWriter.
Best regards.