### PR TITLE
No buffering

### DIFF
--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ServiceModel.Channels;
 using System.Xml;
 using SoapCore.Extensibility;
@@ -56,12 +57,14 @@ namespace SoapCore
 		/// The maximum size in bytes of the in-memory <see cref="System.Buffers.ArrayPool{Byte}"/> used to buffer the
 		/// stream. Larger request bodies are written to disk.
 		/// </summary>
+		[Obsolete]
 		public int BufferThreshold { get; set; } = 1024 * 30;
 
 		/// <summary>
 		/// The maximum size in bytes of the request body. An attempt to read beyond this limit will cause an
 		/// <see cref="System.IO.IOException"/>.
 		/// </summary>
+		[Obsolete]
 		public long BufferLimit { get; set; }
 
 		/// <summary>

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -151,18 +151,11 @@ namespace SoapCore
 			return messageEncoder.WriteMessageAsync(responseMessage, httpContext.Response.Body);
 		}
 
-		private static async Task<Message> ReadMessageAsync(HttpContext httpContext, SoapMessageEncoder messageEncoder)
+		private static Task<Message> ReadMessageAsync(HttpContext httpContext, SoapMessageEncoder messageEncoder)
 		{
-			//Read the body to ensure we have the full message
-			var memoryStream = new MemoryStream((int)httpContext.Request.ContentLength.GetValueOrDefault(1024));
-			await httpContext.Request.Body.CopyToAsync(memoryStream).ConfigureAwait(false);
-			memoryStream.Seek(0, SeekOrigin.Begin);
-			httpContext.Request.Body = memoryStream;
-
-			return await messageEncoder.ReadMessageAsync(httpContext.Request.Body, 0x10000, httpContext.Request.ContentType);
+			return messageEncoder.ReadMessageAsync(httpContext.Request.Body, 0x10000, httpContext.Request.ContentType);
 		}
 #else
-
 		private static Task WriteMessageAsync(SoapMessageEncoder messageEncoder, Message responseMessage, HttpContext httpContext)
 		{
 			return messageEncoder.WriteMessageAsync(responseMessage, httpContext.Response.BodyWriter);
@@ -172,7 +165,6 @@ namespace SoapCore
 		{
 			return messageEncoder.ReadMessageAsync(httpContext.Request.BodyReader, 0x10000, httpContext.Request.ContentType);
 		}
-
 #endif
 
 		private async Task ProcessMeta(HttpContext httpContext)

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -90,26 +90,6 @@ namespace SoapCore
 
 		public async Task Invoke(HttpContext httpContext, IServiceProvider serviceProvider)
 		{
-			if (_options != null)
-			{
-				if (_options.BufferThreshold > 0 && _options.BufferLimit > 0)
-				{
-					httpContext.Request.EnableBuffering(_options.BufferThreshold, _options.BufferLimit);
-				}
-				else if (_options.BufferThreshold > 0)
-				{
-					httpContext.Request.EnableBuffering(_options.BufferThreshold);
-				}
-				else
-				{
-					httpContext.Request.EnableBuffering();
-				}
-			}
-			else
-			{
-				httpContext.Request.EnableBuffering();
-			}
-
 			var trailPathTuner = serviceProvider.GetService<TrailingServicePathTuner>();
 
 			trailPathTuner?.ConvertPath(httpContext);

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -14,7 +14,10 @@ namespace SoapCore
 		public bool CaseInsensitivePath { get; set; }
 		public ISoapModelBounder SoapModelBounder { get; set; }
 		public Binding Binding { get; set; }
+
+		[Obsolete]
 		public int BufferThreshold { get; set; } = 1024 * 30;
+		[Obsolete]
 		public long BufferLimit { get; set; }
 
 		/// <summary>
@@ -52,8 +55,10 @@ namespace SoapCore
 				CaseInsensitivePath = opt.CaseInsensitivePath,
 				SoapModelBounder = opt.SoapModelBounder,
 				Binding = opt.Binding,
+#pragma warning disable CS0612 // Type or member is obsolete
 				BufferThreshold = opt.BufferThreshold,
 				BufferLimit = opt.BufferLimit,
+#pragma warning restore CS0612 // Type or member is obsolete
 				HttpsGetEnabled = opt.HttpsGetEnabled,
 				HttpGetEnabled = opt.HttpGetEnabled,
 				OmitXmlDeclaration = opt.OmitXmlDeclaration,


### PR DESCRIPTION
With the latest changes `Body` is read once only.

Therefor buffering is not needed any more.
see https://devblogs.microsoft.com/aspnet/re-reading-asp-net-core-request-bodies-with-enablebuffering/

This should help #364