### PR TITLE
Use MemoryStream to enable correct encoding output (instead of utf-16)

### DIFF
--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -390,13 +390,13 @@ namespace SoapCore
 			context.Response.StatusCode = (int)HttpStatusCode.OK;
 			context.Response.ContentType = "text/xml";
 
-			StringBuilder resultSb = new StringBuilder();
-			XmlWriter writer = XmlWriter.Create(resultSb);
+			using var ms = new MemoryStream();
+			XmlWriter writer = XmlWriter.Create(ms, new XmlWriterSettings() { Encoding = new UTF8Encoding(true) });
 			XmlDictionaryWriter dictionaryWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
 
 			bodyWriter.WriteBodyContents(dictionaryWriter);
 			dictionaryWriter.Flush();
-			await context.Response.WriteAsync(resultSb.ToString());
+			await context.Response.WriteAsync(Encoding.UTF8.GetString(ms.ToArray()));
 		}
 
 		private Func<Message, Task<Message>> MakeProcessorPipe(ISoapMessageProcessor[] soapMessageProcessors, HttpContext httpContext, Func<Message, Task<Message>> processMessageFunc)


### PR DESCRIPTION
In this pull request, I've changed how the request is serialized for the HTTP GET/POST requests.

The main reason is that, when you serialize with a StringBuilder or equivivalent, it will _always_ output `utf-16`, regardless of what encoding you pass it.

So I've changed it to use a MemoryStream instead, when then also outputs the `<?xml ...?>` with the correct encoding (`utf-8`)