### PR TITLE
Added support for XmlChoiceIdentifier attribute (xs:choice).

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/XmlModelsService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/XmlModelsService.cs
@@ -56,6 +56,11 @@ namespace SoapCore.Tests.Wsdl.Services
 		[DataMember]
 		public List<TestDataTypeData2> Data { get; set; }
 
+		[XmlElement("Data4", typeof(TestDataTypeData), IsNullable = false)]
+		[XmlElement("Data5", typeof(TestDataTypeData2), IsNullable = false)]
+		[XmlChoiceIdentifier]
+		public List<object> DataList45 { get; set; }
+
 		[XmlAttributeAttribute]
 		public string PropRoot { get; set; }
 

--- a/src/SoapCore.Tests/Wsdl/Services/XmlModelsService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/XmlModelsService.cs
@@ -6,6 +6,13 @@ using System.Xml.Serialization;
 
 namespace SoapCore.Tests.Wsdl.Services
 {
+	[XmlType(IncludeInSchema = false)]
+	public enum DataChoiceType
+	{
+		Data4,
+		Data5
+	}
+
 #pragma warning disable SA1649 // File name should match first type name
 #pragma warning disable SA1402 // File may only contain a single type
 	[ServiceContract(Namespace = "http://bagov.net/")]
@@ -41,6 +48,7 @@ namespace SoapCore.Tests.Wsdl.Services
 		public TestResponseType()
 		{
 			DataList = new List<TestDataTypeData>();
+			DataTypes = new[] { DataChoiceType.Data4, DataChoiceType.Data5 };
 		}
 
 		[System.Xml.Serialization.XmlArrayItemAttribute("Data", IsNullable = false)]
@@ -56,9 +64,12 @@ namespace SoapCore.Tests.Wsdl.Services
 		[DataMember]
 		public List<TestDataTypeData2> Data { get; set; }
 
-		[XmlElement("Data4", typeof(TestDataTypeData), IsNullable = false)]
-		[XmlElement("Data5", typeof(TestDataTypeData2), IsNullable = false)]
-		[XmlChoiceIdentifier]
+		[XmlIgnore]
+		public DataChoiceType[] DataTypes { get; set; }
+
+		[XmlChoiceIdentifier("DataTypes")]
+		[XmlElement("Data4", typeof(TestDataTypeData))]
+		[XmlElement("Data5", typeof(TestDataTypeData2))]
 		public List<object> DataList45 { get; set; }
 
 		[XmlAttributeAttribute]

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -453,6 +453,12 @@ namespace SoapCore.Tests.Wsdl
 			var dynamicTypeElement2 = root.XPathSelectElement("//xsd:complexType[@name='ArrayOfTestDataTypeData1']/xsd:sequence/xsd:element[@name='Data2']", nm);
 			Assert.IsNotNull(dynamicTypeElement2);
 
+			var choiceTypeElement = root.XPathSelectElement("//xsd:complexType[@name='TestResponseType']/xsd:sequence/xsd:choice[@minOccurs='0'and @maxOccurs='unbounded']/xsd:element[@name='Data4']", nm);
+			Assert.IsNotNull(choiceTypeElement);
+
+			var choiceTypeElement2 = root.XPathSelectElement("//xsd:complexType[@name='TestResponseType']/xsd:sequence/xsd:choice[@minOccurs='0'and @maxOccurs='unbounded']/xsd:element[@name='Data5']", nm);
+			Assert.IsNotNull(choiceTypeElement2);
+
 			var propRootAttribute = root.XPathSelectElement("//xsd:attribute[@name='PropRoot']", nm);
 			Assert.IsNotNull(propRootAttribute);
 

--- a/src/SoapCore/Meta/BodyWriterExtensions.cs
+++ b/src/SoapCore/Meta/BodyWriterExtensions.cs
@@ -118,6 +118,12 @@ namespace SoapCore.Meta
 			return false;
 		}
 
+		public static bool IsChoice(this PropertyInfo property)
+		{
+			var choiceItem = property.GetCustomAttribute<XmlChoiceIdentifierAttribute>();
+			return choiceItem != null;
+		}
+
 		public static bool IsAttribute(this PropertyInfo property)
 		{
 			var attributeItem = property.GetCustomAttribute<XmlAttributeAttribute>();


### PR DESCRIPTION
Currently when building WSDL meta [XmlChoiceIdentifierAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.xml.serialization.xmlchoiceidentifierattribute?view=netcore-3.1) is not supported and this PR is meant to fix this.

XmlChoiceIdentifierAttribute presumes having multiple XmlElement attributes for a single property.
To avoid AmbiguousMatchException from [GetCustomAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.attribute.getcustomattribute?view=netcore-3.1) the iteration is done using GetCustomAttributes.