### PR TITLE
Accept any order of request arguments

### DIFF
--- a/src/SoapCore.Tests/RequestArgumentsOrder/IOriginalParametersOrderService.cs
+++ b/src/SoapCore.Tests/RequestArgumentsOrder/IOriginalParametersOrderService.cs
@@ -1,0 +1,11 @@
+using System.ServiceModel;
+
+namespace SoapCore.Tests.RequestArgumentsOrder
+{
+	[ServiceContract(Namespace = ServiceNamespace.Value)]
+	public interface IOriginalParametersOrderService
+	{
+		[OperationContract]
+		string TwoStringParameters(string first, string second);
+	}
+}

--- a/src/SoapCore.Tests/RequestArgumentsOrder/IReversedParametersOrderService.cs
+++ b/src/SoapCore.Tests/RequestArgumentsOrder/IReversedParametersOrderService.cs
@@ -1,0 +1,11 @@
+using System.ServiceModel;
+
+namespace SoapCore.Tests.RequestArgumentsOrder
+{
+	[ServiceContract(Namespace = ServiceNamespace.Value)]
+	public interface IReversedParametersOrderService
+	{
+		[OperationContract]
+		string TwoStringParameters(string second, string first);
+	}
+}

--- a/src/SoapCore.Tests/RequestArgumentsOrder/RequestArgumentsOrderTests.cs
+++ b/src/SoapCore.Tests/RequestArgumentsOrder/RequestArgumentsOrderTests.cs
@@ -1,0 +1,52 @@
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace SoapCore.Tests.RequestArgumentsOrder
+{
+	public class RequestArgumentsOrderTests : IClassFixture<ServiceFixture<IOriginalParametersOrderService, IReversedParametersOrderService>>
+	{
+		private readonly ServiceFixture<IOriginalParametersOrderService, IReversedParametersOrderService> _fixture;
+
+		public RequestArgumentsOrderTests(ServiceFixture<IOriginalParametersOrderService, IReversedParametersOrderService> fixture)
+		{
+			_fixture = fixture;
+		}
+
+		[Theory]
+		[MemberData(nameof(ServiceFixture<IOriginalParametersOrderService, IReversedParametersOrderService>.SoapSerializersList), MemberType = typeof(ServiceFixture<IOriginalParametersOrderService, IReversedParametersOrderService>))]
+		public void TestOriginalParametersOrder(SoapSerializer soapSerializer)
+		{
+			var client = _fixture.GetOriginalRequestArgumentsOrderClient(soapSerializer);
+
+			_fixture.ServiceMock
+				.Setup(x => x.TwoStringParameters(It.IsAny<string>(), It.IsAny<string>()))
+				.Callback(
+					(string first, string second) =>
+					{
+						first.ShouldBe("1");
+						second.ShouldBe("2");
+					});
+
+			client.TwoStringParameters(first: "1", second: "2");
+		}
+
+		[Theory]
+		[MemberData(nameof(ServiceFixture<IOriginalParametersOrderService, IReversedParametersOrderService>.SoapSerializersList), MemberType = typeof(ServiceFixture<IOriginalParametersOrderService, IReversedParametersOrderService>))]
+		public void TestReversedParametersOrder(SoapSerializer soapSerializer)
+		{
+			var client = _fixture.GetReversedRequestArgumentsOrderClient(soapSerializer);
+
+			_fixture.ServiceMock
+				.Setup(x => x.TwoStringParameters(It.IsAny<string>(), It.IsAny<string>()))
+				.Callback(
+					(string first, string second) =>
+					{
+						first.ShouldBe("1");
+						second.ShouldBe("2");
+					});
+
+			client.TwoStringParameters(second: "2", first: "1");
+		}
+	}
+}

--- a/src/SoapCore.Tests/RequestArgumentsOrder/ServiceFixture.cs
+++ b/src/SoapCore.Tests/RequestArgumentsOrder/ServiceFixture.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.ServiceModel;
+using System.Threading;
+using System.Xml;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace SoapCore.Tests.RequestArgumentsOrder
+{
+	public class ServiceFixture<TOriginalParametersOrderService, TReversedParametersOrderService> : IDisposable
+		where TOriginalParametersOrderService : class
+		where TReversedParametersOrderService : class
+	{
+		private readonly IWebHost _host;
+		private readonly Dictionary<SoapSerializer, TOriginalParametersOrderService> _originalRequestArgumentsOrderClients;
+		private readonly Dictionary<SoapSerializer, TReversedParametersOrderService> _reversedRequestArgumentsOrderClients;
+
+		public ServiceFixture()
+		{
+			var binding = new BasicHttpBinding
+			{
+				MaxReceivedMessageSize = int.MaxValue,
+				ReaderQuotas = XmlDictionaryReaderQuotas.Max
+			};
+
+			// start service host
+			_host = new WebHostBuilder()
+				.ConfigureServices(services =>
+				{
+					// init service mock
+					ServiceMock = new Mock<TOriginalParametersOrderService>();
+					services.AddSingleton(ServiceMock.Object);
+					services.AddSoapCore();
+					services.AddMvc();
+				})
+				.Configure(appBuilder =>
+				{
+#if ASPNET_21
+					appBuilder.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.svc", binding, SoapSerializer.DataContractSerializer);
+					appBuilder.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.asmx", binding, SoapSerializer.XmlSerializer);
+					appBuilder.UseMvc();
+#endif
+
+#if ASPNET_30
+					appBuilder.UseRouting();
+
+					appBuilder.UseEndpoints(x =>
+					{
+						x.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.svc", binding, SoapSerializer.DataContractSerializer);
+						x.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.asmx", binding, SoapSerializer.XmlSerializer);
+					});
+#endif
+				})
+				.UseKestrel()
+				.UseUrls($"http://127.0.0.1:0")
+				.UseContentRoot(Directory.GetCurrentDirectory())
+				.Build();
+
+			var task = _host.RunAsync();
+
+			while (true)
+			{
+				if (_host != null)
+				{
+					if (task.IsFaulted && task.Exception != null)
+					{
+						throw task.Exception;
+					}
+
+					if (!task.IsCompleted || !task.IsCanceled)
+					{
+						if (!_host.ServerFeatures.Get<IServerAddressesFeature>().Addresses.First().EndsWith(":0"))
+						{
+							break;
+						}
+					}
+				}
+
+				Thread.Sleep(2000);
+			}
+
+			var addresses = _host.ServerFeatures.Get<IServerAddressesFeature>();
+			var address = addresses.Addresses.Single();
+
+			//make clients
+			_originalRequestArgumentsOrderClients = InitClients<TOriginalParametersOrderService>(binding, address);
+			_reversedRequestArgumentsOrderClients = InitClients<TReversedParametersOrderService>(binding, address);
+		}
+
+		public Mock<TOriginalParametersOrderService> ServiceMock { get; private set; }
+
+		public static IEnumerable<object[]> SoapSerializersList()
+		{
+			foreach (var soapSerializer in Enum.GetValues(typeof(SoapSerializer)))
+			{
+				yield return new[] { soapSerializer };
+			}
+		}
+
+		public TOriginalParametersOrderService GetOriginalRequestArgumentsOrderClient(SoapSerializer soapSerializer)
+		{
+			return _originalRequestArgumentsOrderClients[soapSerializer];
+		}
+
+		public TReversedParametersOrderService GetReversedRequestArgumentsOrderClient(SoapSerializer soapSerializer)
+		{
+			return _reversedRequestArgumentsOrderClients[soapSerializer];
+		}
+
+		public void Dispose()
+		{
+			_host.StopAsync();
+		}
+
+		private Dictionary<SoapSerializer, TService> InitClients<TService>(BasicHttpBinding binding, string address)
+		{
+			var endpointXml = new EndpointAddress(new Uri($"{address}/Service.asmx"));
+			var channelFactoryXml = new ChannelFactory<TService>(binding, endpointXml);
+			var serviceClientXml = channelFactoryXml.CreateChannel();
+
+			var endpointDC = new EndpointAddress(new Uri($"{address}/Service.svc"));
+			var channelFactoryDC = new ChannelFactory<TService>(binding, endpointDC);
+			var serviceClientDc = channelFactoryDC.CreateChannel();
+
+			return new Dictionary<SoapSerializer, TService>
+			{
+				[SoapSerializer.XmlSerializer] = serviceClientXml,
+				[SoapSerializer.DataContractSerializer] = serviceClientDc
+			};
+		}
+	}
+}

--- a/src/SoapCore.Tests/RequestArgumentsOrder/ServiceNamespace.cs
+++ b/src/SoapCore.Tests/RequestArgumentsOrder/ServiceNamespace.cs
@@ -1,0 +1,7 @@
+namespace SoapCore.Tests.RequestArgumentsOrder
+{
+	public static class ServiceNamespace
+	{
+		public const string Value = "http://service.net/webservices/";
+	}
+}

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -166,6 +166,7 @@ namespace SoapCore
 		}
 #endif
 #if ASPNET_30
+
 		private static Task WriteMessageAsync(SoapMessageEncoder messageEncoder, Message responseMessage, HttpContext httpContext)
 		{
 			return messageEncoder.WriteMessageAsync(responseMessage, httpContext.Response.BodyWriter);
@@ -175,6 +176,7 @@ namespace SoapCore
 		{
 			return messageEncoder.ReadMessageAsync(httpContext.Request.BodyReader, 0x10000, httpContext.Request.ContentType);
 		}
+
 #endif
 
 		private async Task ProcessMeta(HttpContext httpContext)
@@ -466,7 +468,7 @@ namespace SoapCore
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private object[] GetRequestArguments(Message requestMessage, System.Xml.XmlDictionaryReader xmlReader, OperationDescription operation, HttpContext httpContext)
+		private object[] GetRequestArguments(Message requestMessage, XmlDictionaryReader xmlReader, OperationDescription operation, HttpContext httpContext)
 		{
 			var arguments = new object[operation.AllParameters.Length];
 
@@ -474,57 +476,47 @@ namespace SoapCore
 				.GetServiceKnownTypesHierarchy()
 				.Select(x => x.Type);
 
-			// if any ordering issues, possible to rewrite like:
-			/*while (!xmlReader.EOF)
-			{
-				var parameterInfo = operation.InParameters.FirstOrDefault(p => p.Name == xmlReader.LocalName && p.Namespace == xmlReader.NamespaceURI);
-				if (parameterInfo == null)
-				{
-					xmlReader.Skip();
-					continue;
-				}
-				var parameterName = parameterInfo.Name;
-				var parameterNs = parameterInfo.Namespace;
-				...
-			}*/
-
-			// Find the element for the operation's data
 			if (!operation.IsMessageContractRequest)
 			{
 				xmlReader.ReadStartElement(operation.Name, operation.Contract.Namespace);
-
-				foreach (var parameterInfo in operation.InParameters)
+				while (!xmlReader.EOF)
 				{
+					var parameterInfo = operation.InParameters.FirstOrDefault(p => p.Name == xmlReader.LocalName);
+					if (parameterInfo == null)
+					{
+						xmlReader.Skip();
+						continue;
+					}
+
 					var parameterType = parameterInfo.Parameter.ParameterType;
 
-					if (parameterType == typeof(HttpContext))
+					var argumentValue = _serializerHelper.DeserializeInputParameter(
+						xmlReader,
+						parameterType,
+						parameterInfo.Name,
+						operation.Contract.Namespace,
+						parameterInfo.Parameter.Member,
+						serviceKnownTypes);
+
+					//fix https://github.com/DigDes/SoapCore/issues/379 (hack, need research)
+					if (argumentValue == null)
 					{
-						arguments[parameterInfo.Index] = httpContext;
-					}
-					else
-					{
-						var argumentValue = _serializerHelper.DeserializeInputParameter(
+						argumentValue = _serializerHelper.DeserializeInputParameter(
 							xmlReader,
 							parameterType,
 							parameterInfo.Name,
-							operation.Contract.Namespace,
+							parameterInfo.Namespace,
 							parameterInfo.Parameter.Member,
 							serviceKnownTypes);
-
-						//fix https://github.com/DigDes/SoapCore/issues/379 (hack, need research)
-						if (argumentValue == null)
-						{
-							argumentValue = _serializerHelper.DeserializeInputParameter(
-								xmlReader,
-								parameterType,
-								parameterInfo.Name,
-								parameterInfo.Namespace,
-								parameterInfo.Parameter.Member,
-								serviceKnownTypes);
-						}
-
-						arguments[parameterInfo.Index] = argumentValue;
 					}
+
+					arguments[parameterInfo.Index] = argumentValue;
+				}
+
+				var httpContextParameter = operation.InParameters.FirstOrDefault(x => x.Parameter.ParameterType == typeof(HttpContext));
+				if (httpContextParameter != default)
+				{
+					arguments[httpContextParameter.Index] = httpContext;
 				}
 			}
 			else


### PR DESCRIPTION
This PR adds the ability for clients to put request argument in different order. Now an order of request arguments needn't match the order of parameters defined in service.
Issue #543