### PR TITLE
Allow TrailingServicePathTuner to be overridden

### DIFF
--- a/src/SoapCore/TrailingServicePathTuner.cs
+++ b/src/SoapCore/TrailingServicePathTuner.cs
@@ -13,7 +13,7 @@ namespace SoapCore
 	/// </summary>
 	public class TrailingServicePathTuner
 	{
-		public void ConvertPath(HttpContext httpContext)
+		public virtual void ConvertPath(HttpContext httpContext)
 		{
 			string trailingPath = httpContext.Request.Path.Value.Substring(httpContext.Request.Path.Value.LastIndexOf('/'));
 			httpContext.Request.Path = new PathString(trailingPath);


### PR DESCRIPTION
I need to be able to support paths to keep parity with an [existing implementation](https://soapapi.litmusapp.com/2010-06-21/api.asmx).  The current implementation of `TrailingServicePathTuner` doesn't allow for that.  By making `ConvertPath` virtual I can provide my own implementation and override this logic.