### PR TITLE
Set Content-Length header in response

### DIFF
--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -174,7 +174,7 @@ namespace SoapCore
 #else
 		private static Task WriteMessageAsync(SoapMessageEncoder messageEncoder, Message responseMessage, HttpContext httpContext)
 		{
-			return messageEncoder.WriteMessageAsync(responseMessage, httpContext.Response.BodyWriter);
+			return messageEncoder.WriteMessageAsync(responseMessage, httpContext);
 		}
 #endif
 


### PR DESCRIPTION
Came across few SOAP clients which require **Content-Length** header to be set in order for the SOAP request to go through. 
Without this change, **Content-Length** header is not set and **Transfer-Encoding** is **chunked**