### PR TITLE
wsdl has two ComplexType tags for void method with out parameters

### DIFF
--- a/src/SoapCore.sln
+++ b/src/SoapCore.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31815.197
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoapCore", "SoapCore\SoapCore.csproj", "{576F47D4-97EC-4D42-8CD5-89648EEAB688}"
 EndProject


### PR DESCRIPTION
I missed void methods in my previous commit
Have a nice weekend 😄 