### PR TITLE
Support for mixing serializers

### DIFF
--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -80,5 +80,10 @@ namespace SoapCore
 		/// Gets or sets an collection of Xml Namespaces to override the default prefix for.
 		/// </summary>
 		public XmlNamespaceManager XmlNamespacePrefixOverrides { get; set; } = new XmlNamespaceManager(new NameTable());
+
+		/// <summary>
+		/// Gets or sets a value indicating the kind of serializer to use for meta generation - if not provided the SoapSerializer setting is used instead
+		/// </summary>
+		public SoapSerializer? MetaSerializer { get; set; }
 	}
 }

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -180,7 +180,10 @@ namespace SoapCore
 		private async Task ProcessMeta(HttpContext httpContext)
 		{
 			var baseUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host + httpContext.Request.PathBase + httpContext.Request.Path;
-			var bodyWriter = _serializer == SoapSerializer.XmlSerializer ? new MetaBodyWriter(_service, baseUrl, _binding, _xmlNamespaceManager) : (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, _binding);
+			var bodyWriter = (_options?.MetaSerializer ?? _serializer) == SoapSerializer.XmlSerializer
+				? new MetaBodyWriter(_service, baseUrl, _binding, _xmlNamespaceManager)
+				: (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, _binding);
+
 			var responseMessage = Message.CreateMessage(_messageEncoders[0].MessageVersion, null, bodyWriter);
 			responseMessage = new MetaMessage(responseMessage, _service, _binding, _xmlNamespaceManager);
 

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -35,6 +35,8 @@ namespace SoapCore
 
 		public XmlNamespaceManager XmlNamespacePrefixOverrides { get; set; }
 
+		public SoapSerializer? MetaSerializer { get; set; }
+
 		public static SoapOptions FromSoapCoreOptions<T>(SoapCoreOptions opt)
 		{
 			var soapOptions = new SoapOptions
@@ -52,7 +54,8 @@ namespace SoapCore
 				HttpGetEnabled = opt.HttpGetEnabled,
 				OmitXmlDeclaration = opt.OmitXmlDeclaration,
 				IndentXml = opt.IndentXml,
-				XmlNamespacePrefixOverrides = opt.XmlNamespacePrefixOverrides
+				XmlNamespacePrefixOverrides = opt.XmlNamespacePrefixOverrides,
+				MetaSerializer = opt.MetaSerializer
 			};
 
 			return soapOptions;


### PR DESCRIPTION
Due to a scenario where I needed the flexibility of XML processing incoming / outgoing requests but needed the meta (WSDL) endpoint to generate using the DataContract serializer.

This PR add's the ability to allow a user to override the serializer being used for the meta endpoint, by default it's not set so will use the existing SoapSerializer setting.