### PR TITLE
Obsolete Binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerF
     app.UseRouting();
 
     app.UseEndpoints(endpoints => {
-        endpoints.UseSoapEndpoint<ServiceContractImpl>("/ServicePath.asmx", SoapEncoderOptions.Default());
+        endpoints.UseSoapEndpoint<ServiceContractImpl>("/ServicePath.asmx", new SoapEncoderOptions());
     });
     
 }
@@ -58,7 +58,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 {
-    app.UseSoapEndpoint<ServiceContractImpl>("/ServicePath.asmx", SoapEncoderOptions.Default());
+    app.UseSoapEndpoint<ServiceContractImpl>("/ServicePath.asmx", new SoapEncoderOptions());
 }
 ```
 
@@ -105,7 +105,7 @@ var settings = Configuration.GetSection("FileWSDL").Get<WsdlFileOptions>();
 settings.AppPath = env.ContentRootPath; // The hosting environment root path
 ...
 
-app.UseSoapEndpoint<ServiceContractImpl>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer, false, null, settings);
+app.UseSoapEndpoint<ServiceContractImpl>("/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer, false, null, settings);
 ```
 
 If the WsdFileOptions parameter is supplied then this feature is enabled / used.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerF
     app.UseRouting();
 
     app.UseEndpoints(endpoints => {
-        endpoints.UseSoapEndpoint<ServiceContractImpl>("/ServicePath.asmx", new BasicHttpBinding());
+        endpoints.UseSoapEndpoint<ServiceContractImpl>("/ServicePath.asmx", SoapEncoderOptions.Default());
     });
     
 }
@@ -58,7 +58,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 {
-    app.UseSoapEndpoint<ServiceContractImpl>("/ServicePath.asmx", new BasicHttpBinding());
+    app.UseSoapEndpoint<ServiceContractImpl>("/ServicePath.asmx", SoapEncoderOptions.Default());
 }
 ```
 
@@ -105,7 +105,7 @@ var settings = Configuration.GetSection("FileWSDL").Get<WsdlFileOptions>();
 settings.AppPath = env.ContentRootPath; // The hosting environment root path
 ...
 
-app.UseSoapEndpoint<ServiceContractImpl>("/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer, false, null, settings);
+app.UseSoapEndpoint<ServiceContractImpl>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer, false, null, settings);
 ```
 
 If the WsdFileOptions parameter is supplied then this feature is enabled / used.

--- a/samples/Server/Startup.cs
+++ b/samples/Server/Startup.cs
@@ -27,8 +27,8 @@ namespace Server
 			app.UseRouting();
 
 			app.UseEndpoints(endpoints => {
-				endpoints.UseSoapEndpoint<ISampleService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
-				endpoints.UseSoapEndpoint<ISampleService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
+				endpoints.UseSoapEndpoint<ISampleService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+				endpoints.UseSoapEndpoint<ISampleService>("/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
 			});
 		}
 	}

--- a/samples/Server/Startup.cs
+++ b/samples/Server/Startup.cs
@@ -27,8 +27,8 @@ namespace Server
 			app.UseRouting();
 
 			app.UseEndpoints(endpoints => {
-				endpoints.UseSoapEndpoint<ISampleService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
-				endpoints.UseSoapEndpoint<ISampleService>("/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
+				endpoints.UseSoapEndpoint<ISampleService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+				endpoints.UseSoapEndpoint<ISampleService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
 			});
 		}
 	}

--- a/src/SoapCore.Benchmark/Startup.cs
+++ b/src/SoapCore.Benchmark/Startup.cs
@@ -13,7 +13,7 @@ namespace SoapCore.Benchmark
 
 		public void Configure(IApplicationBuilder app)
 		{
-			app.UseSoapEndpoint<PingService>("/TestService.asmx", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint<PingService>("/TestService.asmx", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 			app.Use(async (ctx, next) =>
 			{
 				await ctx.Response.WriteAsync("").ConfigureAwait(false);

--- a/src/SoapCore.Benchmark/Startup.cs
+++ b/src/SoapCore.Benchmark/Startup.cs
@@ -1,9 +1,6 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using SoapCore;
-using System.ServiceModel;
 
 namespace SoapCore.Benchmark
 {
@@ -16,11 +13,7 @@ namespace SoapCore.Benchmark
 
 		public void Configure(IApplicationBuilder app)
 		{
-			// var elm = new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, Encoding.UTF8);
-			// var customBinding = new CustomBinding("MarWebSvcSoap", "http://intercom/malion/MarWebSvc", new BindingElement[] { elm });
-			// var customBinding = new BasicHttpBinding();
-
-			app.UseSoapEndpoint<PingService>("/TestService.asmx", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint<PingService>("/TestService.asmx", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
 			app.Use(async (ctx, next) =>
 			{
 				await ctx.Response.WriteAsync("").ConfigureAwait(false);

--- a/src/SoapCore.Tests/FaultExceptionTransformer/Startup.cs
+++ b/src/SoapCore.Tests/FaultExceptionTransformer/Startup.cs
@@ -21,7 +21,7 @@ namespace SoapCore.Tests.FaultExceptionTransformer
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
 			app.UseMvc();
 		}
 #else
@@ -31,7 +31,7 @@ namespace SoapCore.Tests.FaultExceptionTransformer
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/FaultExceptionTransformer/Startup.cs
+++ b/src/SoapCore.Tests/FaultExceptionTransformer/Startup.cs
@@ -21,7 +21,7 @@ namespace SoapCore.Tests.FaultExceptionTransformer
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 			app.UseMvc();
 		}
 #else
@@ -31,7 +31,7 @@ namespace SoapCore.Tests.FaultExceptionTransformer
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/InvalidXMLTests.cs
+++ b/src/SoapCore.Tests/InvalidXMLTests.cs
@@ -29,7 +29,6 @@ namespace SoapCore.Tests
 			var options = new SoapOptions()
 			{
 				Path = "/Service.svc",
-				Binding = new CustomBinding(),
 				EncoderOptions = new[]
 				{
 					new SoapEncoderOptions

--- a/src/SoapCore.Tests/MessageContract/Startup.cs
+++ b/src/SoapCore.Tests/MessageContract/Startup.cs
@@ -30,8 +30,8 @@ namespace SoapCore.Tests.MessageContract
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint(_serviceType, "/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
-			app.UseSoapEndpoint(_serviceType, "/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
+			app.UseSoapEndpoint(_serviceType, "/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
 
 			app.UseMvc();
 		}
@@ -42,8 +42,8 @@ namespace SoapCore.Tests.MessageContract
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint(_serviceType, "/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
-				x.UseSoapEndpoint(_serviceType, "/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
+				x.UseSoapEndpoint(_serviceType, "/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/MessageContract/Startup.cs
+++ b/src/SoapCore.Tests/MessageContract/Startup.cs
@@ -30,8 +30,8 @@ namespace SoapCore.Tests.MessageContract
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint(_serviceType, "/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
-			app.UseSoapEndpoint(_serviceType, "/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
+			app.UseSoapEndpoint(_serviceType, "/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint(_serviceType, "/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
 
 			app.UseMvc();
 		}
@@ -42,8 +42,8 @@ namespace SoapCore.Tests.MessageContract
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint(_serviceType, "/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
-				x.UseSoapEndpoint(_serviceType, "/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
+				x.UseSoapEndpoint(_serviceType, "/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint(_serviceType, "/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/MessageFilter/Startup.cs
+++ b/src/SoapCore.Tests/MessageFilter/Startup.cs
@@ -20,7 +20,7 @@ namespace SoapCore.Tests.MessageFilter
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 			app.UseMvc();
 		}
 #else
@@ -30,7 +30,7 @@ namespace SoapCore.Tests.MessageFilter
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/MessageFilter/Startup.cs
+++ b/src/SoapCore.Tests/MessageFilter/Startup.cs
@@ -20,7 +20,7 @@ namespace SoapCore.Tests.MessageFilter
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
 			app.UseMvc();
 		}
 #else
@@ -30,7 +30,7 @@ namespace SoapCore.Tests.MessageFilter
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/MessageInspector/Startup.cs
+++ b/src/SoapCore.Tests/MessageInspector/Startup.cs
@@ -22,7 +22,7 @@ namespace SoapCore.Tests.MessageInspector
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
 			app.UseMvc();
 		}
 #else
@@ -32,7 +32,7 @@ namespace SoapCore.Tests.MessageInspector
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/MessageInspector/Startup.cs
+++ b/src/SoapCore.Tests/MessageInspector/Startup.cs
@@ -22,7 +22,7 @@ namespace SoapCore.Tests.MessageInspector
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 			app.UseMvc();
 		}
 #else
@@ -32,7 +32,7 @@ namespace SoapCore.Tests.MessageInspector
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/MessageInspectors/Startup.cs
+++ b/src/SoapCore.Tests/MessageInspectors/Startup.cs
@@ -44,7 +44,7 @@ namespace SoapCore.Tests.MessageInspectors
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 			app.UseMvc();
 		}
 #else
@@ -54,7 +54,7 @@ namespace SoapCore.Tests.MessageInspectors
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/MessageInspectors/Startup.cs
+++ b/src/SoapCore.Tests/MessageInspectors/Startup.cs
@@ -44,7 +44,7 @@ namespace SoapCore.Tests.MessageInspectors
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
 			app.UseMvc();
 		}
 #else
@@ -54,7 +54,7 @@ namespace SoapCore.Tests.MessageInspectors
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/RequestArgumentsOrder/ServiceFixture.cs
+++ b/src/SoapCore.Tests/RequestArgumentsOrder/ServiceFixture.cs
@@ -42,16 +42,16 @@ namespace SoapCore.Tests.RequestArgumentsOrder
 				.Configure(appBuilder =>
 				{
 #if !NETCOREAPP3_0_OR_GREATER
-					appBuilder.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
-					appBuilder.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
+					appBuilder.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+					appBuilder.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
 					appBuilder.UseMvc();
 #else
 					appBuilder.UseRouting();
 
 					appBuilder.UseEndpoints(x =>
 					{
-						x.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
-						x.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
+						x.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+						x.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
 					});
 #endif
 				})

--- a/src/SoapCore.Tests/RequestArgumentsOrder/ServiceFixture.cs
+++ b/src/SoapCore.Tests/RequestArgumentsOrder/ServiceFixture.cs
@@ -42,16 +42,16 @@ namespace SoapCore.Tests.RequestArgumentsOrder
 				.Configure(appBuilder =>
 				{
 #if !NETCOREAPP3_0_OR_GREATER
-					appBuilder.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.svc", binding, SoapSerializer.DataContractSerializer);
-					appBuilder.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.asmx", binding, SoapSerializer.XmlSerializer);
+					appBuilder.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+					appBuilder.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
 					appBuilder.UseMvc();
 #else
 					appBuilder.UseRouting();
 
 					appBuilder.UseEndpoints(x =>
 					{
-						x.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.svc", binding, SoapSerializer.DataContractSerializer);
-						x.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.asmx", binding, SoapSerializer.XmlSerializer);
+						x.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+						x.UseSoapEndpoint<TOriginalParametersOrderService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
 					});
 #endif
 				})

--- a/src/SoapCore.Tests/Serialization/ServiceFixture.cs
+++ b/src/SoapCore.Tests/Serialization/ServiceFixture.cs
@@ -41,16 +41,16 @@ namespace SoapCore.Tests.Serialization
 				.Configure(appBuilder =>
 				{
 #if !NETCOREAPP3_0_OR_GREATER
-					appBuilder.UseSoapEndpoint<TService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
-					appBuilder.UseSoapEndpoint<TService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
+					appBuilder.UseSoapEndpoint<TService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+					appBuilder.UseSoapEndpoint<TService>("/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
 					appBuilder.UseMvc();
 #else
 					appBuilder.UseRouting();
 
 					appBuilder.UseEndpoints(x =>
 					{
-						x.UseSoapEndpoint<TService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
-						x.UseSoapEndpoint<TService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
+						x.UseSoapEndpoint<TService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+						x.UseSoapEndpoint<TService>("/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
 					});
 #endif
 				})

--- a/src/SoapCore.Tests/Serialization/ServiceFixture.cs
+++ b/src/SoapCore.Tests/Serialization/ServiceFixture.cs
@@ -41,16 +41,16 @@ namespace SoapCore.Tests.Serialization
 				.Configure(appBuilder =>
 				{
 #if !NETCOREAPP3_0_OR_GREATER
-					appBuilder.UseSoapEndpoint<TService>("/Service.svc", binding, SoapSerializer.DataContractSerializer);
-					appBuilder.UseSoapEndpoint<TService>("/Service.asmx", binding, SoapSerializer.XmlSerializer);
+					appBuilder.UseSoapEndpoint<TService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+					appBuilder.UseSoapEndpoint<TService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
 					appBuilder.UseMvc();
 #else
 					appBuilder.UseRouting();
 
 					appBuilder.UseEndpoints(x =>
 					{
-						x.UseSoapEndpoint<TService>("/Service.svc", binding, SoapSerializer.DataContractSerializer);
-						x.UseSoapEndpoint<TService>("/Service.asmx", binding, SoapSerializer.XmlSerializer);
+						x.UseSoapEndpoint<TService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+						x.UseSoapEndpoint<TService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
 					});
 #endif
 				})

--- a/src/SoapCore.Tests/ServiceOperationTuner/Startup.cs
+++ b/src/SoapCore.Tests/ServiceOperationTuner/Startup.cs
@@ -20,7 +20,7 @@ namespace SoapCore.Tests.ServiceOperationTuner
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 			app.UseMvc();
 		}
 #else
@@ -30,7 +30,7 @@ namespace SoapCore.Tests.ServiceOperationTuner
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/ServiceOperationTuner/Startup.cs
+++ b/src/SoapCore.Tests/ServiceOperationTuner/Startup.cs
@@ -20,7 +20,7 @@ namespace SoapCore.Tests.ServiceOperationTuner
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
 			app.UseMvc();
 		}
 #else
@@ -30,7 +30,7 @@ namespace SoapCore.Tests.ServiceOperationTuner
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/Startup.cs
+++ b/src/SoapCore.Tests/Startup.cs
@@ -28,13 +28,13 @@ namespace SoapCore.Tests
 		{
 			app.UseWhen(ctx => ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
 			{
-				app2.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+				app2.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 			});
 
 			app.UseWhen(ctx => ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
 			{
 				// For case insensitive path test
-				app2.UseSoapEndpoint<TestService>("/ServiceCI.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer, caseInsensitivePath: true);
+				app2.UseSoapEndpoint<TestService>("/ServiceCI.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer, caseInsensitivePath: true);
 			});
 
 			app.UseWhen(ctx => !ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
@@ -44,7 +44,7 @@ namespace SoapCore.Tests
 
 			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("asmx"), app2 =>
 			{
-				app2.UseSoapEndpoint<TestService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
+				app2.UseSoapEndpoint<TestService>("/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
 			});
 
 			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("/WSA10Service.svc"), app2 =>
@@ -79,7 +79,7 @@ namespace SoapCore.Tests
 
 				app2.UseEndpoints(x =>
 				{
-					x.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+					x.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 				});
 			});
 
@@ -89,7 +89,7 @@ namespace SoapCore.Tests
 
 				app2.UseEndpoints(x =>
 				{
-					x.UseSoapEndpoint<TestService>("/ServiceCI.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer, caseInsensitivePath: true);
+					x.UseSoapEndpoint<TestService>("/ServiceCI.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer, caseInsensitivePath: true);
 				});
 			});
 
@@ -107,7 +107,7 @@ namespace SoapCore.Tests
 			{
 				app2.UseRouting();
 
-				app2.UseSoapEndpoint<TestService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
+				app2.UseSoapEndpoint<TestService>("/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
 			});
 
 			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("/WSA10Service.svc"), app2 =>

--- a/src/SoapCore.Tests/Startup.cs
+++ b/src/SoapCore.Tests/Startup.cs
@@ -28,25 +28,23 @@ namespace SoapCore.Tests
 		{
 			app.UseWhen(ctx => ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
 			{
-				app2.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+				app2.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
 			});
 
 			app.UseWhen(ctx => ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
 			{
 				// For case insensitive path test
-				app2.UseSoapEndpoint<TestService>("/ServiceCI.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer, caseInsensitivePath: true);
+				app2.UseSoapEndpoint<TestService>("/ServiceCI.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer, caseInsensitivePath: true);
 			});
 
 			app.UseWhen(ctx => !ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
 			{
-				var transportBinding = new HttpTransportBindingElement();
-				var textEncodingBinding = new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, System.Text.Encoding.UTF8);
-				app.UseSoapEndpoint<TestService>("/Service.svc", new CustomBinding(transportBinding, textEncodingBinding), SoapSerializer.DataContractSerializer);
+				app.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions { MessageVersion = MessageVersion.Soap12WSAddressing10 }, SoapSerializer.DataContractSerializer);
 			});
 
 			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("asmx"), app2 =>
 			{
-				app2.UseSoapEndpoint<TestService>("/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
+				app2.UseSoapEndpoint<TestService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
 			});
 
 			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("/WSA10Service.svc"), app2 =>
@@ -54,7 +52,7 @@ namespace SoapCore.Tests
 				var transportBinding = new HttpTransportBindingElement();
 				var textEncodingBinding = new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, System.Text.Encoding.UTF8);
 
-				app.UseSoapEndpoint<TestService>("/WSA10Service.svc", new CustomBinding(transportBinding, textEncodingBinding), SoapSerializer.DataContractSerializer);
+				app.UseSoapEndpoint<TestService>("/WSA10Service.svc", new SoapEncoderOptions { MessageVersion = MessageVersion.Soap12WSAddressing10 }, SoapSerializer.DataContractSerializer);
 			});
 
 			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("/WSA11ISO88591Service.svc"), app2 =>
@@ -81,7 +79,7 @@ namespace SoapCore.Tests
 
 				app2.UseEndpoints(x =>
 				{
-					x.UseSoapEndpoint<TestService>("/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
+					x.UseSoapEndpoint<TestService>("/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
 				});
 			});
 
@@ -91,20 +89,17 @@ namespace SoapCore.Tests
 
 				app2.UseEndpoints(x =>
 				{
-					x.UseSoapEndpoint<TestService>("/ServiceCI.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer, caseInsensitivePath: true);
+					x.UseSoapEndpoint<TestService>("/ServiceCI.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer, caseInsensitivePath: true);
 				});
 			});
 
 			app.UseWhen(ctx => !ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
 			{
-				var transportBinding = new HttpTransportBindingElement();
-				var textEncodingBinding = new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, System.Text.Encoding.UTF8);
-
 				app2.UseRouting();
 
 				app2.UseEndpoints(x =>
 				{
-					x.UseSoapEndpoint<TestService>("/Service.svc", new CustomBinding(transportBinding, textEncodingBinding), SoapSerializer.DataContractSerializer);
+					x.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions { MessageVersion = MessageVersion.Soap12WSAddressing10 }, SoapSerializer.DataContractSerializer);
 				});
 			});
 
@@ -112,17 +107,14 @@ namespace SoapCore.Tests
 			{
 				app2.UseRouting();
 
-				app2.UseSoapEndpoint<TestService>("/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
+				app2.UseSoapEndpoint<TestService>("/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
 			});
 
 			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("/WSA10Service.svc"), app2 =>
 			{
-				var transportBinding = new HttpTransportBindingElement();
-				var textEncodingBinding = new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, System.Text.Encoding.UTF8);
-
 				app2.UseRouting();
 
-				app.UseSoapEndpoint<TestService>("/WSA10Service.svc", new CustomBinding(transportBinding, textEncodingBinding), SoapSerializer.DataContractSerializer);
+				app.UseSoapEndpoint<TestService>("/WSA10Service.svc", new SoapEncoderOptions { MessageVersion = MessageVersion.Soap12WSAddressing10 }, SoapSerializer.DataContractSerializer);
 			});
 
 			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("/WSA11ISO88591Service.svc"), app2 =>

--- a/src/SoapCore.Tests/TrailingServicePathTuner/TrailingServicePathTunerTests.cs
+++ b/src/SoapCore.Tests/TrailingServicePathTuner/TrailingServicePathTunerTests.cs
@@ -27,7 +27,6 @@ namespace SoapCore.Tests
 			SoapOptions options = new SoapOptions()
 			{
 				Path = "/Service.svc", // this is the path registered in app startup
-				Binding = new CustomBinding(),
 				EncoderOptions = new[]
 				{
 					new SoapEncoderOptions
@@ -71,7 +70,6 @@ namespace SoapCore.Tests
 			SoapOptions options = new SoapOptions()
 			{
 				Path = "/v1/Service.svc", // this is the multi-part path registered in app startup
-				Binding = new CustomBinding(),
 				EncoderOptions = new[]
 				{
 					new SoapEncoderOptions
@@ -114,7 +112,6 @@ namespace SoapCore.Tests
 			SoapOptions options = new SoapOptions()
 			{
 				Path = "/v1/Service.svc", // this is the multi-part path registered in app startup
-				Binding = new CustomBinding(),
 				EncoderOptions = new[]
 				{
 					new SoapEncoderOptions

--- a/src/SoapCore.Tests/Wsdl/Startup.cs
+++ b/src/SoapCore.Tests/Wsdl/Startup.cs
@@ -30,8 +30,8 @@ namespace SoapCore.Tests.Wsdl
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint(_serviceType, "/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
-			app.UseSoapEndpoint(_serviceType, "/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
+			app.UseSoapEndpoint(_serviceType, "/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
 
 			app.UseMvc();
 		}
@@ -42,8 +42,8 @@ namespace SoapCore.Tests.Wsdl
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint(_serviceType, "/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
-				x.UseSoapEndpoint(_serviceType, "/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
+				x.UseSoapEndpoint(_serviceType, "/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/Wsdl/Startup.cs
+++ b/src/SoapCore.Tests/Wsdl/Startup.cs
@@ -30,8 +30,8 @@ namespace SoapCore.Tests.Wsdl
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint(_serviceType, "/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
-			app.UseSoapEndpoint(_serviceType, "/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
+			app.UseSoapEndpoint(_serviceType, "/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint(_serviceType, "/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
 
 			app.UseMvc();
 		}
@@ -42,8 +42,8 @@ namespace SoapCore.Tests.Wsdl
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint(_serviceType, "/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
-				x.UseSoapEndpoint(_serviceType, "/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
+				x.UseSoapEndpoint(_serviceType, "/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint(_serviceType, "/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -689,11 +689,11 @@ namespace SoapCore.Tests.Wsdl
 			var baseUrl = "http://tempuri.org/";
 			var xmlNamespaceManager = Namespaces.CreateDefaultXmlNamespaceManager();
 			var bodyWriter = serializer == SoapSerializer.DataContractSerializer
-				? new MetaWCFBodyWriter(service, baseUrl, null) as BodyWriter
-				: new MetaBodyWriter(service, baseUrl, null, xmlNamespaceManager) as BodyWriter;
+				? new MetaWCFBodyWriter(service, baseUrl, "BasicHttpBinding", false) as BodyWriter
+				: new MetaBodyWriter(service, baseUrl, xmlNamespaceManager, "BasicHttpBinding", MessageVersion.None) as BodyWriter;
 			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, System.Text.Encoding.UTF8, XmlDictionaryReaderQuotas.Max, false, true);
 			var responseMessage = Message.CreateMessage(encoder.MessageVersion, null, bodyWriter);
-			responseMessage = new MetaMessage(responseMessage, service, null, xmlNamespaceManager);
+			responseMessage = new MetaMessage(responseMessage, service, xmlNamespaceManager, "BasicHttpBinding", false);
 
 			using (var memoryStream = new MemoryStream())
 			{

--- a/src/SoapCore.Tests/WsdlFromFile/Startup.cs
+++ b/src/SoapCore.Tests/WsdlFromFile/Startup.cs
@@ -48,8 +48,8 @@ namespace SoapCore.Tests.WsdlFromFile
 				AppPath = env.ContentRootPath
 			};
 
-			app.UseSoapEndpoint(_serviceType, "/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
-			app.UseSoapEndpoint(_serviceType, "/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer, false, null, options);
+			app.UseSoapEndpoint(_serviceType, "/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer, false, null, options);
 
 			app.UseMvc();
 		}
@@ -78,8 +78,8 @@ namespace SoapCore.Tests.WsdlFromFile
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint(_serviceType, "/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
-				x.UseSoapEndpoint(_serviceType, "/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer, false, null, options);
+				x.UseSoapEndpoint(_serviceType, "/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer, false, null, options);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/WsdlFromFile/Startup.cs
+++ b/src/SoapCore.Tests/WsdlFromFile/Startup.cs
@@ -48,8 +48,8 @@ namespace SoapCore.Tests.WsdlFromFile
 				AppPath = env.ContentRootPath
 			};
 
-			app.UseSoapEndpoint(_serviceType, "/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
-			app.UseSoapEndpoint(_serviceType, "/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer, false, null, options);
+			app.UseSoapEndpoint(_serviceType, "/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+			app.UseSoapEndpoint(_serviceType, "/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer, false, null, options);
 
 			app.UseMvc();
 		}
@@ -78,8 +78,8 @@ namespace SoapCore.Tests.WsdlFromFile
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint(_serviceType, "/Service.svc", new BasicHttpBinding(), SoapSerializer.DataContractSerializer);
-				x.UseSoapEndpoint(_serviceType, "/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer, false, null, options);
+				x.UseSoapEndpoint(_serviceType, "/Service.svc", SoapEncoderOptions.Default(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint(_serviceType, "/Service.asmx", SoapEncoderOptions.Default(), SoapSerializer.XmlSerializer, false, null, options);
 			});
 		}
 #endif

--- a/src/SoapCore/Meta/BindingExtensions.cs
+++ b/src/SoapCore/Meta/BindingExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.ServiceModel.Channels;
 using System.Text;
@@ -5,6 +6,7 @@ using System.Xml;
 
 namespace SoapCore.Meta
 {
+	[Obsolete]
 	internal static class BindingExtensions
 	{
 		public static bool HasBasicAuth(this Binding binding)

--- a/src/SoapCore/Meta/BindingExtensions.cs
+++ b/src/SoapCore/Meta/BindingExtensions.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using System.ServiceModel.Channels;
+using System.Text;
+using System.Xml;
 
 namespace SoapCore.Meta
 {
@@ -15,6 +17,32 @@ namespace SoapCore.Meta
 			}
 
 			return false;
+		}
+
+		public static SoapEncoderOptions[] ToEncoderOptions(this Binding binding)
+		{
+			var elements = binding.CreateBindingElements().FindAll<MessageEncodingBindingElement>();
+			var encoderOptions = new SoapEncoderOptions[elements.Count];
+
+			for (var i = 0; i < encoderOptions.Length; i++)
+			{
+				var encoderOption = new SoapEncoderOptions
+				{
+					MessageVersion = elements[i].MessageVersion,
+					WriteEncoding = Encoding.UTF8,
+					ReaderQuotas = XmlDictionaryReaderQuotas.Max
+				};
+
+				if (elements[i] is TextMessageEncodingBindingElement textMessageEncodingBindingElement)
+				{
+					encoderOption.WriteEncoding = textMessageEncodingBindingElement.WriteEncoding;
+					encoderOption.ReaderQuotas = textMessageEncodingBindingElement.ReaderQuotas;
+				}
+
+				encoderOptions[i] = encoderOption;
+			}
+
+			return encoderOptions;
 		}
 	}
 }

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -31,16 +31,26 @@ namespace SoapCore.Meta
 		private readonly HashSet<string> _buildArrayTypes;
 		private readonly Dictionary<string, Dictionary<string, string>> _requestedDynamicTypes;
 
-		private readonly MessageVersion _version;
 		private readonly bool _isSoap12 = true;
 
 		private bool _buildDateTimeOffset;
 
-		public MetaBodyWriter(ServiceDescription service, string baseUrl, Binding binding, XmlNamespaceManager xmlNamespaceManager = null) : base(isBuffered: true)
+		[Obsolete]
+		public MetaBodyWriter(ServiceDescription service, string baseUrl, Binding binding, XmlNamespaceManager xmlNamespaceManager = null)
+			: this(
+				service,
+				baseUrl,
+				xmlNamespaceManager ?? new XmlNamespaceManager(new NameTable()),
+				binding?.Name ?? "BasicHttpBinding_" + service.Contracts.First().Name,
+				binding.MessageVersion ?? MessageVersion.None)
+		{
+		}
+
+		public MetaBodyWriter(ServiceDescription service, string baseUrl, XmlNamespaceManager xmlNamespaceManager, string bindingName, MessageVersion messageVersion) : base(isBuffered: true)
 		{
 			_service = service;
 			_baseUrl = baseUrl;
-			_xmlNamespaceManager = xmlNamespaceManager ?? new XmlNamespaceManager(new NameTable());
+			_xmlNamespaceManager = xmlNamespaceManager;
 
 			_enumToBuild = new Queue<Type>();
 			_complexTypeToBuild = new Queue<TypeToBuild>();
@@ -50,18 +60,9 @@ namespace SoapCore.Meta
 			_buildArrayTypes = new HashSet<string>();
 			_requestedDynamicTypes = new Dictionary<string, Dictionary<string, string>>();
 
-			if (binding != null)
-			{
-				BindingName = binding.Name;
-				PortName = binding.Name;
-				_version = binding.MessageVersion;
-				_isSoap12 = _version == MessageVersion.Soap12WSAddressing10 || _version == MessageVersion.Soap12WSAddressingAugust2004;
-			}
-			else
-			{
-				BindingName = "BasicHttpBinding_" + _service.Contracts.First().Name;
-				PortName = "BasicHttpBinding_" + _service.Contracts.First().Name;
-			}
+			BindingName = bindingName;
+			PortName = bindingName;
+			_isSoap12 = messageVersion == MessageVersion.Soap12WSAddressing10 || messageVersion == MessageVersion.Soap12WSAddressingAugust2004;
 		}
 
 		private string BindingName { get; }

--- a/src/SoapCore/Meta/MetaMessage.cs
+++ b/src/SoapCore/Meta/MetaMessage.cs
@@ -9,15 +9,23 @@ namespace SoapCore.Meta
 	{
 		private readonly Message _message;
 		private readonly ServiceDescription _service;
-		private readonly Binding _binding;
 		private readonly XmlNamespaceManager _xmlNamespaceManager;
+		private readonly string _bindingName;
+		private readonly bool _hasBasicAuthentication;
 
+		[Obsolete]
 		public MetaMessage(Message message, ServiceDescription service, Binding binding, XmlNamespaceManager xmlNamespaceManager)
+			: this(message, service, xmlNamespaceManager, binding?.Name, binding.HasBasicAuth())
+		{
+		}
+
+		public MetaMessage(Message message, ServiceDescription service, XmlNamespaceManager xmlNamespaceManager, string bindingName, bool hasBasicAuthentication)
 		{
 			_xmlNamespaceManager = xmlNamespaceManager;
 			_message = message;
 			_service = service;
-			_binding = binding;
+			_bindingName = bindingName;
+			_hasBasicAuthentication = hasBasicAuthentication;
 		}
 
 		public override MessageHeaders Headers => _message.Headers;
@@ -62,10 +70,10 @@ namespace SoapCore.Meta
 			writer.WriteAttributeString("name", _service.ServiceType.Name);
 			WriteXmlnsAttribute(writer, Namespaces.WSDL_NS);
 
-			if (_binding != null && _binding.HasBasicAuth())
+			if (_hasBasicAuthentication)
 			{
 				writer.WriteStartElement("Policy", Namespaces.WSP_NS);
-				writer.WriteAttributeString("Id", _xmlNamespaceManager.LookupPrefix(Namespaces.WSU_NS), $"{_binding.Name}_{_service.GeneralContract.Name}_policy");
+				writer.WriteAttributeString("Id", _xmlNamespaceManager.LookupPrefix(Namespaces.WSU_NS), $"{_bindingName}_{_service.GeneralContract.Name}_policy");
 				writer.WriteStartElement("ExactlyOne", Namespaces.WSP_NS);
 				writer.WriteStartElement("All", Namespaces.WSP_NS);
 				writer.WriteStartElement("BasicAuthentication", Namespaces.HTTP_NS);

--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -39,7 +39,14 @@ namespace SoapCore
 		/// Gets or sets a value indicating the binding to use
 		/// <para>Defaults to null</para>
 		/// </summary>
+		[Obsolete]
 		public Binding Binding { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value whether to use basic authentication
+		/// <para>Defaults to false</para>
+		/// </summary>
+		public bool UseBasicAuthentication { get; set; }
 
 		/// <summary>
 		/// Gets or sets a value indicating whether publication of service metadata on HTTP GET request is activated
@@ -83,5 +90,7 @@ namespace SoapCore
 		/// Gets or sets an collection of Xml Namespaces to override the default prefix for.
 		/// </summary>
 		public XmlNamespaceManager XmlNamespacePrefixOverrides { get; set; }
+
+		public WsdlFileOptions WsdlFileOptions { get; set; }
 	}
 }

--- a/src/SoapCore/SoapEncoderOptions.cs
+++ b/src/SoapCore/SoapEncoderOptions.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.ServiceModel.Channels;
 using System.Text;
 using System.Xml;
@@ -11,5 +9,23 @@ namespace SoapCore
 		public MessageVersion MessageVersion { get; set; }
 		public Encoding WriteEncoding { get; set; }
 		public XmlDictionaryReaderQuotas ReaderQuotas { get; set; }
+
+		internal static SoapEncoderOptions[] Default()
+		{
+			return new SoapEncoderOptions[]
+			{
+				new SoapEncoderOptions
+				{
+					MessageVersion = MessageVersion.Soap11,
+					WriteEncoding = Encoding.UTF8,
+					ReaderQuotas = XmlDictionaryReaderQuotas.Max
+				}
+			};
+		}
+
+		internal static SoapEncoderOptions[] ToArray(SoapEncoderOptions options)
+		{
+			return options is null ? null : new[] { options };
+		}
 	}
 }

--- a/src/SoapCore/SoapEncoderOptions.cs
+++ b/src/SoapCore/SoapEncoderOptions.cs
@@ -6,21 +6,13 @@ namespace SoapCore
 {
 	public class SoapEncoderOptions
 	{
-		public MessageVersion MessageVersion { get; set; }
-		public Encoding WriteEncoding { get; set; }
-		public XmlDictionaryReaderQuotas ReaderQuotas { get; set; }
+		public MessageVersion MessageVersion { get; set; } = MessageVersion.Soap11;
+		public Encoding WriteEncoding { get; set; } = Encoding.UTF8;
+		public XmlDictionaryReaderQuotas ReaderQuotas { get; set; } = XmlDictionaryReaderQuotas.Max;
 
-		internal static SoapEncoderOptions[] Default()
+		public static SoapEncoderOptions Default()
 		{
-			return new SoapEncoderOptions[]
-			{
-				new SoapEncoderOptions
-				{
-					MessageVersion = MessageVersion.Soap11,
-					WriteEncoding = Encoding.UTF8,
-					ReaderQuotas = XmlDictionaryReaderQuotas.Max
-				}
-			};
+			return new SoapEncoderOptions();
 		}
 
 		internal static SoapEncoderOptions[] ToArray(SoapEncoderOptions options)

--- a/src/SoapCore/SoapEncoderOptions.cs
+++ b/src/SoapCore/SoapEncoderOptions.cs
@@ -10,11 +10,6 @@ namespace SoapCore
 		public Encoding WriteEncoding { get; set; } = Encoding.UTF8;
 		public XmlDictionaryReaderQuotas ReaderQuotas { get; set; } = XmlDictionaryReaderQuotas.Max;
 
-		public static SoapEncoderOptions Default()
-		{
-			return new SoapEncoderOptions();
-		}
-
 		internal static SoapEncoderOptions[] ToArray(SoapEncoderOptions options)
 		{
 			return options is null ? null : new[] { options };

--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -16,32 +16,57 @@ namespace SoapCore
 	{
 		public static IApplicationBuilder UseSoapEndpoint<T>(this IApplicationBuilder builder, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
 		{
-			return builder.UseSoapEndpoint(typeof(T), path, new[] { encoder }, serializer, caseInsensitivePath, soapModelBounder, null, wsdlFileOptions, indentXml, omitXmlDeclaration);
+			return builder.UseSoapEndpoint<CustomMessage>(typeof(T), path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint<T, T_MESSAGE>(this IApplicationBuilder builder, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IApplicationBuilder UseSoapEndpoint<T, T_MESSAGE>(this IApplicationBuilder builder, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
 			where T_MESSAGE : CustomMessage, new()
 		{
-			return builder.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, new[] { encoder }, serializer, caseInsensitivePath, soapModelBounder, null, null, indentXml, omitXmlDeclaration);
+			return builder.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, Binding binding = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IApplicationBuilder UseSoapEndpoint(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		{
+			return builder.UseSoapEndpoint<CustomMessage>(type, path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
+		}
+
+		public static IApplicationBuilder UseSoapEndpoint<T_MESSAGE>(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+			where T_MESSAGE : CustomMessage, new()
+		{
+			return builder.UseSoapEndpoint<T_MESSAGE>(type, options =>
+			{
+				options.Path = path;
+				options.EncoderOptions = SoapEncoderOptions.ToArray(encoder);
+				options.SoapSerializer = serializer;
+				options.CaseInsensitivePath = caseInsensitivePath;
+				options.SoapModelBounder = soapModelBounder;
+				options.IndentXml = indentXml;
+				options.OmitXmlDeclaration = omitXmlDeclaration;
+				options.WsdlFileOptions = wsdlFileOptions;
+			});
+		}
+
+		[Obsolete]
+		public static IApplicationBuilder UseSoapEndpoint(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, Binding binding, bool indentXml, bool omitXmlDeclaration)
 		{
 			return builder.UseSoapEndpoint(type, path, new[] { encoder }, serializer, caseInsensitivePath, soapModelBounder, binding, null, indentXml, omitXmlDeclaration);
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint<T_MESSAGE>(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, Binding binding = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		[Obsolete]
+		public static IApplicationBuilder UseSoapEndpoint<T_MESSAGE>(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, Binding binding, bool indentXml, bool omitXmlDeclaration)
 			where T_MESSAGE : CustomMessage, new()
 		{
 			return builder.UseSoapEndpoint<T_MESSAGE>(type, path, new[] { encoder }, serializer, caseInsensitivePath, soapModelBounder, binding, null, indentXml, omitXmlDeclaration);
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint<T>(this IApplicationBuilder builder, string path, Binding binding, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		[Obsolete]
+		public static IApplicationBuilder UseSoapEndpoint<T>(this IApplicationBuilder builder, string path, Binding binding, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, WsdlFileOptions wsdlFileOptions, bool indentXml, bool omitXmlDeclaration)
 		{
 			return builder.UseSoapEndpoint(typeof(T), path, binding, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint<T, T_MESSAGE>(this IApplicationBuilder builder, string path, Binding binding, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		[Obsolete]
+		public static IApplicationBuilder UseSoapEndpoint<T, T_MESSAGE>(this IApplicationBuilder builder, string path, Binding binding, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, bool indentXml, bool omitXmlDeclaration)
 			where T_MESSAGE : CustomMessage, new()
 		{
 			return builder.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, binding, serializer, caseInsensitivePath, soapModelBounder, null, indentXml, omitXmlDeclaration);
@@ -49,29 +74,40 @@ namespace SoapCore
 
 		public static IApplicationBuilder UseSoapEndpoint<T>(this IApplicationBuilder builder, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, bool indentXml = true, bool omitXmlDeclaration = true)
 		{
-			return builder.UseSoapEndpoint(typeof(T), path, encoders, serializer, caseInsensitivePath, soapModelBounder, null, null, indentXml, omitXmlDeclaration);
+			return builder.UseSoapEndpoint<T, CustomMessage>(path, encoders, serializer, caseInsensitivePath, soapModelBounder, indentXml, omitXmlDeclaration);
 		}
 
 		public static IApplicationBuilder UseSoapEndpoint<T, T_MESSAGE>(this IApplicationBuilder builder, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, bool indentXml = true, bool omitXmlDeclaration = true)
 			where T_MESSAGE : CustomMessage, new()
 		{
-			return builder.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, encoders, serializer, caseInsensitivePath, soapModelBounder, null, null, indentXml, omitXmlDeclaration);
+			return builder.UseSoapEndpoint<T_MESSAGE>(typeof(T), options =>
+			{
+				options.Path = path;
+				options.EncoderOptions = encoders;
+				options.SoapSerializer = serializer;
+				options.CaseInsensitivePath = caseInsensitivePath;
+				options.SoapModelBounder = soapModelBounder;
+				options.IndentXml = indentXml;
+				options.OmitXmlDeclaration = omitXmlDeclaration;
+			});
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions[] encoderOptions, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, Binding binding = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		[Obsolete]
+		public static IApplicationBuilder UseSoapEndpoint(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions[] encoderOptions, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, Binding binding, WsdlFileOptions wsdlFileOptions, bool indentXml, bool omitXmlDeclaration)
 		{
 			return builder.UseSoapEndpoint<CustomMessage>(type, path, encoderOptions, serializer, caseInsensitivePath, soapModelBounder, binding, wsdlFileOptions, indentXml, omitXmlDeclaration);
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint<T_MESSAGE>(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions[] encoderOptions, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, Binding binding = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		[Obsolete]
+		public static IApplicationBuilder UseSoapEndpoint<T_MESSAGE>(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions[] encoderOptions, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, Binding binding, WsdlFileOptions wsdlFileOptions, bool indentXml, bool omitXmlDeclaration)
 			where T_MESSAGE : CustomMessage, new()
 		{
 			return UseSoapEndpoint<T_MESSAGE>(builder, type, options =>
 			{
-				options.UseBasicAuthentication = binding.HasBasicAuth();
-				options.CaseInsensitivePath = caseInsensitivePath;
-				options.EncoderOptions = encoderOptions ?? binding.ToEncoderOptions();
 				options.Path = path;
+				options.UseBasicAuthentication = binding.HasBasicAuth();
+				options.EncoderOptions = encoderOptions ?? binding.ToEncoderOptions();
+				options.CaseInsensitivePath = caseInsensitivePath;
 				options.SoapSerializer = serializer;
 				options.SoapModelBounder = soapModelBounder;
 				options.WsdlFileOptions = wsdlFileOptions;
@@ -80,12 +116,14 @@ namespace SoapCore
 			});
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint(this IApplicationBuilder builder, Type type, string path, Binding binding, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		[Obsolete]
+		public static IApplicationBuilder UseSoapEndpoint(this IApplicationBuilder builder, Type type, string path, Binding binding, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, WsdlFileOptions wsdlFileOptions, bool indentXml, bool omitXmlDeclaration)
 		{
 			return builder.UseSoapEndpoint<CustomMessage>(type, path, binding, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint<T_MESSAGE>(this IApplicationBuilder builder, Type type, string path, Binding binding, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		[Obsolete]
+		public static IApplicationBuilder UseSoapEndpoint<T_MESSAGE>(this IApplicationBuilder builder, Type type, string path, Binding binding, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, WsdlFileOptions wsdlFileOptions, bool indentXml, bool omitXmlDeclaration)
 			where T_MESSAGE : CustomMessage, new()
 		{
 			return UseSoapEndpoint<T_MESSAGE>(builder, type, options =>
@@ -100,6 +138,11 @@ namespace SoapCore
 				options.IndentXml = indentXml;
 				options.OmitXmlDeclaration = omitXmlDeclaration;
 			});
+		}
+
+		public static IApplicationBuilder UseSoapEndpoint(this IApplicationBuilder builder, Type serviceType, Action<SoapCoreOptions> options)
+		{
+			return builder.UseSoapEndpoint<CustomMessage>(serviceType, options);
 		}
 
 		public static IApplicationBuilder UseSoapEndpoint<T>(this IApplicationBuilder builder, Action<SoapCoreOptions> options)
@@ -125,34 +168,70 @@ namespace SoapCore
 		}
 
 #if NETCOREAPP3_0_OR_GREATER
-		public static IEndpointConventionBuilder UseSoapEndpoint<T>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IEndpointConventionBuilder UseSoapEndpoint<T>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
 		{
-			return routes.UseSoapEndpoint(typeof(T), path, new[] { encoder }, serializer, caseInsensitivePath, soapModelBounder, null, wsdlFileOptions, indentXml, omitXmlDeclaration);
+			return routes.UseSoapEndpoint<T, CustomMessage>(path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
 			where T_MESSAGE : CustomMessage, new()
 		{
-			return routes.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, new[] { encoder }, serializer, caseInsensitivePath, soapModelBounder, null, wsdlFileOptions, indentXml, omitXmlDeclaration);
+			return routes.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, Binding binding = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IEndpointConventionBuilder UseSoapEndpoint(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
 		{
-			return routes.UseSoapEndpoint(type, path, new[] { encoder }, serializer, caseInsensitivePath, soapModelBounder, binding, null, indentXml, omitXmlDeclaration);
+			return routes.UseSoapEndpoint<CustomMessage>(type, path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint<T_MESSAGE>(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, Binding binding = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IEndpointConventionBuilder UseSoapEndpoint<T_MESSAGE>(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
 			where T_MESSAGE : CustomMessage, new()
 		{
-			return routes.UseSoapEndpoint<T_MESSAGE>(type, path, new[] { encoder }, serializer, caseInsensitivePath, soapModelBounder, binding, wsdlFileOptions, indentXml, omitXmlDeclaration);
+			return routes.UseSoapEndpoint<T_MESSAGE>(type, options =>
+			{
+				options.Path = path;
+				options.EncoderOptions = SoapEncoderOptions.ToArray(encoder);
+				options.SoapSerializer = serializer;
+				options.CaseInsensitivePath = caseInsensitivePath;
+				options.SoapModelBounder = soapModelBounder;
+				options.WsdlFileOptions = wsdlFileOptions;
+				options.IndentXml = indentXml;
+				options.OmitXmlDeclaration = omitXmlDeclaration;
+			});
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint<T>(this IEndpointRouteBuilder routes, string path, Binding binding, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		[Obsolete]
+		public static IEndpointConventionBuilder UseSoapEndpoint(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, Binding binding, bool indentXml, bool omitXmlDeclaration)
+		{
+			return routes.UseSoapEndpoint<CustomMessage>(type, path, encoder, serializer, caseInsensitivePath, soapModelBounder, binding, null, indentXml, omitXmlDeclaration);
+		}
+
+		[Obsolete]
+		public static IEndpointConventionBuilder UseSoapEndpoint<T_MESSAGE>(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, Binding binding, WsdlFileOptions wsdlFileOptions, bool indentXml, bool omitXmlDeclaration)
+			where T_MESSAGE : CustomMessage, new()
+		{
+			return routes.UseSoapEndpoint<T_MESSAGE>(type, options =>
+			{
+				options.Path = path;
+				options.UseBasicAuthentication = binding.HasBasicAuth();
+				options.EncoderOptions = SoapEncoderOptions.ToArray(encoder) ?? binding.ToEncoderOptions();
+				options.SoapSerializer = serializer;
+				options.CaseInsensitivePath = caseInsensitivePath;
+				options.SoapModelBounder = soapModelBounder;
+				options.WsdlFileOptions = wsdlFileOptions;
+				options.IndentXml = indentXml;
+				options.OmitXmlDeclaration = omitXmlDeclaration;
+			});
+		}
+
+		[Obsolete]
+		public static IEndpointConventionBuilder UseSoapEndpoint<T>(this IEndpointRouteBuilder routes, string path, Binding binding, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, WsdlFileOptions wsdlFileOptions, bool indentXml, bool omitXmlDeclaration)
 		{
 			return routes.UseSoapEndpoint(typeof(T), path, binding, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions: wsdlFileOptions, indentXml: indentXml, omitXmlDeclaration: omitXmlDeclaration);
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, Binding binding, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		[Obsolete]
+		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, Binding binding, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, bool indentXml, bool omitXmlDeclaration)
 			where T_MESSAGE : CustomMessage, new()
 		{
 			return routes.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, binding, serializer, caseInsensitivePath, soapModelBounder, null, indentXml, omitXmlDeclaration);
@@ -160,30 +239,31 @@ namespace SoapCore
 
 		public static IEndpointConventionBuilder UseSoapEndpoint<T>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
 		{
-			return routes.UseSoapEndpoint(typeof(T), path, encoders, serializer, caseInsensitivePath, soapModelBounder, null, wsdlFileOptions, indentXml, omitXmlDeclaration);
+			return routes.UseSoapEndpoint<T, CustomMessage>(path, encoders, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
 		}
 
 		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, bool indentXml = true, bool omitXmlDeclaration = true)
 			where T_MESSAGE : CustomMessage, new()
 		{
-			return routes.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, encoders, serializer, caseInsensitivePath, soapModelBounder, null, null, indentXml, omitXmlDeclaration);
+			return routes.UseSoapEndpoint<T, T_MESSAGE>(path, encoders, serializer, caseInsensitivePath, soapModelBounder, null, indentXml, omitXmlDeclaration);
 		}
 
 		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
 		where T_MESSAGE : CustomMessage, new()
 		{
-			return routes.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, encoders, serializer, caseInsensitivePath, soapModelBounder, null, wsdlFileOptions, indentXml, omitXmlDeclaration);
+			return routes.UseSoapEndpoint<T, T_MESSAGE>(path, encoders, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint<T_MESSAGE>(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, Binding binding = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		[Obsolete]
+		public static IEndpointConventionBuilder UseSoapEndpoint<T_MESSAGE>(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, Binding binding, WsdlFileOptions wsdlFileOptions, bool indentXml, bool omitXmlDeclaration)
 			where T_MESSAGE : CustomMessage, new()
 		{
 			return UseSoapEndpoint<T_MESSAGE>(routes, type, options =>
 			{
-				options.UseBasicAuthentication = binding.HasBasicAuth();
-				options.CaseInsensitivePath = caseInsensitivePath;
-				options.EncoderOptions = encoders ?? binding.ToEncoderOptions();
 				options.Path = path;
+				options.UseBasicAuthentication = binding.HasBasicAuth();
+				options.EncoderOptions = encoders ?? binding.ToEncoderOptions();
+				options.CaseInsensitivePath = caseInsensitivePath;
 				options.SoapSerializer = serializer;
 				options.SoapModelBounder = soapModelBounder;
 				options.WsdlFileOptions = wsdlFileOptions;
@@ -192,12 +272,14 @@ namespace SoapCore
 			});
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, Binding binding = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		[Obsolete]
+		public static IEndpointConventionBuilder UseSoapEndpoint(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, Binding binding, WsdlFileOptions wsdlFileOptions, bool indentXml, bool omitXmlDeclaration)
 		{
 			return UseSoapEndpoint<CustomMessage>(routes, type, path, encoders, serializer, caseInsensitivePath, soapModelBounder, binding, wsdlFileOptions, indentXml, omitXmlDeclaration);
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint<T_MESSAGE>(this IEndpointRouteBuilder routes, Type type, string path, Binding binding, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		[Obsolete]
+		public static IEndpointConventionBuilder UseSoapEndpoint<T_MESSAGE>(this IEndpointRouteBuilder routes, Type type, string path, Binding binding, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, WsdlFileOptions wsdlFileOptions, bool indentXml, bool omitXmlDeclaration)
 			where T_MESSAGE : CustomMessage, new()
 		{
 			return UseSoapEndpoint<T_MESSAGE>(routes, type, options =>
@@ -214,7 +296,8 @@ namespace SoapCore
 			});
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint(this IEndpointRouteBuilder routes, Type type, string path, Binding binding, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		[Obsolete]
+		public static IEndpointConventionBuilder UseSoapEndpoint(this IEndpointRouteBuilder routes, Type type, string path, Binding binding, SoapSerializer serializer, bool caseInsensitivePath, ISoapModelBounder soapModelBounder, WsdlFileOptions wsdlFileOptions, bool indentXml, bool omitXmlDeclaration)
 		{
 			return UseSoapEndpoint<CustomMessage>(routes, type, path, binding, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
 		}

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -39,11 +39,11 @@ namespace SoapCore
 			{
 				ServiceType = serviceType,
 				Path = path,
-				EncoderOptions = encoderOptions,
+				EncoderOptions = encoderOptions ?? binding?.ToEncoderOptions(),
 				SoapSerializer = serializer,
 				CaseInsensitivePath = caseInsensitivePath,
 				SoapModelBounder = soapModelBounder,
-				Binding = binding,
+				UseBasicAuthentication = binding.HasBasicAuth(),
 				HttpGetEnabled = httpGetEnabled,
 				HttpsGetEnabled = httpsGetEnabled
 			})
@@ -59,6 +59,11 @@ namespace SoapCore
 			_serializerHelper = new SerializerHelper(options.SoapSerializer);
 			_pathComparisonStrategy = options.CaseInsensitivePath ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 			_service = new ServiceDescription(options.ServiceType);
+
+			if (options.EncoderOptions is null)
+			{
+				options.EncoderOptions = SoapEncoderOptions.Default();
+			}
 
 			_messageEncoders = new SoapMessageEncoder[options.EncoderOptions.Length];
 
@@ -151,9 +156,18 @@ namespace SoapCore
 		{
 			var baseUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host + httpContext.Request.PathBase + httpContext.Request.Path;
 			var xmlNamespaceManager = GetXmlNamespaceManager();
-			var binding = _options.Binding;
-			var bodyWriter = _options.SoapSerializer == SoapSerializer.XmlSerializer ? new MetaBodyWriter(_service, baseUrl, binding, xmlNamespaceManager) : (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, binding);
-			using var responseMessage = new MetaMessage(Message.CreateMessage(_messageEncoders[0].MessageVersion, null, bodyWriter), _service, binding, xmlNamespaceManager);
+			var bindingName = "BasicHttpBinding";
+
+			var bodyWriter = _options.SoapSerializer == SoapSerializer.XmlSerializer
+				? new MetaBodyWriter(_service, baseUrl, xmlNamespaceManager, bindingName, _messageEncoders[0].MessageVersion)
+				: (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, bindingName, _options.UseBasicAuthentication);
+
+			using var responseMessage = new MetaMessage(
+				Message.CreateMessage(_messageEncoders[0].MessageVersion, null, bodyWriter),
+				_service,
+				xmlNamespaceManager,
+				bindingName,
+				_options.UseBasicAuthentication);
 
 			//we should use text/xml in wsdl page for browser compability.
 			httpContext.Response.ContentType = "text/xml;charset=UTF-8"; // _messageEncoders[0].ContentType;

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -62,7 +62,7 @@ namespace SoapCore
 
 			if (options.EncoderOptions is null)
 			{
-				options.EncoderOptions = new[] { SoapEncoderOptions.Default() };
+				options.EncoderOptions = new[] { new SoapEncoderOptions() };
 			}
 
 			_messageEncoders = new SoapMessageEncoder[options.EncoderOptions.Length];

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -62,7 +62,7 @@ namespace SoapCore
 
 			if (options.EncoderOptions is null)
 			{
-				options.EncoderOptions = SoapEncoderOptions.Default();
+				options.EncoderOptions = new[] { SoapEncoderOptions.Default() };
 			}
 
 			_messageEncoders = new SoapMessageEncoder[options.EncoderOptions.Length];

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.ServiceModel.Channels;
 using System.Xml;
 using SoapCore.Extensibility;
+using SoapCore.Meta;
 
 namespace SoapCore
 {
@@ -13,10 +14,14 @@ namespace SoapCore
 		public SoapSerializer SoapSerializer { get; set; }
 		public bool CaseInsensitivePath { get; set; }
 		public ISoapModelBounder SoapModelBounder { get; set; }
-		public Binding Binding { get; set; }
 
 		[Obsolete]
-		public int BufferThreshold { get; set; } = 1024 * 30;
+		public Binding Binding { get; set; }
+
+		public bool UseBasicAuthentication { get; set; }
+
+		[Obsolete]
+		public int BufferThreshold { get; set; }
 		[Obsolete]
 		public long BufferLimit { get; set; }
 
@@ -39,6 +44,7 @@ namespace SoapCore
 		public XmlNamespaceManager XmlNamespacePrefixOverrides { get; set; }
 		public WsdlFileOptions WsdlFileOptions { get; set; }
 
+		[Obsolete]
 		public static SoapOptions FromSoapCoreOptions<T>(SoapCoreOptions opt)
 		{
 			return FromSoapCoreOptions(opt, typeof(T));
@@ -46,7 +52,7 @@ namespace SoapCore
 
 		public static SoapOptions FromSoapCoreOptions(SoapCoreOptions opt, Type serviceType)
 		{
-			var soapOptions = new SoapOptions
+			var options = new SoapOptions
 			{
 				ServiceType = serviceType,
 				Path = opt.Path,
@@ -54,19 +60,31 @@ namespace SoapCore
 				SoapSerializer = opt.SoapSerializer,
 				CaseInsensitivePath = opt.CaseInsensitivePath,
 				SoapModelBounder = opt.SoapModelBounder,
-				Binding = opt.Binding,
-#pragma warning disable CS0612 // Type or member is obsolete
-				BufferThreshold = opt.BufferThreshold,
-				BufferLimit = opt.BufferLimit,
-#pragma warning restore CS0612 // Type or member is obsolete
+				UseBasicAuthentication = opt.UseBasicAuthentication,
 				HttpsGetEnabled = opt.HttpsGetEnabled,
 				HttpGetEnabled = opt.HttpGetEnabled,
 				OmitXmlDeclaration = opt.OmitXmlDeclaration,
 				IndentXml = opt.IndentXml,
-				XmlNamespacePrefixOverrides = opt.XmlNamespacePrefixOverrides
+				XmlNamespacePrefixOverrides = opt.XmlNamespacePrefixOverrides,
+				WsdlFileOptions = opt.WsdlFileOptions
 			};
 
-			return soapOptions;
+#pragma warning disable CS0612 // Type or member is obsolete
+			if (opt.Binding is object)
+			{
+				if (opt.Binding.HasBasicAuth())
+				{
+					options.UseBasicAuthentication = true;
+				}
+
+				if (options.EncoderOptions is null)
+				{
+					opt.EncoderOptions = opt.Binding.ToEncoderOptions();
+				}
+			}
+#pragma warning restore CS0612 // Type or member is obsolete
+
+			return options;
 		}
 	}
 }


### PR DESCRIPTION
Always `Binding` is converted to `SoapEncoderOptions`.

Use  `SoapEncoderOptions` directly and obsolete all methods that use `Binding`.