### PR TITLE
trim ending slash from url when appending /$metadata or /mex to allow "/" as path.

### DIFF
--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -338,8 +338,8 @@ namespace SoapCore
 				.UseMiddleware<SoapEndpointMiddleware<T_MESSAGE>>(soapOptions)
 				.Build();
 
-			routes.Map(soapOptions.Path + "/$metadata", pipeline);
-			routes.Map(soapOptions.Path + "/mex", pipeline);
+			routes.Map(soapOptions.Path?.TrimEnd('/') + "/$metadata", pipeline);
+			routes.Map(soapOptions.Path?.TrimEnd('/') + "/mex", pipeline);
 
 			return routes.Map(soapOptions.Path, pipeline)
 				.WithDisplayName("SoapCore");


### PR DESCRIPTION
Fixes #796 