### PR TITLE
Fix a couple of bugs found when importing existing WSDL

### DIFF
--- a/src/SoapCore/Meta/MetaFromFile.cs
+++ b/src/SoapCore/Meta/MetaFromFile.cs
@@ -67,6 +67,11 @@ namespace SoapCore.Meta
 							{
 								if (importNode.Name == (!string.IsNullOrWhiteSpace(importNode.Prefix) ? importNode.Prefix + ":" : importNode.Prefix) + "import")
 								{
+									if (importNode.Attributes["schemaLocation"] == null)
+									{
+										importNode.Attributes.Append(xmlDoc.CreateAttribute("schemaLocation"));
+									}
+
 									string name = importNode.Attributes["schemaLocation"].InnerText;
 									importNode.Attributes["schemaLocation"].InnerText = SchemaLocation() + "&name=" + name.Replace("./", string.Empty);
 								}

--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -181,7 +181,7 @@ namespace SoapCore
 
 		public static IEndpointConventionBuilder UseSoapEndpoint<T>(this IEndpointRouteBuilder routes, string path, Binding binding, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null)
 		{
-			return routes.UseSoapEndpoint(typeof(T), path, binding, serializer, caseInsensitivePath, soapModelBounder);
+			return routes.UseSoapEndpoint(typeof(T), path, binding, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions: wsdlFileOptions);
 		}
 
 		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, Binding binding, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null)


### PR DESCRIPTION
I am working on integrating this library with an existing [WSDL](https://soapapi.litmusapp.com/2010-06-21/api.asmx?WSDL) and ran into a couple of bugs.

First this `UseSoapEndpoint` extension was not passing the `WsdlFileOptions` to the wrapped function.

The second bug I ran into was a case where the existing WSDL didn't have a `schemaLocation` which triggered a null reference exception.  I handled this case by adding the attribute, but I'd also be open to doing nothing if the attribute is missing.

