### PR TITLE
#567 Support for parameterless operation contracts.

### DIFF
--- a/src/SoapCore.Tests/RawRequestSoap11Tests.cs
+++ b/src/SoapCore.Tests/RawRequestSoap11Tests.cs
@@ -11,7 +11,7 @@ namespace SoapCore.Tests
 	public class RawRequestSoap11Tests
 	{
 		[TestMethod]
-		public async Task Soap11PingEmptyArgs()
+		public async Task Soap11EmptyArgs()
 		{
 			const string body = @"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"">
   <soapenv:Header/>

--- a/src/SoapCore.Tests/RawRequestSoap11Tests.cs
+++ b/src/SoapCore.Tests/RawRequestSoap11Tests.cs
@@ -1,0 +1,65 @@
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SoapCore.Tests
+{
+	[TestClass]
+	public class RawRequestSoap11Tests
+	{
+		[TestMethod]
+		public async Task Soap11PingEmptyArgs()
+		{
+			const string body = @"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"">
+  <soapenv:Header/>
+  <soapenv:Body/>
+</soapenv:Envelope>
+";
+
+			using (var host = CreateTestHost())
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body, Encoding.UTF8, "text/xml"))
+			using (var res = host.CreateRequest("/Service.svc").AddHeader("SOAPAction", @"""EmptyArgs""").And(msg => msg.Content = content).PostAsync().Result)
+			{
+				res.EnsureSuccessStatusCode();
+
+				var response = await res.Content.ReadAsStringAsync();
+				Assert.IsTrue(response.Contains("EmptyArgs"));
+			}
+		}
+
+		[TestMethod]
+		public async Task Soap11Ping()
+		{
+			var pingValue = "abc";
+			var body = $@"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"">
+  <soapenv:Body>
+    <Ping xmlns=""http://tempuri.org/"">
+      <s>{pingValue}</s>
+    </Ping>
+  </soapenv:Body>
+</soapenv:Envelope>
+";
+			using (var host = CreateTestHost())
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body, Encoding.UTF8, "text/xml"))
+			using (var res = host.CreateRequest("/Service.svc").AddHeader("SOAPAction", @"""Ping""").And(msg => msg.Content = content).PostAsync().Result)
+			{
+				res.EnsureSuccessStatusCode();
+
+				var response = await res.Content.ReadAsStringAsync();
+				Assert.IsTrue(response.Contains(pingValue));
+			}
+		}
+
+		private TestServer CreateTestHost()
+		{
+			var webHostBuilder = new WebHostBuilder()
+				.UseStartup<Startup>();
+			return new TestServer(webHostBuilder);
+		}
+	}
+}

--- a/src/SoapCore/HeadersHelper.cs
+++ b/src/SoapCore/HeadersHelper.cs
@@ -86,7 +86,7 @@ namespace SoapCore
 					}
 				}
 
-				if (string.IsNullOrEmpty(soapAction))
+				if (string.IsNullOrEmpty(soapAction) && reader != null)
 				{
 					soapAction = reader.LocalName;
 				}

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -282,9 +282,15 @@ namespace SoapCore
 				return;
 			}
 
-			// for getting soapaction and parameters in body
+			// for getting soapaction and parameters in (optional) body
 			// GetReaderAtBodyContents must not be called twice in one request
-			using (var reader = requestMessage.GetReaderAtBodyContents())
+			XmlDictionaryReader reader = null;
+			if (!requestMessage.IsEmpty)
+			{
+				reader = requestMessage.GetReaderAtBodyContents();
+			}
+
+			try
 			{
 				var soapAction = HeadersHelper.GetSoapAction(httpContext, reader);
 				requestMessage.Headers.Action = soapAction;
@@ -306,7 +312,7 @@ namespace SoapCore
 					SetMessageHeadersToProperty(requestMessage, serviceInstance);
 
 					// Get operation arguments from message
-					var arguments = GetRequestArguments(requestMessage, reader, operation, httpContext);
+					var arguments = requestMessage.IsEmpty ? Array.Empty<object>() : GetRequestArguments(requestMessage, reader, operation, httpContext);
 
 					ExecuteFiltersAndTune(httpContext, serviceProvider, operation, arguments, serviceInstance);
 
@@ -349,6 +355,10 @@ namespace SoapCore
 					_logger.LogError(0, exception, exception?.Message);
 					responseMessage = await WriteErrorResponseMessage(exception, StatusCodes.Status500InternalServerError, serviceProvider, requestMessage, messageEncoder, httpContext);
 				}
+			}
+			finally
+			{
+				reader?.Dispose();
 			}
 
 			// Execute response message filters


### PR DESCRIPTION
PR for #567 - Support for parameterless operation contracts.

Adding support for parameterless requests which currently fail, at least in soap11. Also created some raw soap11 request tests for proofing.

This PR replaces #569, which i closed due to git related issues.
