### PR TITLE
Additional namespace declaration attributes in envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,42 @@ public class MyService : IMyServiceService
     }
 }
 ```
+#### Additional namespace declaration attributes in envelope
+Adding additional namespaces to the **SOAP Envelope** can be done by populating `SoapEncoderOptions.AdditionalEnvelopeXmlnsAttributes` parameter.
+```csharp
+....
+endpoints.UseSoapEndpoint<IService>(opt =>
+{
+	opt.Path = "/ServiceWithAdditionalEnvelopeXmlnsAttributes.asmx";
+	opt.AdditionalEnvelopeXmlnsAttributes = new Dictionary<string, string>()
+	{
+		{ "myNS", "http://schemas.someting.org" },
+		{ "arr", "http://schemas.microsoft.com/2003/10/Serialization/Arrays" }
+	};
+});
+...
+```
+This code will put `xmlns:myNS="...` and `xmlns:arr="...` attributes in `Envelope` and message will look like:
+```xml
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" ... xmlns:myNS="http://schemas.someting.org" xmlns:arr="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+...
+    <myNS:StringList>
+        <arr:string>Error: one</arr:string>
+        <arr:string>Error: two</arr:string>
+    </fin:StringList>
+...
+```
+instead of:
+```xml
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" ... >
+...
+    <d3p1:StringList xmlns:d4p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+        <d4p1:string>Error: one</arr:string>
+        <d4p1:string>Error: two</arr:string>
+    </d3p1:StringList>
+...
+```
+
 ### Contributing
 
 See [Contributing guide](CONTRIBUTING.md)

--- a/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
+++ b/src/SoapCore.Tests/MessageContract/RawRequestSoap11Tests.cs
@@ -287,6 +287,30 @@ namespace SoapCore.Tests.MessageContract
 			}
 		}
 
+		[TestMethod]
+		public async Task SoapMessageContractWithAdditionalEnvelopeXmlnsAttributes()
+		{
+			const string body = @"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"">
+  <soapenv:Header/>
+  <soapenv:Body/>
+</soapenv:Envelope>
+";
+
+			using (var host = CreateTestHost(typeof(TestService)))
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body, Encoding.UTF8, "text/xml"))
+			using (var res = host.CreateRequest("/ServiceWithAdditionalEnvelopeXmlnsAttributes.asmx").AddHeader("SOAPAction", @"""EmptyRequest""").And(msg => msg.Content = content).PostAsync().Result)
+			{
+				res.EnsureSuccessStatusCode();
+				var stream = await res.Content.ReadAsStreamAsync();
+				XmlDocument doc = new XmlDocument();
+				doc.Load(stream);
+				XmlElement root = doc.DocumentElement;
+				Assert.IsTrue(root.HasAttribute("xmlns:arr"));
+				Assert.AreEqual(root.GetAttribute("xmlns:arr"), "http://schemas.microsoft.com/2003/10/Serialization/Arrays");
+			}
+		}
+
 		private TestServer CreateTestHost(Type serviceType)
 		{
 			var webHostBuilder = new WebHostBuilder()

--- a/src/SoapCore.Tests/MessageContract/Startup.cs
+++ b/src/SoapCore.Tests/MessageContract/Startup.cs
@@ -44,6 +44,14 @@ namespace SoapCore.Tests.MessageContract
 			{
 				x.UseSoapEndpoint(_serviceType, "/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
 				x.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
+				x.UseSoapEndpoint(_serviceType, opt =>
+				{
+					opt.Path = "/ServiceWithAdditionalEnvelopeXmlnsAttributes.asmx";
+					opt.AdditionalEnvelopeXmlnsAttributes = new Dictionary<string, string>()
+					{
+						{ "arr", "http://schemas.microsoft.com/2003/10/Serialization/Arrays" }
+					};
+				});
 			});
 		}
 #endif

--- a/src/SoapCore/CustomMessage.cs
+++ b/src/SoapCore/CustomMessage.cs
@@ -18,6 +18,8 @@ namespace SoapCore
 
 		public XmlNamespaceManager NamespaceManager { get; internal set; }
 
+		public System.Collections.Generic.Dictionary<string, string> AdditionalEnvelopeXmlnsAttributes { get; internal set; }
+
 		public override MessageHeaders Headers => Message.Headers;
 
 		public override MessageProperties Properties => Message.Properties;
@@ -40,6 +42,14 @@ namespace SoapCore
 
 			var xsiPrefix = Namespaces.AddNamespaceIfNotAlreadyPresentAndGetPrefix(NamespaceManager, "xsi", Namespaces.XMLNS_XSI);
 			writer.WriteXmlnsAttribute(xsiPrefix, Namespaces.XMLNS_XSI);
+
+			if (AdditionalEnvelopeXmlnsAttributes != null)
+			{
+				foreach (var rec in AdditionalEnvelopeXmlnsAttributes)
+				{
+					writer.WriteXmlnsAttribute(rec.Key, rec.Value);
+				}
+			}
 		}
 
 		protected override void OnWriteStartBody(XmlDictionaryWriter writer)

--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -99,5 +99,10 @@ namespace SoapCore
 		public XmlNamespaceManager XmlNamespacePrefixOverrides { get; set; }
 
 		public WsdlFileOptions WsdlFileOptions { get; set; }
+
+		/// <summary>
+		/// Sets additional namespace declaration attributes in envelope
+		/// </summary>
+		public Dictionary<string, string> AdditionalEnvelopeXmlnsAttributes { get; set; }
 	}
 }

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -382,6 +382,7 @@ namespace SoapCore
 				responseMessage = new T_MESSAGE
 				{
 					Message = Message.CreateMessage(soapMessageEncoder.MessageVersion, soapAction, bodyWriter),
+					AdditionalEnvelopeXmlnsAttributes = _options.AdditionalEnvelopeXmlnsAttributes,
 					NamespaceManager = xmlNamespaceManager
 				};
 				responseMessage.Headers.Action = operation.ReplyAction;
@@ -393,6 +394,7 @@ namespace SoapCore
 				responseMessage = new T_MESSAGE
 				{
 					Message = Message.CreateMessage(soapMessageEncoder.MessageVersion, null, bodyWriter),
+					AdditionalEnvelopeXmlnsAttributes = _options.AdditionalEnvelopeXmlnsAttributes,
 					NamespaceManager = xmlNamespaceManager
 				};
 			}

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -50,6 +50,7 @@ namespace SoapCore
 
 		public XmlNamespaceManager XmlNamespacePrefixOverrides { get; set; }
 		public WsdlFileOptions WsdlFileOptions { get; set; }
+		public Dictionary<string, string> AdditionalEnvelopeXmlnsAttributes { get; set; }
 
 		[Obsolete]
 		public static SoapOptions FromSoapCoreOptions<T>(SoapCoreOptions opt)
@@ -74,6 +75,7 @@ namespace SoapCore
 				IndentXml = opt.IndentXml,
 				XmlNamespacePrefixOverrides = opt.XmlNamespacePrefixOverrides,
 				WsdlFileOptions = opt.WsdlFileOptions,
+				AdditionalEnvelopeXmlnsAttributes = opt.AdditionalEnvelopeXmlnsAttributes,
 				CheckXmlCharacters = opt.CheckXmlCharacters
 			};
 


### PR DESCRIPTION
Added new option AdditionalEnvelopeXmlnsAttributes
when:
`
opt.AdditionalEnvelopeXmlnsAttributes = new Dictionary<string, string>()
{
	{"arr","http://schemas.microsoft.com/2003/10/Serialization/Arrays" }
};
`
writes `xmlns:arr="http://schemas.microsoft.com/2003/10/Serialization/Arrays"` in envelope:
`﻿<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:arr="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
`