### PR TITLE
correct netstandard2.1 dependencies and update benchmark project

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The following frameworks are supported:
 - .NET 6.0 (using ASP.NET Core 6.0)
 - .NET 5.0 (using ASP.NET Core 5.0)
 - .NET Core 3.1 (using ASP.NET Core 3.1)
+- .NET Standard 2.1 (using ASP.NET Core 2.1)
 - .NET Standard 2.0 (using ASP.NET Core 2.1)
-- .NET Standard 2.1 (using ASP.NET Core 2.2)
 
 ### Installing
 

--- a/src/SoapCore.Benchmark/SoapCore.Benchmark.csproj
+++ b/src/SoapCore.Benchmark/SoapCore.Benchmark.csproj
@@ -2,18 +2,12 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 		<CodeAnalysisRuleSet>..\SoapCore.ruleset</CodeAnalysisRuleSet>
 		<NoWin32Manifest>true</NoWin32Manifest>
 		<LangVersion>8</LangVersion>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
-	
-	<ItemGroup Condition="$(TargetFramework) =='netcoreapp2.1'">
-		<PackageReference Include="Microsoft.AspNetCore" Version="2.1.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.0" />
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.0" />
-	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
@@ -23,8 +17,12 @@
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.0" />
 	</ItemGroup>
 
+	<ItemGroup Condition="$(TargetFramework) == 'net6.0'">
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" />
+	</ItemGroup>
+
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SoapCore.Benchmark/Startup.cs
+++ b/src/SoapCore.Benchmark/Startup.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading.Tasks;
 
 namespace SoapCore.Benchmark
 {
@@ -14,7 +16,7 @@ namespace SoapCore.Benchmark
 		public void Configure(IApplicationBuilder app)
 		{
 			app.UseSoapEndpoint<PingService>("/TestService.asmx", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
-			app.Use(async (ctx, next) =>
+			app.Use(async (HttpContext ctx, Func<Task> next) =>
 			{
 				await ctx.Response.WriteAsync("").ConfigureAwait(false);
 			});

--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -27,7 +27,7 @@
 		<AdditionalFiles Include="stylecop.json" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'netcoreapp2.1'">
+	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'netstandard2.1'">
 		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
@@ -49,14 +49,6 @@
 		<PackageReference Include="System.CodeDom" Version="6.0.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.1'">
-		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-		<PackageReference Include="System.IO.Pipelines" Version="6.0.0" />
-		<PackageReference Include="System.CodeDom" Version="6.0.0" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<None Include="..\logo.png">
 			<Pack>True</Pack>
@@ -65,7 +57,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
 		<PackageReference Include="System.ServiceModel.Http" Version="4.8.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "6.0.100",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
ASP.NET Core 2.2 is EOL (see https://en.wikipedia.org/wiki/ASP.NET_Core).
ASP.NET Core 2.1 is still supported for .NET Framework (see https://dotnet.microsoft.com/platform/support/policy/dotnet-core).