### PR TITLE
fix: examination of prefixes for generated namespace imports

### DIFF
--- a/src/SoapCore/Meta/MetaFromFile.cs
+++ b/src/SoapCore/Meta/MetaFromFile.cs
@@ -57,15 +57,15 @@ namespace SoapCore.Meta
 
 			foreach (XmlNode node in xmlDoc.DocumentElement.ChildNodes)
 			{
-				if (node.Name == "types")
+				if (node.Name == (!string.IsNullOrWhiteSpace(xmlDoc.DocumentElement.Prefix) ? xmlDoc.DocumentElement.Prefix + ":" : xmlDoc.DocumentElement.Prefix) + "types")
 				{
 					foreach (XmlNode schemaNode in node.ChildNodes)
 					{
-						if (schemaNode.Name == "xs:schema")
+						if (schemaNode.Name == (!string.IsNullOrWhiteSpace(schemaNode.Prefix) ? schemaNode.Prefix + ":" : schemaNode.Prefix) + "schema")
 						{
 							foreach (XmlNode importNode in schemaNode.ChildNodes)
 							{
-								if (importNode.Name == "xs:import")
+								if (importNode.Name == (!string.IsNullOrWhiteSpace(importNode.Prefix) ? importNode.Prefix + ":" : importNode.Prefix) + "import")
 								{
 									string name = importNode.Attributes["schemaLocation"].InnerText;
 									importNode.Attributes["schemaLocation"].InnerText = SchemaLocation() + "&name=" + name.Replace("./", string.Empty);
@@ -75,11 +75,11 @@ namespace SoapCore.Meta
 					}
 				}
 
-				if (node.Name == "service")
+				if (node.Name == (!string.IsNullOrWhiteSpace(xmlDoc.DocumentElement.Prefix) ? xmlDoc.DocumentElement.Prefix + ":" : xmlDoc.DocumentElement.Prefix) + "service")
 				{
 					foreach (XmlNode schemaNode in node.ChildNodes)
 					{
-						if (schemaNode.Name == "port")
+						if (schemaNode.Name == (!string.IsNullOrWhiteSpace(schemaNode.Prefix) ? schemaNode.Prefix + ":" : schemaNode.Prefix) + "port")
 						{
 							foreach (XmlNode soapAdressNode in schemaNode.ChildNodes)
 							{
@@ -101,7 +101,7 @@ namespace SoapCore.Meta
 
 			foreach (XmlNode node in xmlDoc.DocumentElement.ChildNodes)
 			{
-				if (node.Name == "xs:import")
+				if (node.Name == (!string.IsNullOrWhiteSpace(node.Prefix) ? node.Prefix + ":" : node.Prefix) + "import")
 				{
 					string name = node.Attributes["schemaLocation"].InnerText;
 					node.Attributes["schemaLocation"].InnerText = SchemaLocation() + "&name=" + name.Replace("./", string.Empty);


### PR DESCRIPTION
Hello,

I've got problem with different namespaces which started with prefixes.
for example:

``` xml
<wsdl:definitions xmlns:tns="urn:myNamespace:ws"
	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
	xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="myType"
	targetNamespace="urn:myNamespace:ws"
	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
	xmlns:xsd1="myType:types">
	<wsdl:types>
		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
			<xsd:import namespace="urn:myNamespace"
				schemaLocation="myXsdFile.xsd">
			</xsd:import>
		</xsd:schema>
	</wsdl:types>
	<wsdl:message
		name="ElementRequest">
		<wsdl:part name="parameters"
			element="xsd1:MyRequest"></wsdl:part>
	</wsdl:message>
	<wsdl:message
		name="ElementResponse">
		<wsdl:part name="parameters"
			element="xsd1:ElementResponse"></wsdl:part>
	</wsdl:message>
	<wsdl:portType name="myPortType">
(operations)
	</wsdl:portType>

<...>
</wsdl:definitions>
```

With default code service couldn't export WSDL properly without changes in wsdl and xsd files. I can't change nothing in those files so I wrote this fix to manage different namespaces.
We use Your NuGet packages in our organization so it would be nice to see this fix in main branch.