### PR TITLE
cleanup TrailingServicePathTuner

### DIFF
--- a/src/SoapCore.Tests/ServiceOperationTuner/Startup.cs
+++ b/src/SoapCore.Tests/ServiceOperationTuner/Startup.cs
@@ -13,7 +13,6 @@ namespace SoapCore.Tests.ServiceOperationTuner
 		{
 			services.AddSoapCore();
 			services.TryAddSingleton<TestService>();
-			services.TryAddSingleton<TrailingServicePathTuner>();
 			services.AddSoapServiceOperationTuner(new TestServiceOperationTuner());
 			services.AddMvc();
 		}

--- a/src/SoapCore.Tests/TrailingServicePathTuner/MockServiceProvider.cs
+++ b/src/SoapCore.Tests/TrailingServicePathTuner/MockServiceProvider.cs
@@ -1,11 +1,10 @@
 using System;
-using System.Collections.Generic;
 
 namespace SoapCore.Tests
 {
 	internal class MockServiceProvider : IServiceProvider
 	{
-		private bool _isTrailingService = false;
+		private readonly bool _isTrailingService;
 
 		public MockServiceProvider(bool isTrailingService)
 		{
@@ -14,7 +13,7 @@ namespace SoapCore.Tests
 
 		public object GetService(Type serviceType)
 		{
-			return _isTrailingService ? new List<TrailingServicePathTuner> { new TrailingServicePathTuner() } : new List<TrailingServicePathTuner>();
+			return (serviceType == typeof(TrailingServicePathTuner) && _isTrailingService) ? new TrailingServicePathTuner() : null;
 		}
 	}
 }

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -110,7 +110,7 @@ namespace SoapCore
 				httpContext.Request.EnableBuffering();
 			}
 
-			var trailPathTuner = serviceProvider.GetServices<TrailingServicePathTuner>().FirstOrDefault();
+			var trailPathTuner = serviceProvider.GetService<TrailingServicePathTuner>();
 
 			trailPathTuner?.ConvertPath(httpContext);
 

--- a/src/SoapCore/TrailingServicePathTuner.cs
+++ b/src/SoapCore/TrailingServicePathTuner.cs
@@ -9,7 +9,7 @@ namespace SoapCore
 {
 	/// <summary>
 	/// This tuner truncates the incoming http request to the last path-part. ie. /DynamicPath/Service.svc becomes /Service.svc
-	/// Register this tuner in ConfigureServices: services.AddSoapServiceOperationTuner(new TrailingServicePathTuner());
+	/// Register this tuner in ConfigureServices: services.TryAddSingleton&lt;TrailingServicePathTuner&gt;();
 	/// </summary>
 	public class TrailingServicePathTuner
 	{


### PR DESCRIPTION
Cleanup TrailingServicePathTuner a bit.

It is useful without endpoint routing only, I guess.
Could `app.MapWhen()` or `endpoints.Map()` be used alternatively?