### PR TITLE
configured XmlReader to use IgnoreWhitespace = true

### DIFF
--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -35,6 +35,7 @@ namespace SoapCore.MessageEncoder
 			_indentXml = indentXml;
 			_omitXmlDeclaration = omitXmlDeclaration;
 			_checkXmlCharacters = checkXmlCharacters;
+
 			if (writeEncoding == null)
 			{
 				throw new ArgumentNullException(nameof(writeEncoding));
@@ -129,7 +130,7 @@ namespace SoapCore.MessageEncoder
 
 			XmlReader reader = _supportXmlDictionaryReader ?
 			 	XmlDictionaryReader.CreateTextReader(stream, _writeEncoding, ReaderQuotas, dictionaryReader => { }) :
-				XmlReader.Create(stream, new XmlReaderSettings());
+				XmlReader.Create(stream, new XmlReaderSettings() { IgnoreWhitespace = true });
 
 			Message message = Message.CreateMessage(reader, maxSizeOfHeaders, MessageVersion);
 


### PR DESCRIPTION
If one has only whitespace in a parameter, like
```
<ns0:sort>       </ns0:sort>
```
the message parsing crashes. That is weird but apparently expected.

I thought about adding an option to ignore "insignificant whitespace", but then I read https://github.com/dotnet/runtime/issues/16029 
and https://docs.microsoft.com/en-us/dotnet/api/system.xml.xmldictionaryreader?view=net-6.0
suggesting that XmlDictionaryReader ignores whitespace and you can't change that behavior. 

For that reason I thought it made sense to ignore whitespace by default for XmlReader.Create also.

What do you think @kotovaleksandr? Should I add a setting even thought it's not used for XmlDictionaryReader? Or just go with IgnoreWhitespace = true?

I'm not in a hurry with this one. I already solved my problem by removing the insignificant whitespace in a middleware, before the message reaches SoapCore. This PR is more in case anyone else runs into the same issue.

Damn legacy services with their legacy workloads that I have no control over 😆 