### PR TITLE
Handle calls to operations without arguments. with .Net Framework client

### DIFF
--- a/src/SoapCore.Tests/ITestService.cs
+++ b/src/SoapCore.Tests/ITestService.cs
@@ -87,5 +87,8 @@ namespace SoapCore.Tests
 		[ServiceKnownType(typeof(ComplexModelInput))]
 		[OperationContract]
 		object ObjectFromServiceKnownType(ComplexModelInput value);
+
+		[OperationContract]
+		string EmpryBody(EmptyMembers members);
 	}
 }

--- a/src/SoapCore.Tests/IntegrationTests.cs
+++ b/src/SoapCore.Tests/IntegrationTests.cs
@@ -69,6 +69,14 @@ namespace SoapCore.Tests
 		}
 
 		[TestMethod]
+		public void EmptyArgsASMX()
+		{
+			var client = CreateClientASMX();
+			var result = client.EmptyArgs();
+			Assert.AreEqual("EmptyArgs", result);
+		}
+
+		[TestMethod]
 		public void SingleInt()
 		{
 			var client = CreateClient();
@@ -277,11 +285,30 @@ namespace SoapCore.Tests
 			Assert.AreEqual("Detail message", e.Detail.ExceptionProperty);
 		}
 
+		[TestMethod]
+		public void EmptyBody()
+		{
+			var client = CreateClientASMX();
+			EmptyMembers empty_members = new EmptyMembers();
+			var result = client.EmpryBody(null);
+			Assert.AreEqual("OK", result);
+		}
+
 		private ITestService CreateClient(bool caseInsensitivePath = false)
 		{
 			var binding = new BasicHttpBinding();
 			var endpoint = new EndpointAddress(new Uri(
 				string.Format("http://{0}:5050/{1}.svc", "localhost", caseInsensitivePath ? "serviceci" : "Service")));
+			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);
+			var serviceClient = channelFactory.CreateChannel();
+			return serviceClient;
+		}
+
+		private ITestService CreateClientASMX(bool caseInsensitivePath = false)
+		{
+			var binding = new BasicHttpBinding();
+			var endpoint = new EndpointAddress(new Uri(
+				string.Format("http://{0}:5050/{1}.asmx", "localhost", caseInsensitivePath ? "serviceci" : "Service")));
 			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);
 			var serviceClient = channelFactory.CreateChannel();
 			return serviceClient;

--- a/src/SoapCore.Tests/Model/EmptyMembers.cs
+++ b/src/SoapCore.Tests/Model/EmptyMembers.cs
@@ -1,4 +1,6 @@
-namespace SoapCore.Tests.Wsdl.Services
+using System.Runtime.Serialization;
+
+namespace SoapCore.Tests.Model
 {
 	//[System.ServiceModel.MessageContractAttribute(IsWrapped = false)]
 	public class EmptyMembers

--- a/src/SoapCore.Tests/TestService.cs
+++ b/src/SoapCore.Tests/TestService.cs
@@ -173,5 +173,10 @@ namespace SoapCore.Tests
 
 			return value;
 		}
+
+		public string EmpryBody(EmptyMembers members)
+		{
+			return "OK";
+		}
 	}
 }


### PR DESCRIPTION
After fixing service description for clients without empty/no arguments, I got a problem calling this operations from .Net Framework. Same problem even if I use a client generated from wsdl.exe or web reference, so I think there is nothing wrong in the service description.
What happen is that the incoming requestMessage is empty and got no reader, then the request failed.
I introduced a check not trying to get the reader in these cases and now the code can continue.
I tried to add some tests to detect this but I did not succeed, instead the test more confirms that this does not happen with a WCF client. This because all test uses WCF/Service Model. 