### PR TITLE
#614 ParameterInfo.Name is used when XmlRootElementName ist an empty string. This fixes a deserialization problem.

### DIFF
--- a/src/SoapCore.Tests/OperationDescription/IServiceWithMessageContractAndEmptyXmlRoot.cs
+++ b/src/SoapCore.Tests/OperationDescription/IServiceWithMessageContractAndEmptyXmlRoot.cs
@@ -1,0 +1,17 @@
+using SoapCore.Tests.OperationDescription.Model;
+
+namespace SoapCore.Tests.OperationDescription
+{
+	/// <summary>
+	/// Interface to test OperationDescription.cs functionality.
+	/// </summary>
+	public interface IServiceWithMessageContractAndEmptyXmlRoot : IServiceWithMessageContract
+	{
+		/// <summary>
+		/// Returns a class with an empty string as XMLRoot element.
+		/// </summary>
+		/// <param name="classWithXmlRoot">Class with empty string as XMLRoot element.</param>
+		/// <returns><see cref="ClassWithEmptyXmlRoot"/> instance used in a test.</returns>
+		ClassWithEmptyXmlRoot GetClassWithEmptyXmlRoot(ClassWithEmptyXmlRoot classWithXmlRoot);
+	}
+}

--- a/src/SoapCore.Tests/OperationDescription/Model/ClassWithEmptyXmlRoot.cs
+++ b/src/SoapCore.Tests/OperationDescription/Model/ClassWithEmptyXmlRoot.cs
@@ -1,0 +1,16 @@
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.OperationDescription.Model
+{
+	/// <summary>
+	/// Test stub to test the operation description parameter extraction with emtpy XmlRootElementName.
+	/// </summary>
+	[XmlRoot(ElementName = "")]
+	public class ClassWithEmptyXmlRoot
+	{
+		/// <summary>
+		/// Gets or sets SomeString.
+		/// </summary>
+		public string SomeString { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/OperationDescription/OperationDescriptionTests.cs
+++ b/src/SoapCore.Tests/OperationDescription/OperationDescriptionTests.cs
@@ -39,6 +39,21 @@ namespace SoapCore.Tests
 		}
 
 		[Fact]
+		public void TestSupportXmlRootForParameterNameWithEmptyStringAsRootElementNameUsesParameterInfoToExtractAName()
+		{
+			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContractAndEmptyXmlRoot));
+			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContractAndEmptyXmlRoot), new ServiceContractAttribute());
+
+			System.Reflection.MethodInfo method = typeof(IServiceWithMessageContractAndEmptyXmlRoot).GetMethod(nameof(IServiceWithMessageContractAndEmptyXmlRoot.GetClassWithEmptyXmlRoot));
+
+			OperationContractAttribute contractAttribute = new OperationContractAttribute();
+
+			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute);
+
+			Assert.Equal("classWithXmlRoot", operationDescription.AllParameters.FirstOrDefault()?.Name);
+		}
+
+		[Fact]
 		public void TestProperUnrappingOfNonGenericResponses()
 		{
 			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract));

--- a/src/SoapCore/ServiceModel/OperationDescription.cs
+++ b/src/SoapCore/ServiceModel/OperationDescription.cs
@@ -105,12 +105,19 @@ namespace SoapCore.ServiceModel
 			var arrayAttribute = info.GetCustomAttribute<XmlArrayAttribute>();
 			var rootAttribute = (XmlRootAttribute)Attribute.GetCustomAttribute(info.ParameterType, typeof(XmlRootAttribute));
 			var arrayItemAttribute = info.GetCustomAttribute<XmlArrayItemAttribute>();
-			var parameterName = elementAttribute?.ElementName
-				?? arrayAttribute?.ElementName
-				?? rootAttribute?.ElementName
-				?? info.GetCustomAttribute<MessageParameterAttribute>()?.Name
-				?? info.ParameterType.GetCustomAttribute<MessageContractAttribute>()?.WrapperName
-				?? info.Name;
+
+			var parameterName = string.IsNullOrEmpty(elementAttribute?.ElementName)
+				? string.IsNullOrEmpty(arrayAttribute?.ElementName)
+					? string.IsNullOrEmpty(rootAttribute?.ElementName)
+						? string.IsNullOrEmpty(info.GetCustomAttribute<MessageParameterAttribute>()?.Name)
+							? string.IsNullOrEmpty(info.ParameterType.GetCustomAttribute<MessageContractAttribute>()?.WrapperName)
+								? info.Name
+								: info.ParameterType.GetCustomAttribute<MessageContractAttribute>().WrapperName
+							: info.GetCustomAttribute<MessageParameterAttribute>().Name
+						: rootAttribute.ElementName
+					: arrayAttribute.ElementName
+				: elementAttribute.ElementName;
+
 			var arrayName = arrayAttribute?.ElementName;
 			var arrayItemName = arrayItemAttribute?.ElementName;
 			var parameterNs = elementAttribute?.Form == XmlSchemaForm.Unqualified


### PR DESCRIPTION
I don't know if it is a common problem. I noticed it as the cause of broken communication that works in version 1.0.0.