### PR TITLE
Incompatibility with primitive array-parameters

### DIFF
--- a/src/SoapCore.Tests/MessageContract/Models/IArrayOfIntService.cs
+++ b/src/SoapCore.Tests/MessageContract/Models/IArrayOfIntService.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Text;
+
+namespace SoapCore.Tests.MessageContract.Models
+{
+	[ServiceContract(Namespace = "http://tempuri.org")]
+	public interface IArrayOfIntService
+	{
+		[OperationContract]
+		int[] ArrayOfIntMethod(int[] arrayOfIntParam);
+
+		[OperationContract]
+		int IntMethod(int intParam);
+	}
+
+	public class ArrayOfIntService : IArrayOfIntService
+	{
+		public int[] ArrayOfIntMethod(int[] arrayOfIntParam)
+		{
+			return arrayOfIntParam;
+		}
+
+		public int IntMethod(int intParam)
+		{
+			return intParam;
+		}
+	}
+}

--- a/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
+++ b/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
@@ -90,7 +90,7 @@ namespace SoapCore.Tests.MessageContract
   <soapenv:Header/>
   <soapenv:Body>
 	<tem:ArrayOfIntMethod>
-    <tem:arrayOfIntParam>1</tem:arrayOfIntParam>
+    <tem:arrayOfIntParam>1,2</tem:arrayOfIntParam>
 	</tem:ArrayOfIntMethod>
   </soapenv:Body>
 </soapenv:Envelope>
@@ -103,6 +103,54 @@ namespace SoapCore.Tests.MessageContract
 			{
 				res.EnsureSuccessStatusCode();
 				var resultMessage = await res.Content.ReadAsStringAsync();
+				Assert.IsTrue(resultMessage.Contains("<int>1</int>"));
+				Assert.IsTrue(resultMessage.Contains("<int>2</int>"));
+			}
+
+			const string body2 = @"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:tem=""http://tempuri.org"">
+  <soapenv:Header/>
+  <soapenv:Body>
+	<tem:ArrayOfIntMethod>
+    <tem:arrayOfIntParam><tem:int>1</tem:int><tem:int>2</tem:int></tem:arrayOfIntParam>
+	</tem:ArrayOfIntMethod>
+  </soapenv:Body>
+</soapenv:Envelope>
+";
+
+			using (var host = CreateTestHost(typeof(ArrayOfIntService)))
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body2, Encoding.UTF8, "text/xml"))
+			using (var res = await host.CreateRequest("/Service.asmx").AddHeader("SOAPAction", @"""ArrayOfIntMethod""").And(msg => msg.Content = content).PostAsync())
+			{
+				res.EnsureSuccessStatusCode();
+				var resultMessage = await res.Content.ReadAsStringAsync();
+				Assert.IsTrue(resultMessage.Contains("<int>1</int>"));
+				Assert.IsTrue(resultMessage.Contains("<int>2</int>"));
+			}
+		}
+
+		[TestMethod]
+		public async Task Soap11MessageContractArrayOfIntParamWrapped()
+		{
+			const string body2 = @"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:tem=""http://tempuri.org"">
+  <soapenv:Header/>
+  <soapenv:Body>
+	<tem:ArrayOfIntMethod>
+    <tem:arrayOfIntParam><tem:int>1</tem:int><tem:int>2</tem:int></tem:arrayOfIntParam>
+	</tem:ArrayOfIntMethod>
+  </soapenv:Body>
+</soapenv:Envelope>
+";
+
+			using (var host = CreateTestHost(typeof(ArrayOfIntService)))
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body2, Encoding.UTF8, "text/xml"))
+			using (var res = await host.CreateRequest("/Service.asmx").AddHeader("SOAPAction", @"""ArrayOfIntMethod""").And(msg => msg.Content = content).PostAsync())
+			{
+				res.EnsureSuccessStatusCode();
+				var resultMessage = await res.Content.ReadAsStringAsync();
+				Assert.IsTrue(resultMessage.Contains("<int>1</int>"));
+				Assert.IsTrue(resultMessage.Contains("<int>2</int>"));
 			}
 		}
 

--- a/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
+++ b/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
@@ -84,6 +84,28 @@ namespace SoapCore.Tests.MessageContract
 		}
 
 		[TestMethod]
+		public async Task Soap11MessageContractArrayOfIntParam()
+		{
+			const string body = @"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:tem=""http://tempuri.org"">
+  <soapenv:Header/>
+  <soapenv:Body>
+	<tem:ArrayOfIntMethod>
+    <tem:arrayOfIntParam>1/tem:arrayOfIntParam>
+	</tem:ArrayOfIntMethod>
+  </soapenv:Body>
+</soapenv:Envelope>
+";
+
+			using (var host = CreateTestHost(typeof(ArrayOfIntService)))
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body, Encoding.UTF8, "text/xml"))
+			using (var res = await host.CreateRequest("/Service.asmx").AddHeader("SOAPAction", @"""ArrayOfIntMethod""").And(msg => msg.Content = content).PostAsync())
+			{
+				res.EnsureSuccessStatusCode();
+			}
+		}
+
+		[TestMethod]
 		public async Task Soap11MessageContractComplexNotWrapped()
 		{
 			const string body = @"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:tem=""http://tempuri.org"">

--- a/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
+++ b/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
@@ -103,8 +103,9 @@ namespace SoapCore.Tests.MessageContract
 			{
 				res.EnsureSuccessStatusCode();
 				var resultMessage = await res.Content.ReadAsStringAsync();
-				Assert.IsTrue(resultMessage.Contains("<int>1</int>"));
-				Assert.IsTrue(resultMessage.Contains("<int>2</int>"));
+
+				//the result should be an empty array
+				Assert.IsTrue(resultMessage.Contains("<ArrayOfIntMethodResult />"));
 			}
 
 			const string body2 = @"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:tem=""http://tempuri.org"">

--- a/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
+++ b/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
@@ -107,27 +107,6 @@ namespace SoapCore.Tests.MessageContract
 				//the result should be an empty array
 				Assert.IsTrue(resultMessage.Contains("<ArrayOfIntMethodResult />"));
 			}
-
-			const string body2 = @"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:tem=""http://tempuri.org"">
-  <soapenv:Header/>
-  <soapenv:Body>
-	<tem:ArrayOfIntMethod>
-    <tem:arrayOfIntParam><tem:int>1</tem:int><tem:int>2</tem:int></tem:arrayOfIntParam>
-	</tem:ArrayOfIntMethod>
-  </soapenv:Body>
-</soapenv:Envelope>
-";
-
-			using (var host = CreateTestHost(typeof(ArrayOfIntService)))
-			using (var client = host.CreateClient())
-			using (var content = new StringContent(body2, Encoding.UTF8, "text/xml"))
-			using (var res = await host.CreateRequest("/Service.asmx").AddHeader("SOAPAction", @"""ArrayOfIntMethod""").And(msg => msg.Content = content).PostAsync())
-			{
-				res.EnsureSuccessStatusCode();
-				var resultMessage = await res.Content.ReadAsStringAsync();
-				Assert.IsTrue(resultMessage.Contains("<int>1</int>"));
-				Assert.IsTrue(resultMessage.Contains("<int>2</int>"));
-			}
 		}
 
 		[TestMethod]

--- a/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
+++ b/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
@@ -90,7 +90,7 @@ namespace SoapCore.Tests.MessageContract
   <soapenv:Header/>
   <soapenv:Body>
 	<tem:ArrayOfIntMethod>
-    <tem:arrayOfIntParam>1/tem:arrayOfIntParam>
+    <tem:arrayOfIntParam>1</tem:arrayOfIntParam>
 	</tem:ArrayOfIntMethod>
   </soapenv:Body>
 </soapenv:Envelope>
@@ -102,6 +102,7 @@ namespace SoapCore.Tests.MessageContract
 			using (var res = await host.CreateRequest("/Service.asmx").AddHeader("SOAPAction", @"""ArrayOfIntMethod""").And(msg => msg.Content = content).PostAsync())
 			{
 				res.EnsureSuccessStatusCode();
+				var resultMessage = await res.Content.ReadAsStringAsync();
 			}
 		}
 

--- a/src/SoapCore/SerializerHelper.cs
+++ b/src/SoapCore/SerializerHelper.cs
@@ -13,6 +13,7 @@ namespace SoapCore
 	internal class SerializerHelper
 	{
 		private readonly SoapSerializer _serializer;
+		private readonly Type[] _excludedPrimitiveTypesForArrayWithoutWrapping = new Type[] { typeof(float), typeof(double), typeof(IntPtr), typeof(UIntPtr) };
 
 		public SerializerHelper(SoapSerializer serializer)
 		{
@@ -149,10 +150,10 @@ namespace SoapCore
 			{
 				result = xmlReader.ReadContentAsBase64();
 			}
-			else if (xmlReader.HasValue && elementType == typeof(int))
+			else if (xmlReader.HasValue && elementType.IsPrimitive && !_excludedPrimitiveTypesForArrayWithoutWrapping.Contains(elementType))
 			{
 				var values = xmlReader.Value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-				result = values.Select(x => int.Parse(x)).ToArray();
+				result = CastPrimitiveArray(values, elementType);
 				xmlReader.Skip();
 			}
 			else
@@ -166,6 +167,59 @@ namespace SoapCore
 			}
 
 			return result;
+		}
+
+		//Cast any primitive type, except double, float, IntPtr and UIntPtr
+		private object CastPrimitiveArray(IEnumerable<string> values, Type elementType)
+		{
+			if (elementType == typeof(bool))
+			{
+				return CastArray<bool>(values);
+			}
+			else if (elementType == typeof(byte))
+			{
+				return CastArray<byte>(values);
+			}
+			else if (elementType == typeof(sbyte))
+			{
+				return CastArray<sbyte>(values);
+			}
+			else if (elementType == typeof(short))
+			{
+				return CastArray<short>(values);
+			}
+			else if (elementType == typeof(ushort))
+			{
+				return CastArray<ushort>(values);
+			}
+			else if (elementType == typeof(int))
+			{
+				return CastArray<int>(values);
+			}
+			else if (elementType == typeof(uint))
+			{
+				return CastArray<uint>(values);
+			}
+			else if (elementType == typeof(long))
+			{
+				return CastArray<long>(values);
+			}
+			else if (elementType == typeof(ulong))
+			{
+				return CastArray<ulong>(values);
+			}
+
+			return null;
+		}
+
+		private T[] CastArray<T>(IEnumerable<string> input)
+		{
+			return input.Select(x => Cast<T>(x)).ToArray();
+		}
+
+		private T Cast<T>(string input)
+		{
+			return (T)Convert.ChangeType(input, typeof(T));
 		}
 	}
 }

--- a/src/SoapCore/SerializerHelper.cs
+++ b/src/SoapCore/SerializerHelper.cs
@@ -13,7 +13,6 @@ namespace SoapCore
 	internal class SerializerHelper
 	{
 		private readonly SoapSerializer _serializer;
-		private readonly Type[] _excludedPrimitiveTypesForArrayWithoutWrapping = new Type[] { typeof(float), typeof(double), typeof(IntPtr), typeof(UIntPtr) };
 
 		public SerializerHelper(SoapSerializer serializer)
 		{

--- a/src/SoapCore/SerializerHelper.cs
+++ b/src/SoapCore/SerializerHelper.cs
@@ -150,12 +150,6 @@ namespace SoapCore
 			{
 				result = xmlReader.ReadContentAsBase64();
 			}
-			else if (xmlReader.HasValue && elementType.IsPrimitive && !_excludedPrimitiveTypesForArrayWithoutWrapping.Contains(elementType))
-			{
-				var values = xmlReader.Value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-				result = CastPrimitiveArray(values, elementType);
-				xmlReader.Skip();
-			}
 			else
 			{
 				result = deserializeMethod.Invoke(null, new object[] { serializer, arrayItemName, arrayItemNamespace, xmlReader });
@@ -167,59 +161,6 @@ namespace SoapCore
 			}
 
 			return result;
-		}
-
-		//Cast any primitive type, except double, float, IntPtr and UIntPtr
-		private object CastPrimitiveArray(IEnumerable<string> values, Type elementType)
-		{
-			if (elementType == typeof(bool))
-			{
-				return CastArray<bool>(values);
-			}
-			else if (elementType == typeof(byte))
-			{
-				return CastArray<byte>(values);
-			}
-			else if (elementType == typeof(sbyte))
-			{
-				return CastArray<sbyte>(values);
-			}
-			else if (elementType == typeof(short))
-			{
-				return CastArray<short>(values);
-			}
-			else if (elementType == typeof(ushort))
-			{
-				return CastArray<ushort>(values);
-			}
-			else if (elementType == typeof(int))
-			{
-				return CastArray<int>(values);
-			}
-			else if (elementType == typeof(uint))
-			{
-				return CastArray<uint>(values);
-			}
-			else if (elementType == typeof(long))
-			{
-				return CastArray<long>(values);
-			}
-			else if (elementType == typeof(ulong))
-			{
-				return CastArray<ulong>(values);
-			}
-
-			return null;
-		}
-
-		private T[] CastArray<T>(IEnumerable<string> input)
-		{
-			return input.Select(x => Cast<T>(x)).ToArray();
-		}
-
-		private T Cast<T>(string input)
-		{
-			return (T)Convert.ChangeType(input, typeof(T));
 		}
 	}
 }

--- a/src/SoapCore/SerializerHelper.cs
+++ b/src/SoapCore/SerializerHelper.cs
@@ -149,6 +149,12 @@ namespace SoapCore
 			{
 				result = xmlReader.ReadContentAsBase64();
 			}
+			else if (xmlReader.HasValue && elementType == typeof(int))
+			{
+				var values = xmlReader.Value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+				result = values.Select(x => int.Parse(x)).ToArray();
+				xmlReader.Skip();
+			}
 			else
 			{
 				result = deserializeMethod.Invoke(null, new object[] { serializer, arrayItemName, arrayItemNamespace, xmlReader });

--- a/src/SoapCore/XmlSerializerExtensions.cs
+++ b/src/SoapCore/XmlSerializerExtensions.cs
@@ -29,6 +29,12 @@ namespace SoapCore
 				argument.Add((T)serializer.Deserialize(xmlReader));
 			}
 
+			if (argument.Count == 0 && xmlReader.HasValue)
+			{
+				//If there was no valid array items we can assume that any value is trash and skip it
+				xmlReader.Skip();
+			}
+
 			return argument.ToArray();
 		}
 


### PR DESCRIPTION
I think it's easier to discuss this in a PR rather than an issue.

We have a method that accepts an int[] as a parameter.

In our full framework web service that method could be called with a comma separated list of ints,
In SoapCore it needs to be called with each int wrapped in an element.

If I change the parameter in the test to
`<tem:arrayOfIntParam><tem:int>1</tem:int></tem:arrayOfIntParam>`
everything works, but for backwards compatibility we need this test to work.

This line assumes that there will be a wrapping element (not unreasonable).
https://github.com/DigDes/SoapCore/blob/096c5c2855d353527be9e73c7b465f53be978fb4/src/SoapCore/XmlSerializerExtensions.cs#L27
There is also an assumption that the wrapping element will be of the service namespace, even though it should just be `<int>` in this case, if I'm not mistaken?

Not sure how the old api handles return values, but I'm assuming that they will be wrapped.

What is the best way to approach this? Should I just add a special case for System.Int32 like for System.Byte here:
https://github.com/DigDes/SoapCore/blob/096c5c2855d353527be9e73c7b465f53be978fb4/src/SoapCore/SerializerHelper.cs#L148
and assume that Int32 will be the most common case for this? Might be the safest way.
The current behavior should, of course, be used as fallback.

I can't really see how string would be able to handle this behavior, for instance... But there might be an issue with the namespace assumption there also.

@kotovaleksandr I would appreciate your input here



