### PR TITLE
Fix for issue #504 Custom name on MessageBodyMember is included in WSDL

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/MessageAttributesService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/MessageAttributesService.cs
@@ -1,0 +1,28 @@
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+#pragma warning disable SA1649 // File name should match first type name
+#pragma warning disable SA1402 // File may only contain a single type
+	[ServiceContract(Namespace = "http://bagov.net")]
+	public interface IMessageHeadersService
+	{
+		[OperationContract]
+		MessageHeadersResponseType GetResponse();
+	}
+
+	public class MessageHeadersService : IMessageHeadersService
+	{
+		public MessageHeadersResponseType GetResponse()
+		{
+			return new MessageHeadersResponseType();
+		}
+	}
+
+	[MessageContract]
+	public class MessageHeadersResponseType
+	{
+		[MessageBodyMember(Name = "ModifiedStringProperty")]
+		public string StringProperty { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -459,6 +459,22 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(propAnonAttribute);
 		}
 
+		[TestMethod]
+		public async Task CheckMessageHeadersServiceWsdl()
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<MessageHeadersService>();
+			Trace.TraceInformation(wsdl);
+			Assert.IsNotNull(wsdl);
+
+			Assert.IsFalse(wsdl.Contains("name=\"\""));
+
+			var root = XElement.Parse(wsdl);
+			var nm = Namespaces.CreateDefaultXmlNamespaceManager();
+
+			var stringPropertyElement = root.XPathSelectElement("//xsd:element[@name='ModifiedStringProperty']", nm);
+			Assert.IsNotNull(stringPropertyElement);
+		}
+
 		[TestCleanup]
 		public void StopServer()
 		{

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -719,6 +719,7 @@ namespace SoapCore.Meta
 			}
 
 			var attributeItem = property.GetCustomAttribute<XmlAttributeAttribute>();
+			var messageBodyMemberAttribute = property.GetCustomAttribute<MessageBodyMemberAttribute>();
 			if (attributeItem != null)
 			{
 				var name = attributeItem.AttributeName;
@@ -728,6 +729,16 @@ namespace SoapCore.Meta
 				}
 
 				AddSchemaType(writer, toBuild, name, isAttribute: true);
+			}
+			else if (messageBodyMemberAttribute != null)
+			{
+				var name = messageBodyMemberAttribute.Name;
+				if (string.IsNullOrWhiteSpace(name))
+				{
+					name = property.Name;
+				}
+
+				AddSchemaType(writer, toBuild, name, isArray: createListWithoutProxyType, isListWithoutWrapper: createListWithoutProxyType);
 			}
 			else
 			{


### PR DESCRIPTION
I have added another check to the WSDL generation, if `[XmlAttribute]` is not found then a check for  a `[MessageBodyMember]` attribute is performed. If found and the `Name` property is set then that is used in the WSDL output.