### PR TITLE
added support (and test) for arrayofarrayof

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/ArrayService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ArrayService.cs
@@ -26,6 +26,7 @@ namespace SoapCore.Tests.Wsdl.Services
 	{
 		public IEnumerable<long?> LongNullableEnumerable { get; set; }
 		public IEnumerable<long> LongEnumerable { get; set; }
+		public IEnumerable<IEnumerable<long>> LongEnumerableEnumerable { get; set; }
 	}
 
 	[MessageContract]
@@ -33,5 +34,6 @@ namespace SoapCore.Tests.Wsdl.Services
 	{
 		public long?[] LongNullableArray { get; set; }
 		public long[] LongArray { get; set; }
+		public long[][] LongArrayArray { get; set; }
 	}
 }

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -553,11 +553,17 @@ namespace SoapCore.Tests.Wsdl
 			var array = root.XPathSelectElement("//xsd:complexType[@name='ArrayRequest']/xsd:sequence/xsd:element[@name='LongArray' and @type='tns:ArrayOfLong' and @nillable='true']", nm);
 			Assert.IsNotNull(array);
 
+			var arrayArray = root.XPathSelectElement("//xsd:complexType[@name='ArrayRequest']/xsd:sequence/xsd:element[@name='LongArrayArray' and @type='tns:ArrayOfArrayOfLong' and @nillable='true']", nm);
+			Assert.IsNotNull(arrayArray);
+
 			var nullableEnumerable = root.XPathSelectElement("//xsd:complexType[@name='EnumerableResponse']/xsd:sequence/xsd:element[@name='LongNullableEnumerable' and @type='tns:ArrayOfNullableLong' and @nillable='true']", nm);
 			Assert.IsNotNull(nullableEnumerable);
 
 			var enumerable = root.XPathSelectElement("//xsd:complexType[@name='EnumerableResponse']/xsd:sequence/xsd:element[@name='LongEnumerable' and @type='tns:ArrayOfLong' and @nillable='true']", nm);
 			Assert.IsNotNull(enumerable);
+
+			var enumerableEnumberable = root.XPathSelectElement("//xsd:complexType[@name='EnumerableResponse']/xsd:sequence/xsd:element[@name='LongEnumerableEnumerable' and @type='tns:ArrayOfArrayOfLong' and @nillable='true']", nm);
+			Assert.IsNotNull(enumerableEnumberable);
 		}
 
 		[TestMethod]

--- a/src/SoapCore/Meta/BodyWriterExtensions.cs
+++ b/src/SoapCore/Meta/BodyWriterExtensions.cs
@@ -220,14 +220,14 @@ namespace SoapCore.Meta
 				typeName = xmlTypeAttribute.TypeName;
 			}
 
-			if (type.IsArray)
+			if (type.IsArray || (typeof(IEnumerable).IsAssignableFrom(type) && type.IsGenericType))
 			{
-				typeName = GetArrayTypeName(typeName.Replace("[]", string.Empty), isNullableArray);
-			}
+				if (namedType.IsArray || (typeof(IEnumerable).IsAssignableFrom(type) && type.IsGenericType))
+				{
+					typeName = GetSerializedTypeName(namedType);
+				}
 
-			if (typeof(IEnumerable).IsAssignableFrom(type) && type.IsGenericType)
-			{
-				typeName = GetArrayTypeName(typeName, isNullableArray);
+				typeName = GetArrayTypeName(typeName.Replace("[]", string.Empty), isNullableArray);
 			}
 
 			return typeName;


### PR DESCRIPTION
We have a method that returns `List<List<Thingy>>`. That resulted in a return type of ArrayOfList'1 in the wsdl.

This PR fixes so that nested arrays/ienumerables works.

If you merge this PR I'd appreciate a new nuget package