### PR TITLE
Fix MessageContract Serialization WSDL Generation.

### DIFF
--- a/src/SoapCore.Tests/MessageContract/Models/IServiceWithMessageContractComplexNotWrapped.cs
+++ b/src/SoapCore.Tests/MessageContract/Models/IServiceWithMessageContractComplexNotWrapped.cs
@@ -1,0 +1,13 @@
+using System;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.MessageContract.Models
+{
+	[ServiceContract(Namespace = "http://tempuri.org")]
+	public interface IServiceWithMessageContractComplexNotWrapped
+	{
+		[OperationContract]
+		[XmlSerializerFormat(SupportFaults = true)]
+		Model.MessageContractResponseNotWrapped PostData(Model.MessageContractRequestComplexNotWrapped req);
+	}
+}

--- a/src/SoapCore.Tests/MessageContract/TestServiceComplexNotWrapped.cs
+++ b/src/SoapCore.Tests/MessageContract/TestServiceComplexNotWrapped.cs
@@ -1,0 +1,16 @@
+using System;
+using SoapCore.Tests.MessageContract.Models;
+using SoapCore.Tests.Model;
+
+namespace SoapCore.Tests.MessageContract
+{
+	public class TestServiceComplexNotWrapped : IServiceWithMessageContractComplexNotWrapped
+	{
+		public MessageContractResponseNotWrapped PostData(MessageContractRequestComplexNotWrapped req)
+		{
+			MessageContractResponseNotWrapped ret = new MessageContractResponseNotWrapped();
+			ret.ReferenceNumber = req.PostData.IntProperty;
+			return ret;
+		}
+	}
+}

--- a/src/SoapCore.Tests/Model/MessageContractRequestComplexNotWrapped.cs
+++ b/src/SoapCore.Tests/Model/MessageContractRequestComplexNotWrapped.cs
@@ -1,0 +1,12 @@
+using System;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Model
+{
+	[MessageContract(IsWrapped = false)]
+	public class MessageContractRequestComplexNotWrapped
+	{
+		[MessageBodyMember]
+		public ComplexModelInput PostData { get; set; }
+	}
+}

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -291,7 +291,7 @@ namespace SoapCore.Meta
 					if (TryGetMessageContractBodyType(parameterInfo.Parameter.ParameterType, out var messageBodyType))
 					{
 						writer.WriteAttributeString("type", "tns:" + messageBodyType.Name);
-						_complexTypeToBuild.Enqueue(new TypeToBuild(parameterInfo.Parameter.ParameterType));
+						_complexTypeToBuild.Enqueue(new TypeToBuild(messageBodyType));
 					}
 				}
 			}


### PR DESCRIPTION
When creating the WSDL for input messages that are MessageContracts (with the Wrapped property set to false), the WSDL would have the incorrect type. It would have the outer message type, rather than the inner type so the WSDL could not be consumed by clients like SoapUI.