### PR TITLE
Fixed a problem where we weren't generating WSDL's correctly for async methods with no return values

### DIFF
--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -36,6 +36,10 @@ namespace SoapCore.Tests.Wsdl
 			var wsdl = GetWsdl();
 			Trace.TraceInformation(wsdl);
 			Assert.IsNotNull(wsdl);
+
+			wsdl = GetWsdlFromAsmx();
+			Trace.TraceInformation(wsdl);
+			Assert.IsNotNull(wsdl);
 			StopServer();
 		}
 
@@ -484,6 +488,24 @@ namespace SoapCore.Tests.Wsdl
 		private string GetWsdl()
 		{
 			var serviceName = "Service.svc";
+
+			return GetWsdlFromService(serviceName);
+		}
+
+		private string GetWsdlFromService(string serviceName)
+		{
+			var addresses = _host.ServerFeatures.Get<IServerAddressesFeature>();
+			var address = addresses.Addresses.Single();
+
+			using (var httpClient = new HttpClient())
+			{
+				return httpClient.GetStringAsync(string.Format("{0}/{1}?wsdl", address, serviceName)).Result;
+			}
+		}
+
+		private string GetWsdlFromAsmx()
+		{
+			var serviceName = "Service.asmx";
 
 			var addresses = _host.ServerFeatures.Get<IServerAddressesFeature>();
 			var address = addresses.Addresses.Single();

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -279,7 +279,7 @@ namespace SoapCore.Meta
 				writer.WriteStartElement("element", Namespaces.XMLNS_XSD);
 				writer.WriteAttributeString("name", operation.Name + "Response");
 
-				if (operation.DispatchMethod.ReturnType != typeof(void))
+				if (operation.DispatchMethod.ReturnType != typeof(void) && operation.DispatchMethod.ReturnType != typeof(Task))
 				{
 					var returnType = operation.DispatchMethod.ReturnType;
 					if (returnType.IsConstructedGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>))


### PR DESCRIPTION
When using the .asmx endpoints with a Task return type we weren't treating it the same as void when we were generating the WSDL.

Modified a test so that it checked this too. However it did look like there may be other similar bugs in this area. When I just changed all the tests in WsdlTests to use the .asmx endpoint there were other failures, some of them looked benign but some looked worse.