### PR TITLE
support soap1.1 message with multipart attachments

### DIFF
--- a/src/SoapCore.Tests/RawRequestSoap11Tests.cs
+++ b/src/SoapCore.Tests/RawRequestSoap11Tests.cs
@@ -1,4 +1,5 @@
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
@@ -81,6 +82,38 @@ namespace SoapCore.Tests
 				var response = res.Content.ReadAsStringAsync().Result;
 				Assert.IsTrue(response.Contains(pingValue));
 			}
+		}
+
+		[TestMethod]
+		public async Task Soap11PingInMultipart()
+		{
+			var pingValue = "abc";
+			var soapBody = $@"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"">
+				<soapenv:Body>
+					<Ping xmlns=""http://tempuri.org/"">
+						<s>{pingValue}</s>
+					</Ping>
+				</soapenv:Body>
+			</soapenv:Envelope>";
+
+			using var host = CreateTestHost();
+			using var client = host.CreateClient();
+			using var multipartContent = new MultipartContent("related");
+			multipartContent.Headers.ContentType!.Parameters.Add(new NameValueHeaderValue("type", "\"text/xml\""));
+
+			using var soapContent = new StringContent(soapBody, Encoding.UTF8, "text/xml");
+			soapContent.Headers.Add("SOAPAction", @"""Ping""");
+
+			using var extraContent = new StringContent("some text payload", Encoding.UTF8, "text/plain");
+
+			multipartContent.Add(soapContent);
+			multipartContent.Add(extraContent);
+
+			using var res = await host.CreateRequest("/Service.svc").And(msg => msg.Content = multipartContent).PostAsync();
+
+			res.EnsureSuccessStatusCode();
+			var response = await res.Content.ReadAsStringAsync();
+			Assert.IsTrue(response.Contains(pingValue));
 		}
 
 		private TestServer CreateTestHost()

--- a/src/SoapCore.Tests/Startup.cs
+++ b/src/SoapCore.Tests/Startup.cs
@@ -73,7 +73,7 @@ namespace SoapCore.Tests
 		{
 			app.UseRouting();
 
-			app.UseWhen(ctx => ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
+			app.UseWhen(ctx => ctx.Request.Headers.ContainsKey("SOAPAction") || ctx.Request.ContentType.StartsWith("multipart"), app2 =>
 			{
 				app2.UseRouting();
 
@@ -93,7 +93,7 @@ namespace SoapCore.Tests
 				});
 			});
 
-			app.UseWhen(ctx => !ctx.Request.Headers.ContainsKey("SOAPAction"), app2 =>
+			app.UseWhen(ctx => !ctx.Request.Headers.ContainsKey("SOAPAction") && !ctx.Request.ContentType.StartsWith("multipart"), app2 =>
 			{
 				app2.UseRouting();
 


### PR DESCRIPTION
Issue: According to https://www.w3.org/TR/SOAP-attachments/ soap messages can be posted together with binary attachments in multipart message. This pull request enables processing of soap messages that are encapsulated within multipart.

Note that it only processes soap messages but does no validation or processing for other sections of multipart. Other sections can be processed by implementing your own `IServiceOperationTuner` and accessing multipart data from `httpContext`. Sample code in case someone wants to try it:
```
    private async Task<MultipartSection[]> ExtractAttachmentsFromRequestAsync()
    {
        var boundary = this.HttpContext!.Request.GetMultipartBoundary();

        if (string.IsNullOrWhiteSpace(boundary))
        {
            return Array.Empty<MultipartSection>();
        }

        this.HttpContext.Request.Body.Position = 0;
        var reader = new MultipartReader(boundary, this.HttpContext.Request.Body);
        var attachments = new List<MultipartSection>();

        while (true)
        {
            var section = await reader.ReadNextSectionAsync();

            if (section == null)
            {
                break;
            }

            if (section.Headers == null || !section.Headers.ContainsKey("Content-ID"))
            {
                continue;
            }

            attachments.Add(section);
        }

        return attachments.ToArray();
    }
```

In order for this sample to work one should enable request buffering in some middleware `context.Request.EnableBuffering()` as otherwise we loose ability to read stream multiple times - I couldn't figure a way how to avoid that.