### PR TITLE
Message inspector 3

### DIFF
--- a/src/SoapCore.Tests/MessageInspectors/InspectorStyle.cs
+++ b/src/SoapCore.Tests/MessageInspectors/InspectorStyle.cs
@@ -3,6 +3,7 @@ namespace SoapCore.Tests.MessageInspectors
 	public enum InspectorStyle
 	{
 		MessageInspector,
-		MessageInspector2
+		MessageInspector2,
+		MessageInspector3
 	}
 }

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector3/MessageInspector3Mock.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector3/MessageInspector3Mock.cs
@@ -24,10 +24,7 @@ namespace SoapCore.Tests.MessageInspectors.MessageInspector3
 			LastReceivedMessage = message;
 			AfterReceivedRequestCalled = true;
 
-			// validate message
-			ValidateMessage(ref message);
-
-			return null;
+			return ValidateMessage(ref message);
 		}
 
 		public void BeforeSendReply(ref Message reply, ServiceDescription serviceDescription, object correlationState)
@@ -35,9 +32,9 @@ namespace SoapCore.Tests.MessageInspectors.MessageInspector3
 			BeforeSendReplyCalled = true;
 		}
 
-		private void ValidateMessage(ref Message message)
+		private string ValidateMessage(ref Message message)
 		{
-			throw new FaultException(new FaultReason("Message is invalid."), new FaultCode("Sender"), null);
+			return "Failed";
 		}
 	}
 }

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector3/MessageInspector3Mock.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector3/MessageInspector3Mock.cs
@@ -9,14 +9,12 @@ namespace SoapCore.Tests.MessageInspectors.MessageInspector3
 	public class MessageInspector3Mock : IMessageInspector3
 	{
 		public static bool AfterReceivedRequestCalled { get; private set; }
-		public static bool BeforeSendReplyCalled { get; private set; }
 		public static Message LastReceivedMessage { get; private set; }
 
 		public static void Reset()
 		{
 			LastReceivedMessage = null;
 			AfterReceivedRequestCalled = false;
-			BeforeSendReplyCalled = false;
 		}
 
 		public object AfterReceiveRequest(ref Message message, ServiceDescription serviceDescription, HttpContext httpContext)
@@ -25,11 +23,6 @@ namespace SoapCore.Tests.MessageInspectors.MessageInspector3
 			AfterReceivedRequestCalled = true;
 
 			return ValidateMessage(ref message);
-		}
-
-		public void BeforeSendReply(ref Message reply, ServiceDescription serviceDescription, object correlationState)
-		{
-			BeforeSendReplyCalled = true;
 		}
 
 		private string ValidateMessage(ref Message message)

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector3/MessageInspector3Mock.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector3/MessageInspector3Mock.cs
@@ -1,0 +1,43 @@
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using Microsoft.AspNetCore.Http;
+using SoapCore.Extensibility;
+using SoapCore.ServiceModel;
+
+namespace SoapCore.Tests.MessageInspectors.MessageInspector3
+{
+	public class MessageInspector3Mock : IMessageInspector3
+	{
+		public static bool AfterReceivedRequestCalled { get; private set; }
+		public static bool BeforeSendReplyCalled { get; private set; }
+		public static Message LastReceivedMessage { get; private set; }
+
+		public static void Reset()
+		{
+			LastReceivedMessage = null;
+			AfterReceivedRequestCalled = false;
+			BeforeSendReplyCalled = false;
+		}
+
+		public object AfterReceiveRequest(ref Message message, ServiceDescription serviceDescription, HttpContext httpContext)
+		{
+			LastReceivedMessage = message;
+			AfterReceivedRequestCalled = true;
+
+			// validate message
+			ValidateMessage(ref message);
+
+			return null;
+		}
+
+		public void BeforeSendReply(ref Message reply, ServiceDescription serviceDescription, object correlationState)
+		{
+			BeforeSendReplyCalled = true;
+		}
+
+		private void ValidateMessage(ref Message message)
+		{
+			throw new FaultException(new FaultReason("Message is invalid."), new FaultCode("Sender"), null);
+		}
+	}
+}

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector3/MessageInspector3Tests.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector3/MessageInspector3Tests.cs
@@ -42,30 +42,22 @@ namespace SoapCore.Tests.MessageInspectors.MessageInspector3
 		}
 
 		[TestMethod]
-		[ExpectedException(typeof(FaultException))]
 		public void AfterReceivedRequestCalled()
 		{
 			Assert.IsFalse(MessageInspector3Mock.AfterReceivedRequestCalled);
 			var client = CreateClient();
-			var result = client.Ping("Hello World");
+			var result = client.Ping("Fail");
+			Assert.AreEqual("Failed", result);
 			Assert.IsTrue(MessageInspector3Mock.AfterReceivedRequestCalled);
 		}
 
 		[TestMethod]
-		[ExpectedException(typeof(FaultException))]
 		public void BeforeSendReplyShouldNotBeCalled()
 		{
 			Assert.IsFalse(MessageInspector3Mock.BeforeSendReplyCalled);
 			var client = CreateClient();
 			var result = client.Ping("Hello World");
 			Assert.IsFalse(MessageInspector3Mock.BeforeSendReplyCalled);
-		}
-
-		[TestMethod]
-		public void AfterReceivedThrowsException()
-		{
-			var client = CreateClient();
-			Assert.ThrowsException<FaultException>(() => client.Ping("Hello World"));
 		}
 	}
 }

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector3/MessageInspector3Tests.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector3/MessageInspector3Tests.cs
@@ -50,14 +50,5 @@ namespace SoapCore.Tests.MessageInspectors.MessageInspector3
 			Assert.AreEqual("Failed", result);
 			Assert.IsTrue(MessageInspector3Mock.AfterReceivedRequestCalled);
 		}
-
-		[TestMethod]
-		public void BeforeSendReplyShouldNotBeCalled()
-		{
-			Assert.IsFalse(MessageInspector3Mock.BeforeSendReplyCalled);
-			var client = CreateClient();
-			var result = client.Ping("Hello World");
-			Assert.IsFalse(MessageInspector3Mock.BeforeSendReplyCalled);
-		}
 	}
 }

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector3/MessageInspector3Tests.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector3/MessageInspector3Tests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SoapCore.Tests.MessageInspectors.MessageInspector3
+{
+	[TestClass]
+	public class MessageInspector3Tests
+	{
+		[ClassInitialize]
+		public static void StartServer(TestContext testContext)
+		{
+			Task.Run(() =>
+			{
+				var host = new WebHostBuilder()
+					.UseKestrel()
+					.UseUrls("http://localhost:7052")
+					.UseStartup<Startup>()
+					.UseSetting("InspectorStyle", InspectorStyle.MessageInspector3.ToString())
+					.Build();
+
+				host.Run();
+			}).Wait(1000);
+		}
+
+		[TestInitialize]
+		public void Reset()
+		{
+			MessageInspector3Mock.Reset();
+		}
+
+		public ITestService CreateClient()
+		{
+			var binding = new BasicHttpBinding();
+			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:7052/Service.svc", "localhost")));
+			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);
+			var serviceClient = channelFactory.CreateChannel();
+			return serviceClient;
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(FaultException))]
+		public void AfterReceivedRequestCalled()
+		{
+			Assert.IsFalse(MessageInspector3Mock.AfterReceivedRequestCalled);
+			var client = CreateClient();
+			var result = client.Ping("Hello World");
+			Assert.IsTrue(MessageInspector3Mock.AfterReceivedRequestCalled);
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(FaultException))]
+		public void BeforeSendReplyShouldNotBeCalled()
+		{
+			Assert.IsFalse(MessageInspector3Mock.BeforeSendReplyCalled);
+			var client = CreateClient();
+			var result = client.Ping("Hello World");
+			Assert.IsFalse(MessageInspector3Mock.BeforeSendReplyCalled);
+		}
+
+		[TestMethod]
+		public void AfterReceivedThrowsException()
+		{
+			var client = CreateClient();
+			Assert.ThrowsException<FaultException>(() => client.Ping("Hello World"));
+		}
+	}
+}

--- a/src/SoapCore.Tests/MessageInspectors/Startup.cs
+++ b/src/SoapCore.Tests/MessageInspectors/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using SoapCore.Tests.MessageInspectors.MessageInspector;
 using SoapCore.Tests.MessageInspectors.MessageInspector2;
+using SoapCore.Tests.MessageInspectors.MessageInspector3;
 
 namespace SoapCore.Tests.MessageInspectors
 {
@@ -35,6 +36,9 @@ namespace SoapCore.Tests.MessageInspectors
 					break;
 				case InspectorStyle.MessageInspector2:
 					services.AddSoapMessageInspector(new MessageInspector2Mock());
+					break;
+				case InspectorStyle.MessageInspector3:
+					services.AddSoapMessageInspector(new MessageInspector3Mock());
 					break;
 			}
 

--- a/src/SoapCore/Extensibility/IMessageInspector3.cs
+++ b/src/SoapCore/Extensibility/IMessageInspector3.cs
@@ -1,0 +1,12 @@
+using System.ServiceModel.Channels;
+using Microsoft.AspNetCore.Http;
+using SoapCore.ServiceModel;
+
+namespace SoapCore.Extensibility
+{
+	public interface IMessageInspector3
+	{
+		object AfterReceiveRequest(ref Message message, ServiceDescription serviceDescription, HttpContext httpContext);
+		void BeforeSendReply(ref Message reply, ServiceDescription serviceDescription, object correlationState);
+	}
+}

--- a/src/SoapCore/Extensibility/IMessageInspector3.cs
+++ b/src/SoapCore/Extensibility/IMessageInspector3.cs
@@ -7,6 +7,5 @@ namespace SoapCore.Extensibility
 	public interface IMessageInspector3
 	{
 		object AfterReceiveRequest(ref Message message, ServiceDescription serviceDescription, HttpContext httpContext);
-		void BeforeSendReply(ref Message reply, ServiceDescription serviceDescription, object correlationState);
 	}
 }

--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -390,6 +390,11 @@ namespace SoapCore
 			serviceCollection.AddSingleton(messageInspector);
 			return serviceCollection;
 		}
+		public static IServiceCollection AddSoapMessageInspector(this IServiceCollection serviceCollection, IMessageInspector3 messageInspector)
+		{
+			serviceCollection.AddSingleton(messageInspector);
+			return serviceCollection;
+		}
 
 		[Obsolete]
 		public static IServiceCollection AddSoapMessageFilter(this IServiceCollection serviceCollection, IMessageFilter messageFilter)


### PR DESCRIPTION
Problem:
I need a way to 
1. Validate some http header 
2. Validate Message against XmlSchema

Before deserializing request Message into typed input
And respond with a specific SOAP Message (no faults) if either fail.

Tried using MessageInspector2 and Tuner but they don't provide a seamless way to skip the pipeline and issue a response.

This PR adds a way to do just that with the IMessageInspector3.

Please let me know if this can be tackled with the existing functionality, or any other suggestion.

To do:
Add some more tests and docs. 