### PR TITLE
modify wsdl soap endpoint location only on address nodes

### DIFF
--- a/src/SoapCore.Tests/WsdlFromFile/WSDL/SnapshotPull.wsdl
+++ b/src/SoapCore.Tests/WsdlFromFile/WSDL/SnapshotPull.wsdl
@@ -47,6 +47,7 @@
 	
 	<service name="snapshotPull">
 		<port name="snapshotPullSoapEndPoint" binding="tns:snapshotPullSoapBinding">
+			<soapbind:documentation>The service endpoint</soapbind:documentation>
 			<soapbind:address location="http://localhost/snapshotPullService/2020"/>
 			<!-- Here, the "location" depends on each implementation and MUST be filled  by each developer, for instance "http://localhost:8080/snapshotPullService/2020"-->
 		</port>

--- a/src/SoapCore/Meta/MetaFromFile.cs
+++ b/src/SoapCore/Meta/MetaFromFile.cs
@@ -108,10 +108,18 @@ namespace SoapCore.Meta
 					{
 						if (schemaNode.Name == (!string.IsNullOrWhiteSpace(schemaNode.Prefix) ? schemaNode.Prefix + ":" : schemaNode.Prefix) + "port")
 						{
-							foreach (XmlNode soapAdressNode in schemaNode.ChildNodes)
+							foreach (XmlNode portNode in schemaNode.ChildNodes)
 							{
-								soapAdressNode.Attributes["location"].InnerText = WebServiceLocation();
-								break;
+								if (portNode.Name == (!string.IsNullOrWhiteSpace(portNode.Prefix) ? portNode.Prefix + ":" : portNode.Prefix) + "address")
+								{
+									if (portNode.Attributes["location"] == null)
+									{
+										portNode.Attributes.Append(xmlDoc.CreateAttribute("location"));
+									}
+
+									portNode.Attributes["location"].InnerText = WebServiceLocation();
+									break;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
modify the location attribute only on soap:address nodes and skip others (e. g. wsdl:documentation). Add location attribute if it doesn't already exist

#820