### PR TITLE
Improvement of generic type support and Dictionary handling

### DIFF
--- a/src/SoapCore.Tests/ITestService.cs
+++ b/src/SoapCore.Tests/ITestService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ServiceModel;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -66,5 +67,14 @@ namespace SoapCore.Tests
 
 		[OperationContract]
 		string PingWithServiceOperationTuning();
+
+		[OperationContract]
+		ComplexModelInput[] ArrayOfComplexItems(ComplexModelInput[] items);
+
+		[OperationContract]
+		List<ComplexModelInput> ListOfComplexItems(List<ComplexModelInput> items);
+
+		[OperationContract]
+		Dictionary<string, string> ListOfDictionaryItems(Dictionary<string, string> items);
 	}
 }

--- a/src/SoapCore.Tests/IntegrationTests.cs
+++ b/src/SoapCore.Tests/IntegrationTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Numerics;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Text;
@@ -131,6 +133,37 @@ namespace SoapCore.Tests
 			string message = string.Empty;
 			client.RefParam(ref message);
 			Assert.AreEqual("hello, world", message);
+		}
+
+		[TestMethod]
+		public void ArrayInput()
+		{
+			var client = CreateClient();
+			List<ComplexModelInput> complexModelInputs = new List<ComplexModelInput>();
+			complexModelInputs.Add(new ComplexModelInput());
+			var e = client.ArrayOfComplexItems(complexModelInputs.ToArray());
+			Assert.AreEqual(e.Length, complexModelInputs.Count);
+		}
+
+		[TestMethod]
+		public void ListInput()
+		{
+			var client = CreateClient();
+			List<ComplexModelInput> complexModelInputs = new List<ComplexModelInput>();
+			complexModelInputs.Add(new ComplexModelInput());
+			var e = client.ListOfComplexItems(complexModelInputs);
+			Assert.AreEqual(e.Count, complexModelInputs.Count);
+		}
+
+		[TestMethod]
+		public void DictionaryInput()
+		{
+			var client = CreateClient();
+			Dictionary<string, string> dictionaryInputs = new Dictionary<string, string>();
+			dictionaryInputs.Add("1", "2");
+			var e = client.ListOfDictionaryItems(dictionaryInputs);
+			Assert.AreEqual(e["1"], dictionaryInputs["1"]);
+			Assert.AreEqual(e.Count, dictionaryInputs.Count);
 		}
 
 		[TestMethod]

--- a/src/SoapCore.Tests/TestService.cs
+++ b/src/SoapCore.Tests/TestService.cs
@@ -112,5 +112,20 @@ namespace SoapCore.Tests
 		{
 			return _pingResultValue.Value;
 		}
+
+		public ComplexModelInput[] ArrayOfComplexItems(ComplexModelInput[] items)
+		{
+			return items;
+		}
+
+		public List<ComplexModelInput> ListOfComplexItems(List<ComplexModelInput> items)
+		{
+			return items;
+		}
+
+		public Dictionary<string, string> ListOfDictionaryItems(Dictionary<string, string> items)
+		{
+			return items;
+		}
 	}
 }

--- a/src/SoapCore.Tests/Wsdl/Services/CustomDictionary.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/CustomDictionary.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	public class CustomDictionary : Dictionary<string, string>
+	{
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/IDictionaryTypeListService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IDictionaryTypeListService.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using SoapCore.Tests.Model;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface IDictionaryTypeListService
+	{
+		[OperationContract]
+		List<ComplexModelInput> Test();
+
+		[OperationContract]
+		Dictionary<string, string> DictionaryTest(Dictionary<string, string> thing);
+	}
+
+	public class DictionaryTypeListService : IDictionaryTypeListService
+	{
+		public Dictionary<string, string> DictionaryTest(Dictionary<string, string> thing)
+		{
+			throw new NotImplementedException();
+		}
+
+		public List<ComplexModelInput> Test() => throw new NotImplementedException();
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -207,6 +207,27 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[TestMethod]
+		public void CheckDictionaryTypeDataContract()
+		{
+			StartService(typeof(DictionaryTypeListService));
+			var wsdl = GetWsdl();
+			StopServer();
+
+			var root = XElement.Parse(wsdl);
+
+			var dictionaryItems = GetElements(root, _xmlSchema + "element").SingleOrDefault(a => a.Attribute("name")?.Value.Equals("thing") == true);
+			Assert.IsNotNull(dictionaryItems);
+			Assert.AreEqual("http://schemas.datacontract.org/2004/07/System.Collections.Generic", dictionaryItems.Attribute(XNamespace.Xmlns + "q2").Value);
+			Assert.AreEqual("q2:ArrayOfKeyValuePairOfStringString", dictionaryItems.Attribute("type").Value);
+
+			var complexTypeList = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value.Equals("ComplexModelInput") == true);
+			Assert.IsNotNull(complexTypeList);
+
+			var myStringElement = GetElements(complexTypeList, _xmlSchema + "element").SingleOrDefault(a => a.Attribute("name")?.Value.Equals("StringProperty") == true);
+			Assert.IsNotNull(myStringElement);
+		}
+
+		[TestMethod]
 		public async Task CheckStringArrayNameWsdl()
 		{
 			//StartService(typeof(StringListService));

--- a/src/SoapCore/Meta/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaWCFBodyWriter.cs
@@ -1336,12 +1336,6 @@ namespace SoapCore.Meta
 
 		private string GetTypeName(Type type)
 		{
-			//special case as string is IEnumerable
-			if (type == typeof(string))
-			{
-				return type.Name;
-			}
-
 			if (type.IsGenericType && !type.IsArray && !typeof(IEnumerable).IsAssignableFrom(type))
 			{
 				var genericTypes = GetGenericTypes(type);
@@ -1357,7 +1351,8 @@ namespace SoapCore.Meta
 				return "ArrayOf" + GetTypeName(type.GetElementType());
 			}
 
-			if (typeof(IEnumerable).IsAssignableFrom(type))
+			//Special case as string is IEnumerable and we don't want to turn it into System.Object
+			if (typeof(IEnumerable).IsAssignableFrom(type) && type != typeof(string))
 			{
 				var collectionDataContractAttribute = type.GetCustomAttribute<CollectionDataContractAttribute>();
 				if (collectionDataContractAttribute != null)


### PR DESCRIPTION
When a service contains Dictionary<string, string> or any other complex type parameter, only the first generic parameter is included and turned into an array, rendering the dictionary as string[] in the proxy.

-- 

This adds fixes to the WSDL generation to support messages containing generic types with more than one generic parameter and support for ICollection in preference over IEnumerable so that collection types are known.  It also handles String being an IEnumerable but needing to be special cased to String in the WSDL.

This fixes WSDL generation so that the parser built into Visual Studio can handle generic collections properly and dictionaries.  It was unable to find types previously as the generated WSDL was malformed and had the wrong names and/or namespaces.

There's some unknowns around how the original WCF parser special cases dictionaries still. Currently, it represents it as a list of KeyValuePairTypeType in the generated proxy, I've made SoapCore behave very close to WCF's original mechanism but it doesn't seem to detect it as a Dictionary yet, when I find how it does it I'll submit another PR to align perfectly to WCF.