### PR TITLE
Specify BindingName and PortName per SoapMessageEncoder

### DIFF
--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -26,8 +26,37 @@ namespace SoapCore.Tests.Wsdl
 	public class WsdlTests
 	{
 		private readonly XNamespace _xmlSchema = "http://www.w3.org/2001/XMLSchema";
+		private readonly XNamespace _wsdlSchema = "http://schemas.xmlsoap.org/wsdl/";
 
 		private IWebHost _host;
+
+		[TestMethod]
+		public async Task CheckBindingAndPortName()
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<TaskNoReturnService>(SoapSerializer.XmlSerializer, "MyBinding", "MyPort");
+			var root = XElement.Parse(wsdl);
+
+			// We should have in the wsdl the definition of a complex type representing the nullable enum
+			var bindingElements = GetElements(root, _wsdlSchema + "binding").Where(a => a.Attribute("name")?.Value.Equals("MyBinding") == true).ToArray();
+			bindingElements.ShouldNotBeEmpty();
+
+			var portElements = GetElements(root, _wsdlSchema + "port").Where(a => a.Attribute("name")?.Value.Equals("MyPort") == true).ToArray();
+			portElements.ShouldNotBeEmpty();
+		}
+
+		[TestMethod]
+		public async Task CheckDefaultBindingAndPortName()
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<TaskNoReturnService>(SoapSerializer.XmlSerializer);
+			var root = XElement.Parse(wsdl);
+
+			// We should have in the wsdl the definition of a complex type representing the nullable enum
+			var bindingElements = GetElements(root, _wsdlSchema + "binding").Where(a => a.Attribute("name")?.Value.Equals("BasicHttpBinding_soap") == true).ToArray();
+			bindingElements.ShouldNotBeEmpty();
+
+			var portElements = GetElements(root, _wsdlSchema + "port").Where(a => a.Attribute("name")?.Value.Equals("BasicHttpBinding_soap") == true).ToArray();
+			portElements.ShouldNotBeEmpty();
+		}
 
 		[TestMethod]
 		public void CheckTaskReturnMethod()
@@ -734,15 +763,15 @@ namespace SoapCore.Tests.Wsdl
 			}
 		}
 
-		private async Task<string> GetWsdlFromMetaBodyWriter<T>(SoapSerializer serializer)
+		private async Task<string> GetWsdlFromMetaBodyWriter<T>(SoapSerializer serializer, string bindingName = null, string portName = null)
 		{
 			var service = new ServiceDescription(typeof(T));
 			var baseUrl = "http://tempuri.org/";
 			var xmlNamespaceManager = Namespaces.CreateDefaultXmlNamespaceManager();
 			var bodyWriter = serializer == SoapSerializer.DataContractSerializer
 				? new MetaWCFBodyWriter(service, baseUrl, "BasicHttpBinding", false) as BodyWriter
-				: new MetaBodyWriter(service, baseUrl, xmlNamespaceManager, "BasicHttpBinding", new[] { MessageVersion.None }) as BodyWriter;
-			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, System.Text.Encoding.UTF8, XmlDictionaryReaderQuotas.Max, false, true, false);
+				: new MetaBodyWriter(service, baseUrl, xmlNamespaceManager, "BasicHttpBinding", new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }) as BodyWriter;
+			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, System.Text.Encoding.UTF8, XmlDictionaryReaderQuotas.Max, false, true, false, bindingName, portName);
 			var responseMessage = Message.CreateMessage(encoder.MessageVersion, null, bodyWriter);
 			responseMessage = new MetaMessage(responseMessage, service, xmlNamespaceManager, "BasicHttpBinding", false);
 

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -30,11 +30,13 @@ namespace SoapCore.MessageEncoder
 		private readonly bool _supportXmlDictionaryReader;
 		private readonly bool _checkXmlCharacters;
 
-		public SoapMessageEncoder(MessageVersion version, Encoding writeEncoding, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool indentXml, bool checkXmlCharacters)
+		public SoapMessageEncoder(MessageVersion version, Encoding writeEncoding, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool indentXml, bool checkXmlCharacters, string bindingName, string portName)
 		{
 			_indentXml = indentXml;
 			_omitXmlDeclaration = omitXmlDeclaration;
 			_checkXmlCharacters = checkXmlCharacters;
+			BindingName = bindingName;
+			PortName = portName;
 
 			if (writeEncoding == null)
 			{
@@ -55,6 +57,9 @@ namespace SoapCore.MessageEncoder
 			CharSet = SoapMessageEncoderDefaults.EncodingToCharSet(writeEncoding);
 			ContentType = GetContentType(MediaType, CharSet);
 		}
+
+		public string BindingName { get; }
+		public string PortName { get; }
 
 		public string ContentType { get; }
 

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -31,8 +31,6 @@ namespace SoapCore.Meta
 		private readonly HashSet<string> _buildArrayTypes;
 		private readonly Dictionary<string, Dictionary<string, string>> _requestedDynamicTypes;
 
-		private readonly HashSet<int> _soapVersions;
-
 		private bool _buildDateTimeOffset;
 
 		[Obsolete]
@@ -42,11 +40,11 @@ namespace SoapCore.Meta
 				baseUrl,
 				xmlNamespaceManager ?? new XmlNamespaceManager(new NameTable()),
 				binding?.Name ?? "BasicHttpBinding_" + service.GeneralContract.Name,
-				new[] { binding.MessageVersion ?? MessageVersion.None })
+				new[] { new SoapBindingInfo(binding.MessageVersion ?? MessageVersion.None, null, null) })
 		{
 		}
 
-		public MetaBodyWriter(ServiceDescription service, string baseUrl, XmlNamespaceManager xmlNamespaceManager, string bindingName, MessageVersion[] messageVersions) : base(isBuffered: true)
+		public MetaBodyWriter(ServiceDescription service, string baseUrl, XmlNamespaceManager xmlNamespaceManager, string bindingName, SoapBindingInfo[] soapBindings) : base(isBuffered: true)
 		{
 			_service = service;
 			_baseUrl = baseUrl;
@@ -59,24 +57,14 @@ namespace SoapCore.Meta
 			_builtComplexTypes = new HashSet<string>();
 			_buildArrayTypes = new HashSet<string>();
 			_requestedDynamicTypes = new Dictionary<string, Dictionary<string, string>>();
-			_soapVersions = new HashSet<int>();
 
 			BindingName = bindingName;
 			PortName = bindingName;
+			SoapBindings = soapBindings;
 
-			foreach (var messageVersion in messageVersions)
-			{
-				if (messageVersion == MessageVersion.Soap12WSAddressing10 || messageVersion == MessageVersion.Soap12WSAddressingAugust2004)
-				{
-					_soapVersions.Add(12);
-				}
-				else
-				{
-					_soapVersions.Add(11);
-				}
-			}
 		}
 
+		private SoapBindingInfo[] SoapBindings { get; }
 		private string BindingName { get; }
 		private string BindingType => _service.GeneralContract.Name;
 		private string PortName { get; }
@@ -215,9 +203,20 @@ namespace SoapCore.Meta
 			return true;
 		}
 
-		private static (string name, string ns) GetSoapNameAndNamespace(int soapVersion)
+		private (string soapPrefix, string ns, string qualifiedBindingName, string qualifiedPortName) GetSoapMetaParameters(SoapBindingInfo bindingInfo)
 		{
-			return soapVersion == 12 ? ("soap12", Namespaces.SOAP12_NS) : ("soap", Namespaces.SOAP11_NS);
+			int soapVersion = 11;
+			if (bindingInfo.MessageVersion == MessageVersion.Soap12WSAddressingAugust2004 || bindingInfo.MessageVersion == MessageVersion.Soap12WSAddressing10)
+			{
+				soapVersion = 12;
+			}
+
+			(var soapPrefix, var ns) = soapVersion == 12 ? ("soap12", Namespaces.SOAP12_NS) : ("soap", Namespaces.SOAP11_NS);
+
+			var qualifiedBindingName = !string.IsNullOrWhiteSpace(bindingInfo.BindingName) ? bindingInfo.BindingName : (BindingName + $"_{soapPrefix}");
+			var qualifiedPortName = !string.IsNullOrWhiteSpace(bindingInfo.PortName) ? bindingInfo.PortName : (PortName + $"_{soapPrefix}");
+
+			return (soapPrefix, ns, qualifiedBindingName, qualifiedPortName);
 		}
 
 		private XmlQualifiedName ResolveType(Type type)
@@ -637,12 +636,12 @@ namespace SoapCore.Meta
 
 		private void AddBinding(XmlDictionaryWriter writer)
 		{
-			foreach (var soapVersion in _soapVersions)
+			foreach (var bindingInfo in SoapBindings)
 			{
-				(var soap, var soapNamespace) = GetSoapNameAndNamespace(soapVersion);
+				(var soap, var soapNamespace, var qualifiedBindingName, _) = GetSoapMetaParameters(bindingInfo);
 
 				writer.WriteStartElement("wsdl", "binding", Namespaces.WSDL_NS);
-				writer.WriteAttributeString("name", BindingName + $"_{soap}");
+				writer.WriteAttributeString("name", qualifiedBindingName);
 				writer.WriteAttributeString("type", "tns:" + BindingType);
 				writer.WriteAttributeString("style", "document");
 				writer.WriteStartElement(soap, "binding", soapNamespace);
@@ -686,15 +685,16 @@ namespace SoapCore.Meta
 			writer.WriteStartElement("wsdl", "service", Namespaces.WSDL_NS);
 			writer.WriteAttributeString("name", _service.ServiceName);
 
-			foreach (var soapVersion in _soapVersions)
+			foreach (var bindingInfo in SoapBindings)
 			{
-				(string soapName, string soapNamespace) = GetSoapNameAndNamespace(soapVersion);
+				(var soap, var soapNamespace, var qualifiedBindingName, var qualifiedPortName) = GetSoapMetaParameters(bindingInfo);
+
 
 				writer.WriteStartElement("wsdl", "port", Namespaces.WSDL_NS);
-				writer.WriteAttributeString("name", PortName + $"_{soapName}");
-				writer.WriteAttributeString("binding", "tns:" + BindingName + $"_{soapName}");
+				writer.WriteAttributeString("name", qualifiedPortName);
+				writer.WriteAttributeString("binding", "tns:" + qualifiedBindingName);
 
-				writer.WriteStartElement(soapName, "address", soapNamespace);
+				writer.WriteStartElement(soap, "address", soapNamespace);
 
 				writer.WriteAttributeString("location", _baseUrl);
 				writer.WriteEndElement(); // soap:address

--- a/src/SoapCore/Meta/SoapBindingInfo.cs
+++ b/src/SoapCore/Meta/SoapBindingInfo.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel.Channels;
+using System.Text;
+
+namespace SoapCore.Meta
+{
+	public class SoapBindingInfo
+	{
+		public SoapBindingInfo(MessageVersion messageVersion, string bindingName, string portName)
+		{
+			MessageVersion = messageVersion;
+			BindingName = bindingName;
+			PortName = portName;
+		}
+
+		public MessageVersion MessageVersion { get; private set; }
+		public string BindingName { get; private set; }
+		public string PortName { get; private set; }
+	}
+}

--- a/src/SoapCore/SoapEncoderOptions.cs
+++ b/src/SoapCore/SoapEncoderOptions.cs
@@ -9,6 +9,8 @@ namespace SoapCore
 		public MessageVersion MessageVersion { get; set; } = MessageVersion.Soap11;
 		public Encoding WriteEncoding { get; set; } = Encoding.UTF8;
 		public XmlDictionaryReaderQuotas ReaderQuotas { get; set; } = XmlDictionaryReaderQuotas.Max;
+		public string BindingName { get; set; } = null;
+		public string PortName { get; set; } = null;
 
 		internal static SoapEncoderOptions[] ToArray(SoapEncoderOptions options)
 		{

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -69,7 +69,7 @@ namespace SoapCore
 
 			for (var i = 0; i < options.EncoderOptions.Length; i++)
 			{
-				_messageEncoders[i] = new SoapMessageEncoder(options.EncoderOptions[i].MessageVersion, options.EncoderOptions[i].WriteEncoding, options.EncoderOptions[i].ReaderQuotas, options.OmitXmlDeclaration, options.IndentXml, options.CheckXmlCharacters);
+				_messageEncoders[i] = new SoapMessageEncoder(options.EncoderOptions[i].MessageVersion, options.EncoderOptions[i].WriteEncoding, options.EncoderOptions[i].ReaderQuotas, options.OmitXmlDeclaration, options.IndentXml, options.CheckXmlCharacters, options.EncoderOptions[i].BindingName, options.EncoderOptions[i].PortName);
 			}
 		}
 
@@ -167,7 +167,7 @@ namespace SoapCore
 			var bindingName = "BasicHttpBinding_" + _service.GeneralContract.Name;
 
 			var bodyWriter = _options.SoapSerializer == SoapSerializer.XmlSerializer
-				? new MetaBodyWriter(_service, baseUrl, xmlNamespaceManager, bindingName, _messageEncoders.Select(me => me.MessageVersion).ToArray())
+				? new MetaBodyWriter(_service, baseUrl, xmlNamespaceManager, bindingName, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray())
 				: (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, bindingName, _options.UseBasicAuthentication);
 
 			//assumption that you want soap12 if your service supports that


### PR DESCRIPTION
* added ability to set custom bindingname and portname per SoapMessageEncoder.

* added tests to verify both this behavior and default behavior

A client uses an integration platform that rebuilds the service reference from wsdl as soon as they compile their integration project. To avoid errors in those cases we need the ability to set BindingName and PortName explicitly, so that it's identical with the old Api.

Since you need different names for each soap version you support I thought the most straightforward solution would be to add bindingname and portname to SoapMessageEncoderOptions.