### PR TITLE
Soap 12 issue

### DIFF
--- a/src/SoapCore/HeadersHelper.cs
+++ b/src/SoapCore/HeadersHelper.cs
@@ -101,6 +101,20 @@ namespace SoapCore
 			return soapAction;
 		}
 
+		public static string GetTrimmedClearedSoapAction(string inSoapAction)
+		{
+			string trimmedAction = GetTrimmedSoapAction(inSoapAction);
+
+			if (trimmedAction.EndsWith("Request"))
+			{
+				int endIndex = trimmedAction.LastIndexOf('R');
+				string clearedAction = trimmedAction.Substring(0, endIndex);
+				return clearedAction;
+			}
+
+			return trimmedAction;
+		}
+
 		public static string GetTrimmedSoapAction(string inSoapAction)
 		{
 			string soapAction = inSoapAction;

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -313,7 +313,16 @@ namespace SoapCore
 			{
 				var soapAction = HeadersHelper.GetSoapAction(httpContext, reader);
 				requestMessage.Headers.Action = soapAction;
-				var operation = _service.Operations.FirstOrDefault(o => o.SoapAction.Equals(soapAction, StringComparison.Ordinal) || o.Name.Equals(HeadersHelper.GetTrimmedSoapAction(soapAction), StringComparison.Ordinal));
+
+				var operation = _service.Operations.FirstOrDefault(o => o.SoapAction.Equals(soapAction, StringComparison.Ordinal)
+				|| o.Name.Equals(HeadersHelper.GetTrimmedSoapAction(soapAction), StringComparison.Ordinal)
+				|| soapAction.Equals(HeadersHelper.GetTrimmedSoapAction(o.Name), StringComparison.Ordinal));
+
+				if (operation == null)
+				{
+					operation = _service.Operations.FirstOrDefault(o => soapAction.Equals(HeadersHelper.GetTrimmedClearedSoapAction(o.SoapAction), StringComparison.Ordinal));
+				}
+
 				if (operation == null)
 				{
 					var ex = new InvalidOperationException($"No operation found for specified action: {requestMessage.Headers.Action}");


### PR DESCRIPTION
In some case (with SOAP 12 binding) the request doesn't have necessary header to denife full action name by HeadersHelper.GetSoapAction method.

To fix this, I have added a soapAction comparison with trimmed service action names to define target service action, if in another case no valid action found.

The issue defined, fixed and tested for following service action: http://www.onvif.org/ver10/events/wsdl/EventPortType/CreatePullPointSubscriptionRequest with SOAP12 binding options