### PR TITLE
support for extra xmlnamespaceprefixoverrides per messageversion

### DIFF
--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ServiceModel.Channels;
 using System.Xml;
 using SoapCore.Extensibility;
@@ -96,6 +97,11 @@ namespace SoapCore
 		/// Gets or sets an collection of Xml Namespaces to override the default prefix for.
 		/// </summary>
 		public XmlNamespaceManager XmlNamespacePrefixOverrides { get; set; }
+
+		/// <summary>
+		/// Gets or sets an collection of Xml Namespaces to override the default prefix for, per MessageVersion
+		/// </summary>
+		public Dictionary<MessageVersion, XmlNamespaceManager> XmlNamespacePrefixOverridesPerMessageVersion { get; set; }
 
 		public WsdlFileOptions WsdlFileOptions { get; set; }
 	}

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ServiceModel.Channels;
 using System.Xml;
 using SoapCore.Extensibility;
@@ -48,6 +49,7 @@ namespace SoapCore
 		public bool CheckXmlCharacters { get; set; } = true;
 
 		public XmlNamespaceManager XmlNamespacePrefixOverrides { get; set; }
+		public Dictionary<MessageVersion, XmlNamespaceManager> XmlNamespacePrefixOverridesPerMessageVersion { get; set; }
 		public WsdlFileOptions WsdlFileOptions { get; set; }
 
 		[Obsolete]
@@ -73,7 +75,8 @@ namespace SoapCore
 				IndentXml = opt.IndentXml,
 				XmlNamespacePrefixOverrides = opt.XmlNamespacePrefixOverrides,
 				WsdlFileOptions = opt.WsdlFileOptions,
-				CheckXmlCharacters = opt.CheckXmlCharacters
+				CheckXmlCharacters = opt.CheckXmlCharacters,
+				XmlNamespacePrefixOverridesPerMessageVersion = opt.XmlNamespacePrefixOverridesPerMessageVersion
 			};
 
 #pragma warning disable CS0612 // Type or member is obsolete


### PR DESCRIPTION
Fixes #781

Uses the single XmlNamespacePrefixOverrides as default, and adds any MessageVersion specific overrides on top.
XmlNamespaceManager will use the latest namespace for any prefix, so this can be used to override namespaces from the base XmlNamespacePrefixOverrides

If you're OK with this PR I'd appreciate a new nuget version