### PR TITLE
Resolve DigDes#531

### DIFF
--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -51,8 +51,8 @@
 		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
 		<PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
 		<PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.2" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework) == 'netcoreapp2.1'">
@@ -65,6 +65,7 @@
 
 	<ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.0' OR $(TargetFramework) == 'netcoreapp3.1'">
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.2" />
 		<PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
 		<PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
@@ -73,7 +74,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
 		<PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.5.31" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Resolve DigDes#531 by moving `Microsoft.AspNetCore.Http` version `2.2.2` into the `netcoreapp3.0` and `netcoreapp3.1` conditional `ItemGroup`. Revert to 
 Asp.NET Core 2.1 compatible Microsoft.Extensions.DependencyInjection.Abstractions and Microsoft.Extensions.Logging.Abstractions versions. This will make it again possible to host SoapCore under the .NET Framework and AspNetCore 2.1.