### PR TITLE
Fix deserialization for messageheader  array

### DIFF
--- a/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
@@ -129,5 +129,9 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 
 		[OperationContract(IsOneWay = true)]
 		void OneWayCall(string s);
+
+		[OperationContract(Action = ServiceNamespace.Value + nameof(PingComplexMessageHeaderArray), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
+		PingComplexMessageHeaderArrayResponse PingComplexMessageHeaderArray(PingComplexMessageHeaderArrayRequest request);
 	}
 }

--- a/src/SoapCore.Tests/Serialization/Models.Xml/PingComplexMessageHeaderArrayRequest.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/PingComplexMessageHeaderArrayRequest.cs
@@ -1,0 +1,12 @@
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[MessageContract(WrapperName = nameof(ISampleService.PingComplexMessageHeaderArray), WrapperNamespace = ServiceNamespace.Value, IsWrapped = true)]
+	public class PingComplexMessageHeaderArrayRequest
+	{
+		[MessageHeader(Namespace = ServiceNamespace.Value)]
+		[System.Xml.Serialization.XmlArrayItemAttribute("ComplexModel1", Namespace = ServiceNamespace.Value + "SomethingDifferent", IsNullable = false)]
+		public ComplexModel1[] MyHeaderValue { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Serialization/Models.Xml/PingComplexMessageHeaderArrayResponse.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/PingComplexMessageHeaderArrayResponse.cs
@@ -1,0 +1,9 @@
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[MessageContract(WrapperName = nameof(PingComplexMessageHeaderArrayResponse), WrapperNamespace = ServiceNamespace.Value, IsWrapped = true)]
+	public class PingComplexMessageHeaderArrayResponse
+	{
+	}
+}

--- a/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
+++ b/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
@@ -711,5 +711,35 @@ namespace SoapCore.Tests.Serialization
 
 			sampleServiceClient.GetComplexObjectWithXmlElement(obj);
 		}
+
+		[Theory]
+		[InlineData(SoapSerializer.XmlSerializer)]
+		public void TestPingComplexMessageHeaderArraySerialization(SoapSerializer soapSerializer)
+		{
+			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
+			var myHeaderValue = new[] { ComplexModel1.CreateSample1() };
+
+			_fixture.ServiceMock
+				.Setup(x => x.PingComplexMessageHeaderArray(It.IsAny<PingComplexMessageHeaderArrayRequest>()))
+				.Callback(
+					(PingComplexMessageHeaderArrayRequest request_service) =>
+					{
+						// check input paremeters serialization
+						request_service.MyHeaderValue.ShouldDeepEqual(myHeaderValue);
+					})
+				.Returns(
+					() => new PingComplexMessageHeaderArrayResponse());
+
+			var pingComplexMessageHeaderArrayResult_client =
+				sampleServiceClient.PingComplexMessageHeaderArray(
+					new PingComplexMessageHeaderArrayRequest
+					{
+						MyHeaderValue = myHeaderValue
+					});
+
+			// Verify method has been called
+			pingComplexMessageHeaderArrayResult_client.ShouldNotBeNull();
+			_fixture.ServiceMock.Verify(x => x.PingComplexMessageHeaderArray(It.IsAny<PingComplexMessageHeaderArrayRequest>()), Times.Once());
+		}
 	}
 }

--- a/src/SoapCore/SerializerHelper.cs
+++ b/src/SoapCore/SerializerHelper.cs
@@ -1,10 +1,10 @@
-using Microsoft.CSharp;
-using SoapCore.ServiceModel;
 using System;
 using System.CodeDom;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
+using Microsoft.CSharp;
+using SoapCore.ServiceModel;
 
 namespace SoapCore
 {
@@ -116,7 +116,7 @@ namespace SoapCore
 			var elementType = parameterType.GetElementType();
 
 			var localName = parameterInfo.ArrayItemName ?? elementType.Name;
-			if (parameterInfo.ArrayItemName == null && elementType.Namespace.StartsWith("System"))
+			if (parameterInfo.ArrayItemName == null && elementType.Namespace?.StartsWith("System") == true)
 			{
 				var compiler = new CSharpCodeProvider();
 				var type = new CodeTypeReference(elementType);
@@ -125,13 +125,15 @@ namespace SoapCore
 
 			//localName = "ComplexModelInput";
 			var deserializeMethod = typeof(XmlSerializerExtensions).GetGenericMethod(nameof(XmlSerializerExtensions.DeserializeArray), elementType);
-			var serializer = CachedXmlSerializer.GetXmlSerializer(elementType, localName, parameterNs);
+			var ns = parameterInfo.Namespace ?? parameterNs;
+
+			var serializer = CachedXmlSerializer.GetXmlSerializer(elementType, localName, ns);
 
 			object result = null;
 
 			lock (serializer)
 			{
-				result = deserializeMethod.Invoke(null, new object[] { serializer, localName, parameterNs, xmlReader });
+				result = deserializeMethod.Invoke(null, new object[] { serializer, localName, ns, xmlReader });
 			}
 
 			//if (parameterInfo.ArrayItemName != null)

--- a/src/SoapCore/SerializerHelper.cs
+++ b/src/SoapCore/SerializerHelper.cs
@@ -2,9 +2,10 @@ using System;
 using System.CodeDom;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Runtime.Serialization;
+using System.Xml.Serialization;
 using Microsoft.CSharp;
-using SoapCore.ServiceModel;
 
 namespace SoapCore
 {
@@ -22,7 +23,7 @@ namespace SoapCore
 			Type parameterType,
 			string parameterName,
 			string parameterNs,
-			SoapMethodParameterInfo parameterInfo = null,
+			MemberInfo memberInfo,
 			IEnumerable<Type> knownTypes = null)
 		{
 			if (xmlReader.IsStartElement(parameterName, parameterNs))
@@ -34,18 +35,18 @@ namespace SoapCore
 					switch (_serializer)
 					{
 						case SoapSerializer.XmlSerializer:
-							if (!parameterType.IsArray || (parameterInfo != null && parameterInfo.ArrayName != null && parameterInfo.ArrayItemName == null))
+							if (!parameterType.IsArray)
 							{
 								// case [XmlElement("parameter")] int parameter
-								// case int[] parameter
 								// case [XmlArray("parameter")] int[] parameter
 								return DeserializeObject(xmlReader, parameterType, parameterName, parameterNs);
 							}
 							else
 							{
+								// case int[] parameter
 								// case [XmlElement("parameter")] int[] parameter
 								// case [XmlArray("parameter"), XmlArrayItem(ElementName = "item")] int[] parameter
-								return DeserializeArray(xmlReader, parameterType, parameterName, parameterNs, parameterInfo);
+								return DeserializeArrayXmlSerializer(xmlReader, parameterType, parameterName, parameterNs, memberInfo);
 							}
 
 						case SoapSerializer.DataContractSerializer:
@@ -105,38 +106,35 @@ namespace SoapCore
 			return serializer.ReadObject(xmlReader, verifyObjectName: true);
 		}
 
-		private object DeserializeArray(System.Xml.XmlDictionaryReader xmlReader, Type parameterType, string parameterName, string parameterNs, SoapMethodParameterInfo parameterInfo)
+		private object DeserializeArrayXmlSerializer(System.Xml.XmlDictionaryReader xmlReader, Type parameterType, string parameterName, string parameterNs, MemberInfo memberInfo)
 		{
+			XmlArrayItemAttribute xmlArrayItemAttribute = memberInfo.GetCustomAttribute(typeof(XmlArrayItemAttribute)) as XmlArrayItemAttribute;
+
 			var isEmpty = xmlReader.IsEmptyElement;
-			//if (parameterInfo.ArrayItemName != null)
-			{
-				xmlReader.ReadStartElement(parameterName, parameterNs);
-			}
+			xmlReader.ReadStartElement(parameterName, parameterNs);
 
 			var elementType = parameterType.GetElementType();
 
-			var localName = parameterInfo.ArrayItemName ?? elementType.Name;
-			if (parameterInfo.ArrayItemName == null && elementType.Namespace?.StartsWith("System") == true)
+			var arrayItemName = xmlArrayItemAttribute?.ElementName ?? elementType.Name;
+			if (xmlArrayItemAttribute?.ElementName == null && elementType.Namespace?.StartsWith("System") == true)
 			{
 				var compiler = new CSharpCodeProvider();
 				var type = new CodeTypeReference(elementType);
-				localName = compiler.GetTypeOutput(type);
+				arrayItemName = compiler.GetTypeOutput(type);
 			}
 
-			//localName = "ComplexModelInput";
 			var deserializeMethod = typeof(XmlSerializerExtensions).GetGenericMethod(nameof(XmlSerializerExtensions.DeserializeArray), elementType);
-			var ns = parameterInfo.Namespace ?? parameterNs;
+			var arrayItemNamespace = xmlArrayItemAttribute?.Namespace ?? parameterNs;
 
-			var serializer = CachedXmlSerializer.GetXmlSerializer(elementType, localName, ns);
+			var serializer = CachedXmlSerializer.GetXmlSerializer(elementType, arrayItemName, arrayItemNamespace);
 
 			object result = null;
 
 			lock (serializer)
 			{
-				result = deserializeMethod.Invoke(null, new object[] { serializer, localName, ns, xmlReader });
+				result = deserializeMethod.Invoke(null, new object[] { serializer, arrayItemName, arrayItemNamespace, xmlReader });
 			}
 
-			//if (parameterInfo.ArrayItemName != null)
 			if (!isEmpty)
 			{
 				xmlReader.ReadEndElement();

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -599,7 +599,7 @@ namespace SoapCore
 								reader, member.MemberInfo.GetPropertyOrFieldType(),
 								member.MessageHeaderMemberAttribute.Name ?? member.MemberInfo.Name,
 								member.MessageHeaderMemberAttribute.Namespace ?? @namespace,
-								member.MemberInfo,//parameterInfo:pi,
+								member.MemberInfo,
 								serviceKnownTypes);
 
 							member.MemberInfo.SetValueToPropertyOrField(wrapperObject, value);

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -508,7 +508,7 @@ namespace SoapCore
 							parameterType,
 							parameterInfo.Name,
 							operation.Contract.Namespace,
-							parameterInfo,
+							parameterInfo.Parameter.Member,
 							serviceKnownTypes);
 
 						//fix https://github.com/DigDes/SoapCore/issues/379 (hack, need research)
@@ -519,7 +519,7 @@ namespace SoapCore
 								parameterType,
 								parameterInfo.Name,
 								parameterInfo.Namespace,
-								parameterInfo,
+								parameterInfo.Parameter.Member,
 								serviceKnownTypes);
 						}
 
@@ -570,7 +570,7 @@ namespace SoapCore
 							parameterInfo.Parameter.ParameterType,
 							parameterInfo.Name,
 							@namespace,
-							parameterInfo,
+							parameterInfo.Parameter.Member,
 							serviceKnownTypes);
 					}
 				}
@@ -595,15 +595,11 @@ namespace SoapCore
 						{
 							var reader = requestMessage.Headers.GetReaderAtHeader(i);
 
-							XmlArrayAttribute xmlArrayAttribute =  member.MemberInfo.GetCustomAttribute(typeof(XmlArrayAttribute)) as XmlArrayAttribute;
-							XmlArrayItemAttribute xmlArrayItemAttribute = member.MemberInfo.GetCustomAttribute(typeof(XmlArrayItemAttribute)) as XmlArrayItemAttribute;
-							var pi = new SoapMethodParameterInfo(parameterInfo.Parameter, 0, member.MemberInfo.Name, xmlArrayAttribute?.ElementName ?? member.MemberInfo.Name, xmlArrayItemAttribute?.ElementName, xmlArrayItemAttribute?.Namespace);
-
 							var value = _serializerHelper.DeserializeInputParameter(
 								reader, member.MemberInfo.GetPropertyOrFieldType(),
 								member.MessageHeaderMemberAttribute.Name ?? member.MemberInfo.Name,
 								member.MessageHeaderMemberAttribute.Namespace ?? @namespace,
-								parameterInfo:pi,
+								member.MemberInfo,//parameterInfo:pi,
 								serviceKnownTypes);
 
 							member.MemberInfo.SetValueToPropertyOrField(wrapperObject, value);
@@ -638,7 +634,7 @@ namespace SoapCore
 							innerParameterType,
 							innerParameterName,
 							innerParameterNs,
-							parameterInfo,
+							parameterInfo.Parameter.Member,
 							serviceKnownTypes);
 
 						messageBodyMemberInfo.SetValueToPropertyOrField(wrapperObject, innerParameter);

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -595,11 +595,15 @@ namespace SoapCore
 						{
 							var reader = requestMessage.Headers.GetReaderAtHeader(i);
 
+							XmlArrayAttribute xmlArrayAttribute =  member.MemberInfo.GetCustomAttribute(typeof(XmlArrayAttribute)) as XmlArrayAttribute;
+							XmlArrayItemAttribute xmlArrayItemAttribute = member.MemberInfo.GetCustomAttribute(typeof(XmlArrayItemAttribute)) as XmlArrayItemAttribute;
+							var pi = new SoapMethodParameterInfo(parameterInfo.Parameter, 0, member.MemberInfo.Name, xmlArrayAttribute?.ElementName ?? member.MemberInfo.Name, xmlArrayItemAttribute?.ElementName, xmlArrayItemAttribute?.Namespace);
+
 							var value = _serializerHelper.DeserializeInputParameter(
 								reader, member.MemberInfo.GetPropertyOrFieldType(),
 								member.MessageHeaderMemberAttribute.Name ?? member.MemberInfo.Name,
 								member.MessageHeaderMemberAttribute.Namespace ?? @namespace,
-								parameterInfo: null,
+								parameterInfo:pi,
 								serviceKnownTypes);
 
 							member.MemberInfo.SetValueToPropertyOrField(wrapperObject, value);


### PR DESCRIPTION
I found an issue where my messagecontract doesn't get deserialized using the XmlSerializer, because it contains an array type messageheader . My real world scenario even got different namespaces for the arrayitem and array itself that's why I also added this extra complexity to the testcase. 

Simplified example soap request for my case:
```xml 
<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
	<s:Header>
		<MyHeaderValue xmlns="http://sampleservice.net/webservices/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
			<ComplexModel1 xmlns="http://sampleservice.net/webservices/SomethingDifferent">
				<!-- some properties -->
			</ComplexModel1>
			<ComplexModel1 xmlns="http://sampleservice.net/webservices/SomethingDifferent">
				<!-- some properties -->
			</ComplexModel1>
		</MyHeaderValue>
	</s:Header>
	<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
		<!-- body -->
	</s:Body>
</s:Envelope>
```

This PR fixes the issue and adds an extra testcase.