### PR TITLE
Allow serialization of invalid xml characters

### DIFF
--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -742,7 +742,7 @@ namespace SoapCore.Tests.Wsdl
 			var bodyWriter = serializer == SoapSerializer.DataContractSerializer
 				? new MetaWCFBodyWriter(service, baseUrl, "BasicHttpBinding", false) as BodyWriter
 				: new MetaBodyWriter(service, baseUrl, xmlNamespaceManager, "BasicHttpBinding", new[] { MessageVersion.None }) as BodyWriter;
-			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, System.Text.Encoding.UTF8, XmlDictionaryReaderQuotas.Max, false, true);
+			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, System.Text.Encoding.UTF8, XmlDictionaryReaderQuotas.Max, false, true, false);
 			var responseMessage = Message.CreateMessage(encoder.MessageVersion, null, bodyWriter);
 			responseMessage = new MetaMessage(responseMessage, service, xmlNamespaceManager, "BasicHttpBinding", false);
 

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -28,11 +28,13 @@ namespace SoapCore.MessageEncoder
 		private readonly bool _omitXmlDeclaration;
 		private readonly bool _indentXml;
 		private readonly bool _supportXmlDictionaryReader;
+		private readonly bool _checkXmlCharacters;
 
-		public SoapMessageEncoder(MessageVersion version, Encoding writeEncoding, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool indentXml)
+		public SoapMessageEncoder(MessageVersion version, Encoding writeEncoding, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool indentXml, bool checkXmlCharacters)
 		{
 			_indentXml = indentXml;
 			_omitXmlDeclaration = omitXmlDeclaration;
+			_checkXmlCharacters = checkXmlCharacters;
 			if (writeEncoding == null)
 			{
 				throw new ArgumentNullException(nameof(writeEncoding));
@@ -154,7 +156,7 @@ namespace SoapCore.MessageEncoder
 				Indent = _indentXml,
 				Encoding = _writeEncoding,
 				CloseOutput = true,
-				CheckCharacters = false
+				CheckCharacters = _checkXmlCharacters
 			});
 
 			using var xmlWriter = XmlDictionaryWriter.CreateDictionaryWriter(xmlTextWriter);
@@ -185,7 +187,7 @@ namespace SoapCore.MessageEncoder
 				Indent = _indentXml,
 				Encoding = _writeEncoding,
 				CloseOutput = false,
-				CheckCharacters = false
+				CheckCharacters = _checkXmlCharacters
 			});
 
 			using var xmlWriter = XmlDictionaryWriter.CreateDictionaryWriter(xmlTextWriter);

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -153,7 +153,8 @@ namespace SoapCore.MessageEncoder
 				OmitXmlDeclaration = _optimizeWriteForUtf8 && _omitXmlDeclaration, //can only omit if utf-8
 				Indent = _indentXml,
 				Encoding = _writeEncoding,
-				CloseOutput = true
+				CloseOutput = true,
+				CheckCharacters = false
 			});
 
 			using var xmlWriter = XmlDictionaryWriter.CreateDictionaryWriter(xmlTextWriter);
@@ -183,7 +184,8 @@ namespace SoapCore.MessageEncoder
 				OmitXmlDeclaration = _optimizeWriteForUtf8 && _omitXmlDeclaration, //can only omit if utf-8,
 				Indent = _indentXml,
 				Encoding = _writeEncoding,
-				CloseOutput = false
+				CloseOutput = false,
+				CheckCharacters = false
 			});
 
 			using var xmlWriter = XmlDictionaryWriter.CreateDictionaryWriter(xmlTextWriter);

--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -87,6 +87,12 @@ namespace SoapCore
 		public bool IndentXml { get; set; } = true;
 
 		/// <summary>
+		/// Gets or sets a value indicating whether to check to make sure that the XmlOutput doesn't contain invalid characters
+		/// <para>Defaults to true</para>
+		/// </summary>
+		public bool CheckXmlCharacters { get; set; } = true;
+
+		/// <summary>
 		/// Gets or sets an collection of Xml Namespaces to override the default prefix for.
 		/// </summary>
 		public XmlNamespaceManager XmlNamespacePrefixOverrides { get; set; }

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -686,9 +686,12 @@ namespace SoapCore
 			var faultExceptionTransformer = serviceProvider.GetRequiredService<IFaultExceptionTransformer>();
 			var faultMessage = faultExceptionTransformer.ProvideFault(exception, messageEncoder.MessageVersion, requestMessage, xmlNamespaceManager);
 
-			httpContext.Response.ContentType = httpContext.Request.ContentType;
-			httpContext.Response.Headers["SOAPAction"] = faultMessage.Headers.Action;
-			httpContext.Response.StatusCode = statusCode;
+			if(!httpContext.Response.HasStarted)
+			{
+				httpContext.Response.ContentType = httpContext.Request.ContentType;
+				httpContext.Response.Headers["SOAPAction"] = faultMessage.Headers.Action;
+				httpContext.Response.StatusCode = statusCode;
+			}
 
 			SetHttpResponse(httpContext, faultMessage);
 			if (messageEncoder.MessageVersion.Addressing == AddressingVersion.WSAddressing10)

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -69,7 +69,7 @@ namespace SoapCore
 
 			for (var i = 0; i < options.EncoderOptions.Length; i++)
 			{
-				_messageEncoders[i] = new SoapMessageEncoder(options.EncoderOptions[i].MessageVersion, options.EncoderOptions[i].WriteEncoding, options.EncoderOptions[i].ReaderQuotas, options.OmitXmlDeclaration, options.IndentXml);
+				_messageEncoders[i] = new SoapMessageEncoder(options.EncoderOptions[i].MessageVersion, options.EncoderOptions[i].WriteEncoding, options.EncoderOptions[i].ReaderQuotas, options.OmitXmlDeclaration, options.IndentXml, options.CheckXmlCharacters);
 			}
 		}
 

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -41,6 +41,12 @@ namespace SoapCore
 
 		public bool IndentXml { get; set; } = true;
 
+		/// <summary>
+		/// Gets or sets a value indicating whether to check to make sure that the XmlOutput doesn't contain invalid characters
+		/// <para>Defaults to true</para>
+		/// </summary>
+		public bool CheckXmlCharacters { get; set; } = true;
+
 		public XmlNamespaceManager XmlNamespacePrefixOverrides { get; set; }
 		public WsdlFileOptions WsdlFileOptions { get; set; }
 
@@ -66,7 +72,8 @@ namespace SoapCore
 				OmitXmlDeclaration = opt.OmitXmlDeclaration,
 				IndentXml = opt.IndentXml,
 				XmlNamespacePrefixOverrides = opt.XmlNamespacePrefixOverrides,
-				WsdlFileOptions = opt.WsdlFileOptions
+				WsdlFileOptions = opt.WsdlFileOptions,
+				CheckXmlCharacters = opt.CheckXmlCharacters
 			};
 
 #pragma warning disable CS0612 // Type or member is obsolete


### PR DESCRIPTION
Full framework Web Service allows weird control characters etc. in the xml output but XmlTextWriter doesn't by default.
Added Option "CheckXmlCharacters" (default true) to give control over CheckCharacters-property on XmlTextWriter