### PR TITLE
Write error response message when encountering an invalid schema

### DIFF
--- a/src/SoapCore.Tests/RawRequestSoap12Tests.cs
+++ b/src/SoapCore.Tests/RawRequestSoap12Tests.cs
@@ -255,6 +255,50 @@ namespace SoapCore.Tests
 			}
 		}
 
+		[TestMethod]
+		public async Task Soap12InvalidSchema()
+		{
+			var body = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<soap12:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:soap12=""http://www.w3.org/2003/05/soap-envelope"">
+  <soap12:Body>
+    <NotValid xmlns=""http://tempuri.org/"">
+      <detailMessage>Detail message</detailMessage>
+    </NotValid>
+  </soap12:Body>
+</soap12:Envelope>
+";
+			using (var host = CreateTestHost())
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body, Encoding.UTF8, "application/soap+xml"))
+			using (var response = await host.CreateRequest("/Service.svc").And(msg => msg.Content = content).PostAsync())
+			{
+				Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+
+				var responseBodyStream = await response.Content.ReadAsStreamAsync();
+				var document = XDocument.Load(responseBodyStream);
+
+				var faultElement = document
+					.Element(XName.Get("Envelope", "http://www.w3.org/2003/05/soap-envelope"))
+					.Element(XName.Get("Body", "http://www.w3.org/2003/05/soap-envelope"))
+					.Element(XName.Get("Fault", "http://www.w3.org/2003/05/soap-envelope"));
+
+				var codeElement =
+					faultElement.Element(XName.Get("Code", "http://www.w3.org/2003/05/soap-envelope"));
+
+				Assert.IsNotNull(codeElement);
+				Assert.AreEqual("s:Sender", codeElement.Value);
+
+				var reasonElementText =
+					faultElement
+						.Element(XName.Get("Reason", "http://www.w3.org/2003/05/soap-envelope"))
+						.Elements(XName.Get("Text", "http://www.w3.org/2003/05/soap-envelope"));
+
+				Assert.IsNotNull(reasonElementText);
+				Assert.AreEqual(1, reasonElementText.Count());
+				Assert.AreEqual("No operation found for specified action: NotValid", reasonElementText.First().Value);
+			}
+		}
+
 		private TestServer CreateTestHost()
 		{
 			var webHostBuilder = new WebHostBuilder()

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -291,7 +291,9 @@ namespace SoapCore
 				var operation = _service.Operations.FirstOrDefault(o => o.SoapAction.Equals(soapAction, StringComparison.Ordinal) || o.Name.Equals(soapAction, StringComparison.Ordinal));
 				if (operation == null)
 				{
-					throw new InvalidOperationException($"No operation found for specified action: {requestMessage.Headers.Action}");
+					var ex = new InvalidOperationException($"No operation found for specified action: {requestMessage.Headers.Action}");
+					await WriteErrorResponseMessage(ex, StatusCodes.Status500InternalServerError, serviceProvider, requestMessage, messageEncoder, httpContext);
+					return;
 				}
 
 				_logger.LogInformation($"Request for operation {operation.Contract.Name}.{operation.Name} received");


### PR DESCRIPTION
If the schema format is not correct, an exception is thrown, instead of a proper soap response, this is fixed by creating an exception and using `WriteErrorResponseMessage`