### PR TITLE
Set dtdprocessing prohibit

### DIFF
--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -130,7 +130,7 @@ namespace SoapCore.MessageEncoder
 
 			XmlReader reader = _supportXmlDictionaryReader ?
 			 	XmlDictionaryReader.CreateTextReader(stream, _writeEncoding, ReaderQuotas, dictionaryReader => { }) :
-				XmlReader.Create(stream, new XmlReaderSettings() { IgnoreWhitespace = true });
+				XmlReader.Create(stream, new XmlReaderSettings() { IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit });
 
 			Message message = Message.CreateMessage(reader, maxSizeOfHeaders, MessageVersion);
 

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -686,7 +686,7 @@ namespace SoapCore
 			var faultExceptionTransformer = serviceProvider.GetRequiredService<IFaultExceptionTransformer>();
 			var faultMessage = faultExceptionTransformer.ProvideFault(exception, messageEncoder.MessageVersion, requestMessage, xmlNamespaceManager);
 
-			if(!httpContext.Response.HasStarted)
+			if (!httpContext.Response.HasStarted)
 			{
 				httpContext.Response.ContentType = httpContext.Request.ContentType;
 				httpContext.Response.Headers["SOAPAction"] = faultMessage.Headers.Action;


### PR DESCRIPTION
Apparently the default is DtdProcessing.Prohibit, except when you create your own XmlReaderSettings

https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca3075?view=vs-2022