### PR TITLE
Fix wsdl input message type

### DIFF
--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -549,7 +549,7 @@ namespace SoapCore.Meta
 				writer.WriteStartElement("wsdl", "message", Namespaces.WSDL_NS);
 				writer.WriteAttributeString("name", $"{BindingType}_{operation.Name}_InputMessage");
 
-				if (hasRequestBody)
+				if ((operation.IsMessageContractRequest && hasRequestBody) || !operation.IsMessageContractRequest)
 				{
 					writer.WriteStartElement("wsdl", "part", Namespaces.WSDL_NS);
 					writer.WriteAttributeString("name", "parameters");


### PR DESCRIPTION
WSDL input parameters generation has been broken since version 1.1.0.6. Before that version for the `XmlSerializer`, generated WSDL was correct. Broken WSDL creates empty soap envelope, doesn't allow to scrape input types correctly.

My change respects `MessageContract` attribute and added logic for that attribute, but allows to generate proper input type if attribute is not present. Empty args tests are passing too.

The breaking change was introduced in this PR https://github.com/DigDes/SoapCore/commit/da453249adac0248efec83ae1a809943215c790f

Related issue - https://github.com/DigDes/SoapCore/issues/600