### PR TITLE
Fix empty namespace wsdl error

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/IEmptyNamespaceService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IEmptyNamespaceService.cs
@@ -1,0 +1,19 @@
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract(Namespace = "")]
+	public interface IEmptyNamespaceService
+	{
+		[OperationContract]
+		void TestMethod();
+	}
+
+	public class EmptyNamespaceService : IEmptyNamespaceService
+	{
+		public void TestMethod()
+		{
+			// Do nothing
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -205,6 +205,17 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[TestMethod]
+		public void CheckEmptyNamesapce()
+		{
+			StartService(typeof(EmptyNamespaceService));
+			var wsdl = GetWsdl();
+			StopServer();
+
+			var root = XElement.Parse(wsdl);
+			Assert.IsNotNull(root);
+		}
+
+		[TestMethod]
 		public void CheckValueTypes()
 		{
 			StartService(typeof(ValueTypeService));

--- a/src/SoapCore/Meta/MetaMessage.cs
+++ b/src/SoapCore/Meta/MetaMessage.cs
@@ -101,7 +101,7 @@ namespace SoapCore.Meta
 
 		private void WriteXmlnsAttribute(XmlDictionaryWriter writer, string namespaceUri)
 		{
-			var prefix = _xmlNamespaceManager.LookupPrefix(namespaceUri);
+			var prefix = string.IsNullOrEmpty(namespaceUri) ? null : _xmlNamespaceManager.LookupPrefix(namespaceUri);
 			writer.WriteXmlnsAttribute(prefix, namespaceUri);
 		}
 	}


### PR DESCRIPTION
Resolves #721

Fixes ab error preventing the generating of a WSDL file with an empty namespace.