### PR TITLE
Nullable array error

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/NullableArrayService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/NullableArrayService.cs
@@ -1,0 +1,34 @@
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+#pragma warning disable SA1649 // File name should match first type name
+#pragma warning disable SA1402 // File may only contain a single type
+	[ServiceContract(Namespace = "http://bagov.net")]
+	public interface INullableArrayService
+	{
+		[OperationContract]
+		[XmlSerializerFormat]
+		NullableArrayResponse GetResponse(NullableArrayRequest request);
+	}
+
+	public class NullableArrayService : INullableArrayService
+	{
+		public NullableArrayResponse GetResponse(NullableArrayRequest request)
+		{
+			return new NullableArrayResponse();
+		}
+	}
+
+	[MessageContract]
+	public class NullableArrayResponse
+	{
+		public long?[] Array { get; set; }
+	}
+
+	[MessageContract]
+	public class NullableArrayRequest
+	{
+		public long?[] Array { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -496,6 +496,14 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[TestMethod]
+		public async Task CheckNullableArrayServiceServiceWsdl()
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<NullableArrayService>(SoapSerializer.XmlSerializer);
+			Trace.TraceInformation(wsdl);
+			Assert.IsNotNull(wsdl);
+		}
+
+		[TestMethod]
 		public void CheckFieldMembers()
 		{
 			StartService(typeof(OperationContractFieldMembersService));

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -985,7 +985,10 @@ namespace SoapCore.Meta
 				{
 					writer.WriteAttributeString("minOccurs", "0");
 					writer.WriteAttributeString("maxOccurs", "unbounded");
-					writer.WriteAttributeString("nillable", "true");
+					if (underlyingType == null)
+					{
+						writer.WriteAttributeString("nillable", "true");
+					}
 				}
 				else
 				{


### PR DESCRIPTION
When I ported legacy project to `SoapCore` I found error when models have nullable array properties with `XmlSerializerFormatAttribute` when WSDL generate.

Exception: 
```
System.Xml.XmlException: 'nillable' is a duplicate attribute name.
    at System.Xml.XmlWellFormedWriter.AddAttribute(String prefix, String localName, String namespaceName)
   at System.Xml.XmlWellFormedWriter.WriteStartAttribute(String prefix, String localName, String namespaceName)
   at System.Xml.XmlDictionaryWriter.XmlWrappedWriter.WriteStartAttribute(String prefix, String localName, String namespaceUri)
   at System.Xml.XmlWriter.WriteAttributeString(String localName, String value)
   at SoapCore.Meta.MetaBodyWriter.AddSchemaType(XmlDictionaryWriter writer, TypeToBuild toBuild, String name, Boolean isArray, String namespace, Boolean isAttribute, Boolean isListWithoutWrapper, Boolean isUnqualified) in C:\Projects\SoapCore\src\SoapCore\Meta\MetaBodyWriter.cs:line 988
   at SoapCore.Meta.MetaBodyWriter.AddSchemaType(XmlDictionaryWriter writer, Type type, String name, Boolean isArray, String namespace, Boolean isAttribute, Boolean isUnqualified) in C:\Projects\SoapCore\src\SoapCore\Meta\MetaBodyWriter.cs:line 902
   at SoapCore.Meta.MetaBodyWriter.AddSchemaComplexType(XmlDictionaryWriter writer, TypeToBuild toBuild) in C:\Projects\SoapCore\src\SoapCore\Meta\MetaBodyWriter.cs:line 730
   at SoapCore.Meta.MetaBodyWriter.AddTypes(XmlDictionaryWriter writer) in C:\Projects\SoapCore\src\SoapCore\Meta\MetaBodyWriter.cs:line 449
   at SoapCore.Meta.MetaBodyWriter.OnWriteBodyContents(XmlDictionaryWriter writer) in C:\Projects\SoapCore\src\SoapCore\Meta\MetaBodyWriter.cs:line 75
   at System.ServiceModel.Channels.BodyWriter.WriteBodyContents(XmlDictionaryWriter writer)
   at System.ServiceModel.Channels.BodyWriterMessage.OnWriteBodyContents(XmlDictionaryWriter writer)
   at System.ServiceModel.Channels.Message.WriteBodyContents(XmlDictionaryWriter writer)
   at SoapCore.Meta.MetaMessage.OnWriteBodyContents(XmlDictionaryWriter writer) in C:\Projects\SoapCore\src\SoapCore\Meta\MetaMessage.cs:line 90
   at System.ServiceModel.Channels.Message.OnWriteMessage(XmlDictionaryWriter writer)
   at System.ServiceModel.Channels.Message.WriteMessage(XmlDictionaryWriter writer)
   at System.ServiceModel.Channels.Message.WriteMessage(XmlWriter writer)
   at SoapCore.MessageEncoder.SoapMessageEncoder.WriteXmlCore(Message message, XmlWriter xmlWriter) in C:\Projects\SoapCore\src\SoapCore\MessageEncoder\SoapMessageEncoder.cs:line 330
   at SoapCore.MessageEncoder.SoapMessageEncoder.WriteMessageAsync(Message message, Stream stream) in C:\Projects\SoapCore\src\SoapCore\MessageEncoder\SoapMessageEncoder.cs:line 187
   at SoapCore.Tests.Wsdl.WsdlTests.GetWsdlFromMetaBodyWriter[T](SoapSerializer serializer) in C:\Projects\SoapCore\src\SoapCore.Tests\Wsdl\WsdlTests.cs:line 685
   at SoapCore.Tests.Wsdl.WsdlTests.CheckNullableArrayServiceServiceWsdl() in C:\Projects\SoapCore\src\SoapCore.Tests\Wsdl\WsdlTests.cs:line 501
   at Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.ThreadOperations.ExecuteWithAbortSafety(Action action)
```

This pull request solve this problem.
Thanks