### PR TITLE
Fix, getting service description from asmx with classes with no members

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/EmptyMembers.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/EmptyMembers.cs
@@ -1,0 +1,10 @@
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[System.ServiceModel.MessageContractAttribute(IsWrapped = false)]
+	public class EmptyMembers
+	{
+		public EmptyMembers()
+		{
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/IOperationContractEmptyMembersService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IOperationContractEmptyMembersService.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface IOperationContractEmptyMembersService
+	{
+		[OperationContract]
+		string Method(EmptyMembers members);
+	}
+
+	public class OperationContractEmptyMembersService : IOperationContractEmptyMembersService
+	{
+		public string Method(EmptyMembers members)
+		{
+			return "OK";
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -147,6 +147,29 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[TestMethod]
+		public void CheckEmptyMembersServiceASMX()
+		{
+			//This did not work without fixing the MetaBodyWriter
+			StartService(typeof(OperationContractEmptyMembersService));
+			var wsdl = GetWsdlFromAsmx();
+			StopServer();
+
+			var root = XElement.Parse(wsdl);
+			Assert.IsNotNull(root);
+		}
+
+		[TestMethod]
+		public void CheckEmptyMembersService()
+		{
+			StartService(typeof(OperationContractEmptyMembersService));
+			var wsdl = GetWsdl();
+			StopServer();
+
+			var root = XElement.Parse(wsdl);
+			Assert.IsNotNull(root);
+		}
+
+		[TestMethod]
 		public void CheckStructsInList()
 		{
 			StartService(typeof(StructService));

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -111,8 +111,10 @@ namespace SoapCore.Meta
 						.Where(x => x.MessageBodyMemberAttribute != null)
 						.OrderBy(x => x.MessageBodyMemberAttribute.Order)
 						.ToList();
-
-				return messageBodyMembers[0].Member.GetPropertyOrFieldType();
+				if (messageBodyMembers.Count > 0)
+				{
+					return messageBodyMembers[0].Member.GetPropertyOrFieldType();
+				}
 			}
 
 			return type;


### PR DESCRIPTION
Hi,
Here is a possible fix for the issue #565 

Seams like the code required a class to always have a member. Introduced a check and that solved my problem.
Tried to create some relevant tests.

