### PR TITLE
Support for parameterless operation contracts

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/EmptyMembers.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/EmptyMembers.cs
@@ -1,0 +1,10 @@
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[System.ServiceModel.MessageContractAttribute(IsWrapped = false)]
+	public class EmptyMembers
+	{
+		public EmptyMembers()
+		{
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/IOperationContractEmptyMembersService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IOperationContractEmptyMembersService.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface IOperationContractEmptyMembersService
+	{
+		[OperationContract]
+		string Method(EmptyMembers members);
+	}
+
+	public class OperationContractEmptyMembersService : IOperationContractEmptyMembersService
+	{
+		public string Method(EmptyMembers members)
+		{
+			return "OK";
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -147,6 +147,29 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[TestMethod]
+		public void CheckEmptyMembersServiceASMX()
+		{
+			//This did not work without fixing the MetaBodyWriter
+			StartService(typeof(OperationContractEmptyMembersService));
+			var wsdl = GetWsdlFromAsmx();
+			StopServer();
+
+			var root = XElement.Parse(wsdl);
+			Assert.IsNotNull(root);
+		}
+
+		[TestMethod]
+		public void CheckEmptyMembersService()
+		{
+			StartService(typeof(OperationContractEmptyMembersService));
+			var wsdl = GetWsdl();
+			StopServer();
+
+			var root = XElement.Parse(wsdl);
+			Assert.IsNotNull(root);
+		}
+
+		[TestMethod]
 		public void CheckStructsInList()
 		{
 			StartService(typeof(StructService));

--- a/src/SoapCore/HeadersHelper.cs
+++ b/src/SoapCore/HeadersHelper.cs
@@ -86,7 +86,7 @@ namespace SoapCore
 					}
 				}
 
-				if (string.IsNullOrEmpty(soapAction))
+				if (string.IsNullOrEmpty(soapAction) && reader != null)
 				{
 					soapAction = reader.LocalName;
 				}

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -96,6 +96,16 @@ namespace SoapCore.Meta
 
 		private static Type GetMessageContractBodyType(Type type)
 		{
+			if (!TryGetMessageContractBodyType(type, out var bodyType))
+			{
+				throw new InvalidOperationException(nameof(type));
+			}
+
+			return bodyType;
+		}
+
+		private static bool TryGetMessageContractBodyType(Type type, out Type bodyType)
+		{
 			var messageContractAttribute = type.GetCustomAttribute<MessageContractAttribute>();
 
 			if (messageContractAttribute != null && !messageContractAttribute.IsWrapped)
@@ -112,10 +122,20 @@ namespace SoapCore.Meta
 						.OrderBy(x => x.MessageBodyMemberAttribute.Order)
 						.ToList();
 
-				return messageBodyMembers[0].Member.GetPropertyOrFieldType();
+				if (messageBodyMembers.Count > 0)
+				{
+					bodyType = messageBodyMembers[0].Member.GetPropertyOrFieldType();
+					return true;
+				}
+				else
+				{
+					bodyType = null;
+					return false;
+				}
 			}
 
-			return type;
+			bodyType = type;
+			return true;
 		}
 
 		private XmlQualifiedName ResolveType(Type type)
@@ -224,10 +244,11 @@ namespace SoapCore.Meta
 				}
 				else
 				{
-					var messageBodyType = GetMessageContractBodyType(parameterInfo.Parameter.ParameterType);
-
-					writer.WriteAttributeString("type", "tns:" + messageBodyType.Name);
-					_complexTypeToBuild.Enqueue(new TypeToBuild(parameterInfo.Parameter.ParameterType));
+					if (TryGetMessageContractBodyType(parameterInfo.Parameter.ParameterType, out var messageBodyType))
+					{
+						writer.WriteAttributeString("type", "tns:" + messageBodyType.Name);
+						_complexTypeToBuild.Enqueue(new TypeToBuild(parameterInfo.Parameter.ParameterType));
+					}
 				}
 			}
 
@@ -447,22 +468,32 @@ namespace SoapCore.Meta
 			foreach (var operation in _service.Operations)
 			{
 				// input
+				var hasRequestBody = false;
 				var requestTypeName = operation.Name;
 
 				if (operation.IsMessageContractRequest && operation.InParameters.Length > 0)
 				{
 					if (!IsWrappedMessageContractType(operation.InParameters[0].Parameter.ParameterType))
 					{
-						requestTypeName = GetMessageContractBodyType(operation.InParameters[0].Parameter.ParameterType).Name;
+						hasRequestBody = TryGetMessageContractBodyType(operation.InParameters[0].Parameter.ParameterType, out var requestType);
+						if (hasRequestBody)
+						{
+							requestTypeName = requestType.Name;
+						}
 					}
 				}
 
 				writer.WriteStartElement("wsdl", "message", Namespaces.WSDL_NS);
 				writer.WriteAttributeString("name", $"{BindingType}_{operation.Name}_InputMessage");
-				writer.WriteStartElement("wsdl", "part", Namespaces.WSDL_NS);
-				writer.WriteAttributeString("name", "parameters");
-				writer.WriteAttributeString("element", "tns:" + requestTypeName);
-				writer.WriteEndElement(); // wsdl:part
+
+				if (hasRequestBody)
+				{
+					writer.WriteStartElement("wsdl", "part", Namespaces.WSDL_NS);
+					writer.WriteAttributeString("name", "parameters");
+					writer.WriteAttributeString("element", "tns:" + requestTypeName);
+					writer.WriteEndElement(); // wsdl:part
+				}
+
 				writer.WriteEndElement(); // wsdl:message
 
 				var responseTypeName = operation.Name + "Response";

--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<Description>SOAP protocol middleware for ASP.NET Core</Description>
-		<VersionPrefix>1.1.0.4</VersionPrefix>
+		<VersionPrefix>1.1.0.5</VersionPrefix>
 		<Authors>Digital Design</Authors>
 		<TargetFrameworks>netcoreapp3.0;netstandard2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 		<AssemblyName>SoapCore</AssemblyName>
@@ -14,7 +14,7 @@
 		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-		<Version>1.1.0.4</Version>
+		<Version>1.1.0.5</Version>
 		<DelaySign>false</DelaySign>
 		<AssemblyOriginatorKeyFile>SoapCore.snk</AssemblyOriginatorKeyFile>
 		<SignAssembly>true</SignAssembly>


### PR DESCRIPTION
PR for #567 - Support for parameterless operation contracts. 
This adds support for request params, not sure if needed for responses.