### PR TITLE
Updated with exception handeling when generating message

### DIFF
--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -219,8 +219,17 @@ namespace SoapCore
 				}
 			}
 
+			Message requestMessage;
 			//Get the message
-			Message requestMessage = await ReadMessageAsync(httpContext, messageEncoder);
+			try
+			{
+				requestMessage = await ReadMessageAsync(httpContext, messageEncoder);
+			}
+			catch (Exception ex)
+			{
+				await WriteErrorResponseMessage(ex, StatusCodes.Status500InternalServerError, serviceProvider, null, messageEncoder, httpContext);
+				return;
+			}
 			var messageFilters = serviceProvider.GetServices<IMessageFilter>().ToArray();
 			var asyncMessageFilters = serviceProvider.GetServices<IAsyncMessageFilter>().ToArray();
 


### PR DESCRIPTION
When creating the message in SoapMessageEncoder at line 132 "Message.CreateMessage(reader, maxSizeOfHeaders, MessageVersion)", it can return in a exception which isn't catch.
This can be if the SOAP body looks like this
"Something completely different"
Hence by having the try - catch block we make sure the exception is returned and being picked up by the implementation of the IFaultExceptionTransFormer.