### PR TITLE
Handle arguments on MessageContract

### DIFF
--- a/src/SoapCore.Tests/MessageContract/IServiceWithMessageContract.cs
+++ b/src/SoapCore.Tests/MessageContract/IServiceWithMessageContract.cs
@@ -1,0 +1,13 @@
+using System.ServiceModel;
+using System.Threading.Tasks;
+using SoapCore.Tests.OperationDescription.Model;
+
+namespace SoapCore.Tests.MessageContract
+{
+	[ServiceContract]
+	public interface IServiceWithMessageContract
+	{
+		[OperationContract]
+		string EmptyRequest(Model.MessageContractRequestEmpty req);
+	}
+}

--- a/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
+++ b/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
@@ -1,0 +1,41 @@
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SoapCore.Tests.MessageContract
+{
+	[TestClass]
+	public class RawRequestSoap11Tests
+	{
+		[TestMethod]
+		public async Task Soap11MessageContractEmpty()
+		{
+			const string body = @"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"">
+  <soapenv:Header/>
+  <soapenv:Body/>
+</soapenv:Envelope>
+";
+
+			using (var host = CreateTestHost())
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body, Encoding.UTF8, "text/xml"))
+			using (var res = host.CreateRequest("/Service.svc").AddHeader("SOAPAction", @"""EmptyRequest""").And(msg => msg.Content = content).PostAsync().Result)
+			{
+				res.EnsureSuccessStatusCode();
+
+				var response = await res.Content.ReadAsStringAsync();
+				Assert.IsTrue(response.Contains("EmptyRequest"));
+			}
+		}
+
+		private TestServer CreateTestHost()
+		{
+			var webHostBuilder = new WebHostBuilder()
+				.UseStartup<Startup>();
+			return new TestServer(webHostBuilder);
+		}
+	}
+}

--- a/src/SoapCore.Tests/MessageContract/Startup.cs
+++ b/src/SoapCore.Tests/MessageContract/Startup.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using SoapCore.Tests.Model;
+
+namespace SoapCore.Tests.MessageContract
+{
+	public class Startup
+	{
+		public void ConfigureServices(IServiceCollection services)
+		{
+			services.AddSoapCore();
+			services.TryAddSingleton<TestService>();
+			services.AddSoapModelBindingFilter(new ModelBindingFilter.TestModelBindingFilter(new List<Type> { typeof(ComplexModelInputForModelBindingFilter) }));
+			services.AddScoped<ActionFilter.TestActionFilter>();
+			services.AddMvc();
+		}
+
+#if ASPNET_21
+		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+		{
+			app.UseWhen(ctx => ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
+			{
+				app2.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+			});
+
+			app.UseWhen(ctx => ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
+			{
+				// For case insensitive path test
+				app2.UseSoapEndpoint<TestService>("/ServiceCI.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer, caseInsensitivePath: true);
+			});
+
+			app.UseWhen(ctx => !ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
+			{
+				var transportBinding = new HttpTransportBindingElement();
+				var textEncodingBinding = new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, System.Text.Encoding.UTF8);
+				app.UseSoapEndpoint<TestService>("/Service.svc", new CustomBinding(transportBinding, textEncodingBinding), SoapSerializer.DataContractSerializer);
+			});
+
+			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("asmx"), app2 =>
+			{
+				app2.UseSoapEndpoint<TestService>("/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
+			});
+
+			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("/WSA10Service.svc"), app2 =>
+			{
+				var transportBinding = new HttpTransportBindingElement();
+				var textEncodingBinding = new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, System.Text.Encoding.UTF8);
+
+				app.UseSoapEndpoint<TestService>("/WSA10Service.svc", new CustomBinding(transportBinding, textEncodingBinding), SoapSerializer.DataContractSerializer);
+			});
+
+			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("/WSA11ISO88591Service.svc"), app2 =>
+			{
+				var soapEncodingOptions = new SoapEncoderOptions
+				{
+					MessageVersion = MessageVersion.Soap11,
+					WriteEncoding = Encoding.GetEncoding("ISO-8859-1")
+				};
+
+				app.UseSoapEndpoint<TestService>("/WSA11ISO88591Service.svc", soapEncodingOptions, SoapSerializer.DataContractSerializer);
+			});
+
+			app.UseMvc();
+		}
+#endif
+
+#if ASPNET_30
+		public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
+		{
+			app.UseRouting();
+
+			app.UseWhen(ctx => ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
+			{
+				app2.UseRouting();
+
+				app2.UseEndpoints(x =>
+				{
+					x.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+				});
+			});
+
+			app.UseWhen(ctx => ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
+			{
+				app2.UseRouting();
+
+				app2.UseEndpoints(x =>
+				{
+					x.UseSoapEndpoint<TestService>("/ServiceCI.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer, caseInsensitivePath: true);
+				});
+			});
+
+			app.UseWhen(ctx => !ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
+			{
+				var transportBinding = new HttpTransportBindingElement();
+				var textEncodingBinding = new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, System.Text.Encoding.UTF8);
+
+				app2.UseRouting();
+
+				app2.UseEndpoints(x =>
+				{
+					x.UseSoapEndpoint<TestService>("/Service.svc", new CustomBinding(transportBinding, textEncodingBinding), SoapSerializer.DataContractSerializer);
+				});
+			});
+
+			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("asmx"), app2 =>
+			{
+				app2.UseRouting();
+
+				app2.UseSoapEndpoint<TestService>("/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
+			});
+
+			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("/WSA10Service.svc"), app2 =>
+			{
+				var transportBinding = new HttpTransportBindingElement();
+				var textEncodingBinding = new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, System.Text.Encoding.UTF8);
+
+				app2.UseRouting();
+
+				app.UseSoapEndpoint<TestService>("/WSA10Service.svc", new CustomBinding(transportBinding, textEncodingBinding), SoapSerializer.DataContractSerializer);
+			});
+
+			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("/WSA11ISO88591Service.svc"), app2 =>
+			{
+				var soapEncodingOptions = new SoapEncoderOptions
+				{
+					MessageVersion = MessageVersion.Soap11,
+					WriteEncoding = Encoding.GetEncoding("ISO-8859-1")
+				};
+
+				app.UseSoapEndpoint<TestService>("/WSA11ISO88591Service.svc", soapEncodingOptions, SoapSerializer.DataContractSerializer);
+			});
+		}
+#endif
+	}
+}

--- a/src/SoapCore.Tests/MessageContract/TestService.cs
+++ b/src/SoapCore.Tests/MessageContract/TestService.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using SoapCore.Tests.Model;
+
+namespace SoapCore.Tests.MessageContract
+{
+	public class TestService : IServiceWithMessageContract
+	{
+		public string EmptyRequest(MessageContractRequestEmpty req)
+		{
+			return "OK";
+		}
+	}
+}

--- a/src/SoapCore.Tests/Model/EmptyMembers.cs
+++ b/src/SoapCore.Tests/Model/EmptyMembers.cs
@@ -1,8 +1,8 @@
 using System.Runtime.Serialization;
+using System.ServiceModel;
 
 namespace SoapCore.Tests.Model
 {
-	//[System.ServiceModel.MessageContractAttribute(IsWrapped = false)]
 	public class EmptyMembers
 	{
 		public EmptyMembers()

--- a/src/SoapCore.Tests/Model/MessageContractRequestEmpty.cs
+++ b/src/SoapCore.Tests/Model/MessageContractRequestEmpty.cs
@@ -1,0 +1,13 @@
+using System.Runtime.Serialization;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Model
+{
+	[MessageContract(IsWrapped = false)]
+	public class MessageContractRequestEmpty
+	{
+		public MessageContractRequestEmpty()
+		{
+		}
+	}
+}


### PR DESCRIPTION
This handles empty MessageContracts added test to ensure it continues to work.
Should correct the problems related #567 