### PR TITLE
handling of when Action is null and when someone tries to access /mex or /$metadata

### DIFF
--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -326,6 +326,9 @@ namespace SoapCore
 				.UseMiddleware<SoapEndpointMiddleware<T_MESSAGE>>(soapOptions)
 				.Build();
 
+			routes.Map(soapOptions.Path + "/$metadata", pipeline);
+			routes.Map(soapOptions.Path + "/mex", pipeline);
+
 			return routes.Map(soapOptions.Path, pipeline)
 				.WithDisplayName("SoapCore");
 		}


### PR DESCRIPTION
- Service doesn't crash if you try to post without an action (as "Add service reference" does)
- Gives a clear error when you try to access /mex or /$metadata

Not sure if this is the best way to do it though