### PR TITLE
Add support for WrapperName of the MessageContractAttribute

### DIFF
--- a/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
@@ -133,5 +133,9 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 		[OperationContract(Action = ServiceNamespace.Value + nameof(PingComplexMessageHeaderArray), ReplyAction = "*")]
 		[XmlSerializerFormat(SupportFaults = true)]
 		PingComplexMessageHeaderArrayResponse PingComplexMessageHeaderArray(PingComplexMessageHeaderArrayRequest request);
+
+		[OperationContract(Action = ServiceNamespace.Value + nameof(PingResponseWithMessageContractAttributeWrapperNameDifferentFromClass), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
+		PingComplexMessageMessageContractAttributeResponse PingResponseWithMessageContractAttributeWrapperNameDifferentFromClass(PingComplexMessageHeaderArrayRequest request);
 	}
 }

--- a/src/SoapCore.Tests/Serialization/Models.Xml/PingComplexMessageMessageContractAttributeResponse.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/PingComplexMessageMessageContractAttributeResponse.cs
@@ -1,0 +1,11 @@
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[MessageContract(WrapperName = "MyWrapperNameIsDifferentFromTheClass", WrapperNamespace = ServiceNamespace.Value, IsWrapped = true)]
+	public class PingComplexMessageMessageContractAttributeResponse
+	{
+		[MessageBodyMember(Namespace = ServiceNamespace.Value, Order = 0)]
+		public ComplexModel1 ComplexProperty { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
+++ b/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
@@ -741,5 +741,24 @@ namespace SoapCore.Tests.Serialization
 			pingComplexMessageHeaderArrayResult_client.ShouldNotBeNull();
 			_fixture.ServiceMock.Verify(x => x.PingComplexMessageHeaderArray(It.IsAny<PingComplexMessageHeaderArrayRequest>()), Times.Once());
 		}
+
+		[Theory]
+		[InlineData(SoapSerializer.XmlSerializer)]
+		public void TestPingResponseWithMessageContractAttributeWrapperNameDifferentFromClass(SoapSerializer soapSerializer)
+		{
+			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
+
+			_fixture.ServiceMock
+				.Setup(x => x.PingResponseWithMessageContractAttributeWrapperNameDifferentFromClass(It.IsAny<PingComplexMessageHeaderArrayRequest>()))
+				.Returns(
+					() => new PingComplexMessageMessageContractAttributeResponse { ComplexProperty = new ComplexModel1 { IntProperty = 291 } });
+
+			var result =
+				sampleServiceClient.PingResponseWithMessageContractAttributeWrapperNameDifferentFromClass(new PingComplexMessageHeaderArrayRequest());
+
+			// Verify method has been called
+			result.ShouldNotBeNull();
+			result.ComplexProperty.IntProperty.ShouldBe(291);
+		}
 	}
 }

--- a/src/SoapCore/ServiceBodyWriter.cs
+++ b/src/SoapCore/ServiceBodyWriter.cs
@@ -152,7 +152,7 @@ namespace SoapCore
 				var xmlRootAttr = resultType.GetTypeInfo().GetCustomAttributes<XmlRootAttribute>().FirstOrDefault();
 				var messageContractAttribute = resultType.GetTypeInfo().GetCustomAttribute<MessageContractAttribute>();
 
-				var xmlName = _operation.ReturnElementName
+				var xmlName = _operation.ReturnElementName ?? messageContractAttribute?.WrapperName
 					?? (needResponseEnvelope
 					? (string.IsNullOrWhiteSpace(xmlRootAttr?.ElementName)
 						? _resultName


### PR DESCRIPTION
I found an issue where my messagecontract doesn't get serialized well using the XmlSerializer. My responsemessage is wrapped and the `WrapperName` of the `MessageContractAttribute` is different from the class name. This results in an invalid soap body according to the XSD. Fixed the issue and added a test in this pull request.

Example scenario:
``` CSharp
[MessageContract(WrapperName = "MyWrapperNameIsDifferentFromTheClass", WrapperNamespace = ServiceNamespace.Value, IsWrapped = true)]
public class PingComplexMessageMessageContractAttributeResponse
```
Should result in:
``` Xml
 <MyWrapperNameIsDifferentFromTheClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://sampleservice.net/webservices/">
```