### PR TITLE
Add support for service known types

### DIFF
--- a/src/SoapCore.Tests/ITestService.cs
+++ b/src/SoapCore.Tests/ITestService.cs
@@ -79,5 +79,13 @@ namespace SoapCore.Tests
 
 		[OperationContract]
 		ComplexInheritanceModelInputBase GetComplexInheritanceModel(ComplexInheritanceModelInputBase input);
+
+		[ServiceKnownType(typeof(ComplexModelInput))]
+		[OperationContract]
+		ComplexModelInput ComplexModelInputFromServiceKnownType(object value);
+
+		[ServiceKnownType(typeof(ComplexModelInput))]
+		[OperationContract]
+		object ObjectFromServiceKnownType(ComplexModelInput value);
 	}
 }

--- a/src/SoapCore.Tests/IntegrationTests.cs
+++ b/src/SoapCore.Tests/IntegrationTests.cs
@@ -176,6 +176,35 @@ namespace SoapCore.Tests
 		}
 
 		[TestMethod]
+		public void ComplexModelInputFromServiceKnownType()
+		{
+			var client = CreateClient();
+			var input = new ComplexModelInput
+			{
+				IntProperty = 123,
+				StringProperty = "Test string",
+			};
+			var output = client.ComplexModelInputFromServiceKnownType(input);
+			Assert.AreEqual(input.IntProperty, output.IntProperty);
+			Assert.AreEqual(input.StringProperty, output.StringProperty);
+		}
+
+		[TestMethod]
+		public void ObjectFromServiceKnownType()
+		{
+			var client = CreateClient();
+			var input = new ComplexModelInput
+			{
+				IntProperty = 123,
+				StringProperty = "Test string",
+			};
+			var output = client.ObjectFromServiceKnownType(input);
+			Assert.IsInstanceOfType(output, typeof(ComplexModelInput));
+			Assert.AreEqual(input.IntProperty, ((ComplexModelInput)output).IntProperty);
+			Assert.AreEqual(input.StringProperty, ((ComplexModelInput)output).StringProperty);
+		}
+
+		[TestMethod]
 		public void ThrowsFaultException()
 		{
 			var client = CreateClient();

--- a/src/SoapCore.Tests/TestService.cs
+++ b/src/SoapCore.Tests/TestService.cs
@@ -148,5 +148,30 @@ namespace SoapCore.Tests
 					}
 			}
 		}
+
+		public ComplexModelInput ComplexModelInputFromServiceKnownType(object value)
+		{
+			if (value is null)
+			{
+				throw new ArgumentNullException(nameof(value));
+			}
+
+			if (value is ComplexModelInput input)
+			{
+				return input;
+			}
+
+			throw new Exception($"Invalid object type `{value.GetType()}`.");
+		}
+
+		public object ObjectFromServiceKnownType(ComplexModelInput value)
+		{
+			if (value is null)
+			{
+				throw new ArgumentNullException(nameof(value));
+			}
+
+			return value;
+		}
 	}
 }

--- a/src/SoapCore.Tests/Wsdl/Services/IAnonymousServiceKnownTypesService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IAnonymousServiceKnownTypesService.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Runtime.Serialization;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceKnownType(typeof(AnonymousServiceKnownTypesService.Dog))]
+	[ServiceContract]
+	public interface IAnonymousServiceKnownTypesService
+	{
+		[ServiceKnownType(typeof(AnonymousServiceKnownTypesService.Cat))]
+		[OperationContract]
+		object TestFromTypedToAny(AnonymousServiceKnownTypesService.Animal value);
+
+		[ServiceKnownType(typeof(AnonymousServiceKnownTypesService.Squirrel))]
+		[OperationContract]
+		AnonymousServiceKnownTypesService.Animal TestFromAnyToTyped(object value);
+	}
+
+	public class AnonymousServiceKnownTypesService : IAnonymousServiceKnownTypesService
+	{
+		public object TestFromTypedToAny(Animal value)
+		{
+			return value;
+		}
+
+		public Animal TestFromAnyToTyped(object value)
+		{
+			if (value is null)
+			{
+				throw new ArgumentNullException(nameof(value));
+			}
+
+			if (value is Animal result)
+			{
+				return result;
+			}
+
+			throw new Exception($"Object of type `{value.GetType()}` is not supported in this context.");
+		}
+
+		[DataContract(Name = "Animal")]
+		public class Animal
+		{
+		}
+
+		[DataContract(Name = "Dog")]
+		public class Dog : Animal
+		{
+		}
+
+		[DataContract(Name = "Cat")]
+		public class Cat : Animal
+		{
+		}
+
+		[DataContract(Name = "Squirrel")]
+		public class Squirrel : Animal
+		{
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/IServiceKnownTypesService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IServiceKnownTypesService.cs
@@ -1,0 +1,37 @@
+using System.Runtime.Serialization;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceKnownType(typeof(ServiceKnownTypesService.Dog))]
+	[ServiceContract]
+	public interface IServiceKnownTypesService
+	{
+		[ServiceKnownType(typeof(ServiceKnownTypesService.Cat))]
+		[OperationContract]
+		ServiceKnownTypesService.Animal Test(ServiceKnownTypesService.Animal value);
+	}
+
+	public class ServiceKnownTypesService : IServiceKnownTypesService
+	{
+		public Animal Test(Animal value)
+		{
+			return value;
+		}
+
+		[DataContract(Name = "Animal")]
+		public class Animal
+		{
+		}
+
+		[DataContract(Name = "Dog")]
+		public class Dog : Animal
+		{
+		}
+
+		[DataContract(Name = "Cat")]
+		public class Cat : Animal
+		{
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -98,6 +98,27 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[TestMethod]
+		public void CheckServiceKnownTypes()
+		{
+			StartService(typeof(ServiceKnownTypesService));
+			var wsdl = GetWsdl();
+			StopServer();
+
+			var root = XElement.Parse(wsdl);
+			var dogElement = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value.Equals("Dog") == true);
+			Assert.IsNotNull(dogElement);
+
+			var catElement = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value.Equals("Cat") == true);
+			Assert.IsNotNull(dogElement);
+
+			var animalElement = GetElements(dogElement, _xmlSchema + "extension").SingleOrDefault(a => a.Attribute("base")?.Value.Equals("tns:Animal") == true);
+			Assert.IsNotNull(animalElement);
+
+			animalElement = GetElements(catElement, _xmlSchema + "extension").SingleOrDefault(a => a.Attribute("base")?.Value.Equals("tns:Animal") == true);
+			Assert.IsNotNull(animalElement);
+		}
+
+		[TestMethod]
 		public void CheckStructsInList()
 		{
 			StartService(typeof(StructService));
@@ -180,8 +201,6 @@ namespace SoapCore.Tests.Wsdl
 			StartService(typeof(InheritanceService));
 			var wsdl = GetWsdl();
 			StopServer();
-
-			File.WriteAllText("test.wsdl", wsdl);
 
 			var root = XElement.Parse(wsdl);
 			var childRenamed = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value.Equals("Dog") == true);

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -119,6 +119,32 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[TestMethod]
+		public void CheckAnonymousServiceKnownType()
+		{
+			StartService(typeof(AnonymousServiceKnownTypesService));
+			var wsdl = GetWsdl();
+			StopServer();
+
+			File.WriteAllText("test-ano.wsdl", wsdl);
+
+			var root = XElement.Parse(wsdl);
+			var dogElement = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value.Equals("Dog") == true);
+			Assert.IsNotNull(dogElement);
+
+			var catElement = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value.Equals("Cat") == true);
+			Assert.IsNotNull(dogElement);
+
+			var animalElement = GetElements(dogElement, _xmlSchema + "extension").SingleOrDefault(a => a.Attribute("base")?.Value.Equals("tns:Animal") == true);
+			Assert.IsNotNull(animalElement);
+
+			animalElement = GetElements(catElement, _xmlSchema + "extension").SingleOrDefault(a => a.Attribute("base")?.Value.Equals("tns:Animal") == true);
+			Assert.IsNotNull(animalElement);
+
+			var squirrelElement = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value.Equals("Squirrel") == true);
+			Assert.IsNotNull(dogElement);
+		}
+
+		[TestMethod]
 		public void CheckStructsInList()
 		{
 			StartService(typeof(StructService));

--- a/src/SoapCore/ServiceBodyWriter.cs
+++ b/src/SoapCore/ServiceBodyWriter.cs
@@ -1,4 +1,3 @@
-using SoapCore.ServiceModel;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -10,6 +9,7 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Xml;
 using System.Xml.Serialization;
+using SoapCore.ServiceModel;
 
 namespace SoapCore
 {
@@ -334,7 +334,8 @@ namespace SoapCore
 				}
 				else
 				{
-					Type resultType = _result.GetType();
+					// When operation return type is `System.Object` the `DataContractSerializer` adds `i:type` attribute with the correct object type
+					Type resultType = _operation.ReturnType;
 					IEnumerable<Type> serviceKnownTypes = _operation
 						.GetServiceKnownTypesHierarchy()
 						.Select(x => x.Type);

--- a/src/SoapCore/ServiceModel/ContractDescription.cs
+++ b/src/SoapCore/ServiceModel/ContractDescription.cs
@@ -11,6 +11,7 @@ namespace SoapCore.ServiceModel
 		{
 			Service = service;
 			ContractType = contractType;
+			ServiceKnownTypes = contractType.GetCustomAttributes<ServiceKnownTypeAttribute>(inherit: false);
 			Namespace = attribute.Namespace ?? "http://tempuri.org/"; // Namespace defaults to http://tempuri.org/
 			Name = attribute.Name ?? ContractType.Name; // Name defaults to the type name
 
@@ -27,6 +28,7 @@ namespace SoapCore.ServiceModel
 		}
 
 		public ServiceDescription Service { get; private set; }
+		public IEnumerable<ServiceKnownTypeAttribute> ServiceKnownTypes { get; private set; }
 		public string Name { get; private set; }
 		public string Namespace { get; private set; }
 		public Type ContractType { get; private set; }

--- a/src/SoapCore/ServiceModel/OperationDescription.cs
+++ b/src/SoapCore/ServiceModel/OperationDescription.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -19,15 +20,14 @@ namespace SoapCore.ServiceModel
 			IsOneWay = contractAttribute.IsOneWay;
 			DispatchMethod = operationMethod;
 
-			var returnType = operationMethod.ReturnType;
-
-			if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>))
+			ReturnType = operationMethod.ReturnType;
+			if (ReturnType.IsGenericType && ReturnType.GetGenericTypeDefinition() == typeof(Task<>))
 			{
-				returnType = returnType.GenericTypeArguments[0];
+				ReturnType = ReturnType.GenericTypeArguments[0];
 			}
 
-			IsMessageContractResponse = returnType.CustomAttributes
-					 .FirstOrDefault(ca => ca.AttributeType == typeof(MessageContractAttribute)) != null;
+			IsMessageContractResponse = ReturnType.CustomAttributes
+				.FirstOrDefault(ca => ca.AttributeType == typeof(MessageContractAttribute)) != null;
 
 			AllParameters = operationMethod.GetParameters()
 				.Select((info, index) => CreateParameterInfo(info, index, contract))
@@ -77,6 +77,7 @@ namespace SoapCore.ServiceModel
 		public string ReturnName { get; private set; }
 		public string ReturnElementName { get; private set; }
 		public string ReturnNamespace { get; private set; }
+		public Type ReturnType { get; private set; }
 		public IEnumerable<ServiceKnownTypeAttribute> ServiceKnownTypes { get; private set; }
 
 		public IEnumerable<ServiceKnownTypeAttribute> GetServiceKnownTypesHierarchy()

--- a/src/SoapCore/ServiceModel/OperationDescription.cs
+++ b/src/SoapCore/ServiceModel/OperationDescription.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -57,6 +58,8 @@ namespace SoapCore.ServiceModel
 				.Where(a => a.DetailType?.Name != null)
 				.Select(a => a.DetailType)
 				.ToArray();
+
+			ServiceKnownTypes = operationMethod.GetCustomAttributes<ServiceKnownTypeAttribute>(inherit: false);
 		}
 
 		public ContractDescription Contract { get; private set; }
@@ -74,6 +77,26 @@ namespace SoapCore.ServiceModel
 		public string ReturnName { get; private set; }
 		public string ReturnElementName { get; private set; }
 		public string ReturnNamespace { get; private set; }
+		public IEnumerable<ServiceKnownTypeAttribute> ServiceKnownTypes { get; private set; }
+
+		public IEnumerable<ServiceKnownTypeAttribute> GetServiceKnownTypesHierarchy()
+		{
+			foreach (ServiceKnownTypeAttribute serviceKnownType in ServiceKnownTypes)
+			{
+				yield return serviceKnownType;
+			}
+
+			foreach (ServiceKnownTypeAttribute serviceKnownType in Contract.ServiceKnownTypes)
+			{
+				yield return serviceKnownType;
+			}
+
+			// TODO: should we process service implementation service known type attributes
+			foreach (ServiceKnownTypeAttribute serviceKnownType in Contract.Service.ServiceKnownTypes)
+			{
+				yield return serviceKnownType;
+			}
+		}
 
 		private static SoapMethodParameterInfo CreateParameterInfo(ParameterInfo info, int index, ContractDescription contract)
 		{

--- a/src/SoapCore/ServiceModel/ServiceDescription.cs
+++ b/src/SoapCore/ServiceModel/ServiceDescription.cs
@@ -11,6 +11,7 @@ namespace SoapCore.ServiceModel
 		public ServiceDescription(Type serviceType)
 		{
 			ServiceType = serviceType;
+			ServiceKnownTypes = serviceType.GetCustomAttributes<ServiceKnownTypeAttribute>(inherit: false);
 
 			var types = Enumerable.Empty<Type>().Concat(ServiceType.GetInterfaces());
 			types = types.Concat(new[] { ServiceType });
@@ -28,6 +29,7 @@ namespace SoapCore.ServiceModel
 		}
 
 		public Type ServiceType { get; private set; }
+		public IEnumerable<ServiceKnownTypeAttribute> ServiceKnownTypes { get; private set; }
 		public IEnumerable<ContractDescription> Contracts { get; private set; }
 		public IEnumerable<OperationDescription> Operations => Contracts.SelectMany(c => c.Operations);
 	}


### PR DESCRIPTION
This PR adds support for discovering, serializing and deserializing contracts marked with `ServiceKnownType` attribute.
Allow use of `System.Object` as parameter or return type in operations.