### PR TITLE
Fix issue with container-less arrays on MessageContracts

### DIFF
--- a/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
@@ -76,6 +76,10 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 		[XmlSerializerFormat(SupportFaults = true)]
 		UnwrappedStringMessageBodyMemberResponse TestUnwrappedStringMessageBodyMember(BasicMessageContractPayload x);
 
+		[OperationContract(Action = ServiceNamespace.Value + nameof(TestMessageContractWithArrays), ReplyAction = "*")]
+		[XmlSerializerFormat(SupportFaults = true)]
+		MessageContractResponseWithArrays TestMessageContractWithArrays(MessageContractRequestWithArrays request);
+
 		[OperationContract(Action = ServiceNamespace.Value + nameof(EnumMethod), ReplyAction = "*")]
 		[XmlSerializerFormat(SupportFaults = true)]
 		bool EnumMethod(out SampleEnum e);

--- a/src/SoapCore.Tests/Serialization/Models.Xml/MessageContractRequestWithArrays.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/MessageContractRequestWithArrays.cs
@@ -1,0 +1,60 @@
+using System.ServiceModel;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[MessageContract(WrapperName = "MessageContractWithArrays", WrapperNamespace = "http://xmlelement-namespace/", IsWrapped = true)]
+	public class MessageContractRequestWithArrays
+	{
+		[MessageHeader(Namespace = "http://xmlelement-namespace/")]
+		public ComplexModel1 Header { get; set; }
+
+		[MessageBodyMember(Namespace = "http://xmlelement-namespace/", Order = 0)]
+		[XmlElement("ArrayWithoutContainers")]
+		public ComplexModel1[] ArrayWithoutContainers { get; set; }
+
+		[MessageBodyMember(Namespace = "http://xmlelement-namespace/", Order = 1)]
+		[XmlArray("ArrayWithContainers")]
+		[XmlArrayItem("ComplexModel1")]
+		public ComplexModel1[] ArrayWithContainers { get; set; }
+
+		[MessageBodyMember(Namespace = "http://xmlelement-namespace/", Order = 2)]
+		[XmlElement("ObjectArrayWithoutContainers")]
+		public ComplexObject[] ObjectArrayWithoutContainers { get; set; }
+
+		[MessageBodyMember(Namespace = "http://xmlelement-namespace/", Order = 3)]
+		[XmlArray("ObjectArrayWithContainers")]
+		[XmlArrayItem("ComplexObject")]
+		public ComplexObject[] ObjectArrayWithContainers { get; set; }
+
+		public static MessageContractRequestWithArrays CreateSample()
+			=> new MessageContractRequestWithArrays
+			{
+				Header = ComplexModel1.CreateSample1(),
+				ArrayWithoutContainers = new[]
+				{
+					ComplexModel1.CreateSample1(),
+					ComplexModel1.CreateSample2(),
+					ComplexModel1.CreateSample3()
+				},
+				ArrayWithContainers = new[]
+				{
+					ComplexModel1.CreateSample1(),
+					ComplexModel1.CreateSample2(),
+					ComplexModel1.CreateSample3()
+				},
+				ObjectArrayWithoutContainers = new[]
+				{
+					ComplexObject.CreateSample1(),
+					ComplexObject.CreateSample2(),
+					ComplexObject.CreateSample3(),
+				},
+				ObjectArrayWithContainers = new[]
+				{
+					ComplexObject.CreateSample1(),
+					ComplexObject.CreateSample2(),
+					ComplexObject.CreateSample3(),
+				},
+			};
+	}
+}

--- a/src/SoapCore.Tests/Serialization/Models.Xml/MessageContractRequestWithArrays.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/MessageContractRequestWithArrays.cs
@@ -27,6 +27,15 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 		[XmlArrayItem("ComplexObject")]
 		public ComplexObject[] ObjectArrayWithContainers { get; set; }
 
+		[MessageBodyMember(Namespace = "http://xmlelement-namespace/", Order = 4)]
+		[XmlElement("EmptyArrayWithoutContainers")]
+		public ComplexModel1[] EmptyArrayWithoutContainers { get; set; }
+
+		[MessageBodyMember(Namespace = "http://xmlelement-namespace/", Order = 5)]
+		[XmlArray("EmptyArrayWithContainers")]
+		[XmlArrayItem("ComplexModel1")]
+		public ComplexModel1[] EmptyArrayWithContainers { get; set; }
+
 		public static MessageContractRequestWithArrays CreateSample()
 			=> new MessageContractRequestWithArrays
 			{
@@ -55,6 +64,8 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 					ComplexObject.CreateSample2(),
 					ComplexObject.CreateSample3(),
 				},
+				EmptyArrayWithoutContainers = new ComplexModel1[0],
+				EmptyArrayWithContainers = new ComplexModel1[0]
 			};
 	}
 }

--- a/src/SoapCore.Tests/Serialization/Models.Xml/MessageContractResponseWithArrays.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/MessageContractResponseWithArrays.cs
@@ -26,6 +26,15 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 		[XmlArrayItem("ComplexObject")]
 		public ComplexObject[] ObjectArrayWithContainers { get; set; }
 
+		[MessageBodyMember(Namespace = "http://xmlelement-namespace/", Order = 4)]
+		[XmlElement("EmptyArrayWithoutContainers")]
+		public ComplexModel1[] EmptyArrayWithoutContainers { get; set; }
+
+		[MessageBodyMember(Namespace = "http://xmlelement-namespace/", Order = 5)]
+		[XmlArray("EmptyArrayWithContainers")]
+		[XmlArrayItem("ComplexModel1")]
+		public ComplexModel1[] EmptyArrayWithContainers { get; set; }
+
 		public static MessageContractResponseWithArrays CreateSample()
 			=> new MessageContractResponseWithArrays
 			{
@@ -53,6 +62,8 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 					ComplexObject.CreateSample2(),
 					ComplexObject.CreateSample3(),
 				},
+				EmptyArrayWithoutContainers = new ComplexModel1[0],
+				EmptyArrayWithContainers = new ComplexModel1[0]
 			};
 	}
 }

--- a/src/SoapCore.Tests/Serialization/Models.Xml/MessageContractResponseWithArrays.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/MessageContractResponseWithArrays.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Serialization.Models.Xml
+{
+	[MessageContract(WrapperName = "MessageContractResponseWithArrays", WrapperNamespace = "http://xmlelement-namespace/", IsWrapped = true)]
+	public class MessageContractResponseWithArrays
+	{
+		[MessageBodyMember(Namespace = "http://xmlelement-namespace/", Order = 0)]
+		[XmlElement("ArrayWithoutContainers")]
+		public ComplexModel1[] ArrayWithoutContainers { get; set; }
+
+		[MessageBodyMember(Namespace = "http://xmlelement-namespace/", Order = 1)]
+		[XmlArray("ArrayWithContainers")]
+		[XmlArrayItem("ComplexModel1")]
+		public ComplexModel1[] ArrayWithContainers { get; set; }
+
+		[MessageBodyMember(Namespace = "http://xmlelement-namespace/", Order = 2)]
+		[XmlElement("ObjectArrayWithoutContainers")]
+		public ComplexObject[] ObjectArrayWithoutContainers { get; set; }
+
+		[MessageBodyMember(Namespace = "http://xmlelement-namespace/", Order = 3)]
+		[XmlArray("ObjectArrayWithContainers")]
+		[XmlArrayItem("ComplexObject")]
+		public ComplexObject[] ObjectArrayWithContainers { get; set; }
+
+		public static MessageContractResponseWithArrays CreateSample()
+			=> new MessageContractResponseWithArrays
+			{
+				ArrayWithoutContainers = new[]
+				{
+					ComplexModel1.CreateSample1(),
+					ComplexModel1.CreateSample2(),
+					ComplexModel1.CreateSample3()
+				},
+				ArrayWithContainers = new[]
+				{
+					ComplexModel1.CreateSample1(),
+					ComplexModel1.CreateSample2(),
+					ComplexModel1.CreateSample3()
+				},
+				ObjectArrayWithoutContainers = new[]
+				{
+					ComplexObject.CreateSample1(),
+					ComplexObject.CreateSample2(),
+					ComplexObject.CreateSample3(),
+				},
+				ObjectArrayWithContainers = new[]
+				{
+					ComplexObject.CreateSample1(),
+					ComplexObject.CreateSample2(),
+					ComplexObject.CreateSample3(),
+				},
+			};
+	}
+}

--- a/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
+++ b/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
@@ -205,6 +205,30 @@ namespace SoapCore.Tests.Serialization
 
 		[Theory]
 		[InlineData(SoapSerializer.XmlSerializer)]
+		public void TestMessageContractWithArrays(SoapSerializer soapSerializer)
+		{
+			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
+
+			_fixture.ServiceMock
+				.Setup(x => x.TestMessageContractWithArrays(It.IsAny<MessageContractRequestWithArrays>()))
+				.Callback(
+					(MessageContractRequestWithArrays inputModel_service) =>
+					{
+						// check input paremeters serialization
+						inputModel_service.ShouldDeepEqual(MessageContractRequestWithArrays.CreateSample());
+					})
+				.Returns(() => MessageContractResponseWithArrays.CreateSample());
+
+			var pingComplexModelResult_client =
+				sampleServiceClient
+					.TestMessageContractWithArrays(MessageContractRequestWithArrays.CreateSample());
+
+			// check output paremeters serialization
+			pingComplexModelResult_client.ShouldDeepEqual(MessageContractResponseWithArrays.CreateSample());
+		}
+
+		[Theory]
+		[InlineData(SoapSerializer.XmlSerializer)]
 		public void TestPingComplexArrayModel(SoapSerializer soapSerializer)
 		{
 			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);

--- a/src/SoapCore/SerializerHelper.cs
+++ b/src/SoapCore/SerializerHelper.cs
@@ -58,6 +58,11 @@ namespace SoapCore
 				}
 			}
 
+			if (parameterType.IsArray)
+			{
+				return Array.CreateInstance(parameterType.GetElementType(), 0);
+			}
+
 			return null;
 		}
 

--- a/src/SoapCore/SerializerHelper.cs
+++ b/src/SoapCore/SerializerHelper.cs
@@ -109,13 +109,18 @@ namespace SoapCore
 		private object DeserializeArrayXmlSerializer(System.Xml.XmlDictionaryReader xmlReader, Type parameterType, string parameterName, string parameterNs, MemberInfo memberInfo)
 		{
 			XmlArrayItemAttribute xmlArrayItemAttribute = memberInfo.GetCustomAttribute(typeof(XmlArrayItemAttribute)) as XmlArrayItemAttribute;
+			XmlElementAttribute xmlElementAttribute = memberInfo.GetCustomAttribute(typeof(XmlElementAttribute)) as XmlElementAttribute;
 
 			var isEmpty = xmlReader.IsEmptyElement;
-			xmlReader.ReadStartElement(parameterName, parameterNs);
+			var hasContainerElement = xmlElementAttribute == null;
+			if (!isEmpty && hasContainerElement)
+			{
+				xmlReader.ReadStartElement(parameterName, parameterNs);
+			}
 
 			var elementType = parameterType.GetElementType();
 
-			var arrayItemName = xmlArrayItemAttribute?.ElementName ?? elementType.Name;
+			var arrayItemName = xmlArrayItemAttribute?.ElementName ?? xmlElementAttribute?.ElementName ?? elementType.Name;
 			if (xmlArrayItemAttribute?.ElementName == null && elementType.Namespace?.StartsWith("System") == true)
 			{
 				var compiler = new CSharpCodeProvider();
@@ -135,7 +140,7 @@ namespace SoapCore
 				result = deserializeMethod.Invoke(null, new object[] { serializer, arrayItemName, arrayItemNamespace, xmlReader });
 			}
 
-			if (!isEmpty)
+			if (!isEmpty && hasContainerElement)
 			{
 				xmlReader.ReadEndElement();
 			}

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -662,7 +662,7 @@ namespace SoapCore
 							innerParameterType,
 							innerParameterName,
 							innerParameterNs,
-							parameterInfo.Parameter.Member,
+							messageBodyMemberInfo,
 							serviceKnownTypes);
 
 						messageBodyMemberInfo.SetValueToPropertyOrField(wrapperObject, innerParameter);


### PR DESCRIPTION
This PR solves an issue with serializing arrays without a container element on MessageContracts that contains MessageHeader properties. 

The issue was discovered when trying to use a contract generated from wsdl with the `dotnet-svcutil`. The generated code uses MessageContracts with MessageHeaders, which triggers special logic in the SoapCore XmlSerializer.

An example of a failing contract could look like this (A similar example has been added to the unit tests):
```csharp
[MessageContract]
public class Contract
{
    [MessageHeader]
    public ComplexModel1 Header { get; set; }

    [MessageBodyMember]
    [XmlElement("Array")]
    public ComplexModel1[] Array { get; set; }

    [MessageBodyMember]
    public ComplexModel SomeOtherMember { get; set; }
}
```

Which renders the Array elements side-by-side without a container element, like this:
```xml
<Contract>
    <Array>...</Array> 
    <Array>...</Array>
    <Array>...</Array>
    <SomeOtherMember>...</SomeOtherMember>
</Contract>
```

The fix includes:
* Passing the correct `MemberInfo` to `DeserializeInputParameter()`
* Prevent reading container element if array has the `XmlElementAttribute` which indicate that there is no container element.
* Use the element name from `XmlElementAttribute` if present.
* Add logic for returning empty arrays instead of null.
