### PR TITLE
Fix for #625 Support deserialization from base64 to byte[] in input parameters. Ad…

### DIFF
--- a/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
+++ b/src/SoapCore.Tests/Serialization/Models.Xml/ISampleService.cs
@@ -107,6 +107,10 @@ namespace SoapCore.Tests.Serialization.Models.Xml
 
 		[OperationContract]
 		[XmlSerializerFormat]
+		byte[] PingByteArray(byte[] array);
+
+		[OperationContract]
+		[XmlSerializerFormat]
 		ComplexModel1[] PingComplexModelArray(ComplexModel1[] models, ComplexModel2[] models2);
 
 		[OperationContract]

--- a/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
+++ b/src/SoapCore.Tests/Serialization/XmlSerializationTests.cs
@@ -280,6 +280,22 @@ namespace SoapCore.Tests.Serialization
 			result.ShouldDeepEqual(data);
 		}
 
+		[Theory]
+		[InlineData(SoapSerializer.XmlSerializer)]
+		public void TestPingByteArray(SoapSerializer soapSerializer)
+		{
+			var sampleServiceClient = _fixture.GetSampleServiceClient(soapSerializer);
+
+			var data = Encoding.ASCII.GetBytes("Test");
+
+			_fixture.ServiceMock
+				.Setup(x => x.PingByteArray(It.IsAny<byte[]>()))
+				.Callback((byte[] input) => { input.ShouldDeepEqual(data); })
+				.Returns(data);
+			var result = sampleServiceClient.PingByteArray(data);
+			result.ShouldDeepEqual(data);
+		}
+
 		[Theory(Skip = "test not correct")]
 		[InlineData(SoapSerializer.XmlSerializer)]
 		public void TestPingStringArrayWithXmlArray(SoapSerializer soapSerializer)

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -537,7 +537,7 @@ namespace SoapCore
 							parameterType,
 							parameterInfo.Name,
 							operation.Contract.Namespace,
-							parameterInfo.Parameter.Member,
+							parameterInfo.Parameter,
 							serviceKnownTypes);
 
 						//fix https://github.com/DigDes/SoapCore/issues/379 (hack, need research)
@@ -548,7 +548,7 @@ namespace SoapCore
 								parameterType,
 								parameterInfo.Name,
 								parameterInfo.Namespace,
-								parameterInfo.Parameter.Member,
+								parameterInfo.Parameter,
 								serviceKnownTypes);
 						}
 
@@ -609,7 +609,7 @@ namespace SoapCore
 							parameterInfo.Parameter.ParameterType,
 							messageContractAttribute.WrapperName ?? parameterInfo.Parameter.ParameterType.Name,
 							messageContractAttribute.WrapperNamespace ?? @namespace,
-							parameterInfo.Parameter.Member,
+							parameterInfo.Parameter,
 							serviceKnownTypes);
 					}
 				}


### PR DESCRIPTION
- Support deserialization from base64 to byte[] in input parameters
- Byte array unit test
- Fix XmlArray and XmlElement attribute reading for input parameters, before method attributes were used instead of parameter attributes. Depend on ICustomAttributeProvider instead of MemberInfo in DeserializeArrayXmlSerializer. (Introduced in https://github.com/DigDes/SoapCore/commit/54bc556f96a94218e873ee4b44a8425fc029f573#diff-8bb22c90c9d99146addfac0efb111b8fa0a045dd97ce8b670e18185d9e520340) If you debug you can see that MemberInfo is from method not a parameter, and we want to get parameter attributes as I understand.