### PR TITLE
Set Content-Length header in response

### DIFF
--- a/src/SoapCore/CustomStringWriter.cs
+++ b/src/SoapCore/CustomStringWriter.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using System.Text;
+
+namespace SoapCore
+{    
+    public class CustomStringWriter : StringWriter
+    {
+        private readonly Encoding _encoding;
+
+		public CustomStringWriter(Encoding encoding)
+		{
+			_encoding = encoding;
+		}
+
+        public override Encoding Encoding
+        {
+            get
+            {
+                return _encoding;
+            }
+        }        
+    }
+}

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -147,7 +147,7 @@ namespace SoapCore.MessageEncoder
 			return Task.FromResult(message);
 		}
 
-		public virtual async Task WriteMessageAsync(Message message, HttpContext httpContext)
+		public virtual async Task WriteMessageAsync(Message message, HttpContext httpContext, PipeWriter pipeWriter)
 		{
 			if (message == null)
 			{
@@ -159,14 +159,13 @@ namespace SoapCore.MessageEncoder
 				throw new ArgumentNullException(nameof(httpContext));
 			}
 
-			var pipeWriter = httpContext.Response.BodyWriter;
 			if (pipeWriter == null)
 			{
 				throw new ArgumentNullException(nameof(pipeWriter));
 			}
 
 			ThrowIfMismatchedMessageVersion(message);
-	
+
 			//Custom string writer with custom encoding support
 			using (var stringWriter = new CustomStringWriter(_writeEncoding))
 			{
@@ -191,8 +190,8 @@ namespace SoapCore.MessageEncoder
 				httpContext.Response.ContentLength = data.Length;
 
 				var soapMessage = _writeEncoding.GetBytes(data);
-				await pipeWriter.WriteAsync(soapMessage);		
-				await pipeWriter.FlushAsync();	
+				await pipeWriter.WriteAsync(soapMessage);
+				await pipeWriter.FlushAsync();
 			}
 		}
 
@@ -301,7 +300,7 @@ namespace SoapCore.MessageEncoder
 		internal virtual bool IsCharSetSupported(string charset)
 		{
 			return CharSet?.Equals(charset, StringComparison.OrdinalIgnoreCase)
-			       ?? false;
+				   ?? false;
 		}
 
 		private static bool IsUtf8Encoding(Encoding encoding)

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -14,6 +14,7 @@ using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
+using Microsoft.AspNetCore.Http;
 
 namespace SoapCore.MessageEncoder
 {
@@ -146,35 +147,53 @@ namespace SoapCore.MessageEncoder
 			return Task.FromResult(message);
 		}
 
-		public virtual async Task WriteMessageAsync(Message message, PipeWriter pipeWriter)
+		public virtual async Task WriteMessageAsync(Message message, HttpContext httpContext)
 		{
 			if (message == null)
 			{
 				throw new ArgumentNullException(nameof(message));
 			}
 
+			if (httpContext == null)
+			{
+				throw new ArgumentNullException(nameof(httpContext));
+			}
+
+			var pipeWriter = httpContext.Response.BodyWriter;
 			if (pipeWriter == null)
 			{
 				throw new ArgumentNullException(nameof(pipeWriter));
 			}
 
 			ThrowIfMismatchedMessageVersion(message);
-
-			using var xmlTextWriter = XmlWriter.Create(pipeWriter.AsStream(true), new XmlWriterSettings
+	
+			//Custom string writer with custom encoding support
+			using (var stringWriter = new CustomStringWriter(_writeEncoding))
 			{
-				OmitXmlDeclaration = _optimizeWriteForUtf8 && _omitXmlDeclaration, //can only omit if utf-8
-				Indent = _indentXml,
-				Encoding = _writeEncoding,
-				CloseOutput = true,
-				CheckCharacters = _checkXmlCharacters
-			});
+				using (var xmlTextWriter = XmlWriter.Create(stringWriter, new XmlWriterSettings
+				{
+					OmitXmlDeclaration = _optimizeWriteForUtf8 && _omitXmlDeclaration, //can only omit if utf-8
+					Indent = _indentXml,
+					Encoding = _writeEncoding,
+					CloseOutput = true,
+					CheckCharacters = _checkXmlCharacters
+				}))
+				{
+					using var xmlWriter = XmlDictionaryWriter.CreateDictionaryWriter(xmlTextWriter);
+					message.WriteMessage(xmlWriter);
+					xmlWriter.WriteEndDocument();
+					xmlWriter.Flush();
+				}
 
-			using var xmlWriter = XmlDictionaryWriter.CreateDictionaryWriter(xmlTextWriter);
-			message.WriteMessage(xmlWriter);
-			xmlWriter.WriteEndDocument();
-			xmlWriter.Flush();
+				var data = stringWriter.ToString();
 
-			await pipeWriter.FlushAsync();
+				//Set Content-length in Response
+				httpContext.Response.ContentLength = data.Length;
+
+				var soapMessage = _writeEncoding.GetBytes(data);
+				await pipeWriter.WriteAsync(soapMessage);		
+				await pipeWriter.FlushAsync();	
+			}
 		}
 
 		public virtual Task WriteMessageAsync(Message message, Stream stream)

--- a/src/SoapCore/ServiceBodyWriter.cs
+++ b/src/SoapCore/ServiceBodyWriter.cs
@@ -1,5 +1,3 @@
-using SoapCore.Meta;
-using SoapCore.ServiceModel;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,6 +9,8 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Xml;
 using System.Xml.Serialization;
+using SoapCore.Meta;
+using SoapCore.ServiceModel;
 
 namespace SoapCore
 {

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -174,7 +174,7 @@ namespace SoapCore
 #else
 		private static Task WriteMessageAsync(SoapMessageEncoder messageEncoder, Message responseMessage, HttpContext httpContext)
 		{
-			return messageEncoder.WriteMessageAsync(responseMessage, httpContext);
+			return messageEncoder.WriteMessageAsync(responseMessage, httpContext, httpContext.Response.BodyWriter);
 		}
 #endif
 

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -1,14 +1,3 @@
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
-using SoapCore.DocumentationWriter;
-using SoapCore.Extensibility;
-using SoapCore.MessageEncoder;
-using SoapCore.Meta;
-using SoapCore.ServiceModel;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -23,6 +12,17 @@ using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using SoapCore.DocumentationWriter;
+using SoapCore.Extensibility;
+using SoapCore.MessageEncoder;
+using SoapCore.Meta;
+using SoapCore.ServiceModel;
 
 namespace SoapCore
 {
@@ -174,7 +174,7 @@ namespace SoapCore
 #else
 		private static Task WriteMessageAsync(SoapMessageEncoder messageEncoder, Message responseMessage, HttpContext httpContext)
 		{
-			return messageEncoder.WriteMessageAsync(responseMessage, httpContext.Response.BodyWriter);
+			return messageEncoder.WriteMessageAsync(responseMessage, httpContext);
 		}
 #endif
 


### PR DESCRIPTION
Came across few SOAP clients which require **Content-Length** header to be set in order for the SOAP request to go through.
Without this change, **Content-Length** header is not set and **Transfer-Encoding** is **chunked**