### PR TITLE
Scoped ServiceCollection methods

### DIFF
--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -339,6 +339,13 @@ namespace SoapCore
 			return serviceCollection;
 		}
 
+		public static IServiceCollection AddSoapMessageInspector<TService>(this IServiceCollection serviceCollection)
+			where TService : class, IMessageInspector2
+		{
+			serviceCollection.AddScoped<IMessageInspector2, TService>();
+			return serviceCollection;
+		}
+
 		public static IServiceCollection AddSoapMessageInspector(this IServiceCollection serviceCollection, IMessageInspector2 messageInspector)
 		{
 			serviceCollection.AddSingleton(messageInspector);
@@ -360,6 +367,13 @@ namespace SoapCore
 		public static IServiceCollection AddSoapModelBindingFilter(this IServiceCollection serviceCollection, IModelBindingFilter modelBindingFilter)
 		{
 			serviceCollection.TryAddSingleton(modelBindingFilter);
+			return serviceCollection;
+		}
+
+		public static IServiceCollection AddSoapServiceOperationTuner<TService>(this IServiceCollection serviceCollection)
+			where TService : class, IServiceOperationTuner
+		{
+			serviceCollection.AddScoped<IServiceOperationTuner, TService>();
 			return serviceCollection;
 		}
 


### PR DESCRIPTION
Adding extension methods to allow an IMessageInspector2 or IServiceOperationTuner to be added as a scoped service allows the implementations to resolve other dependencies.

