### PR TITLE
Added a way to read SOAPAction from soap request's headers

### DIFF
--- a/src/SoapCore/HeadersHelper.cs
+++ b/src/SoapCore/HeadersHelper.cs
@@ -98,6 +98,24 @@ namespace SoapCore
 					}
 				}
 
+				if (string.IsNullOrEmpty(soapAction))
+				{
+					if (!string.IsNullOrEmpty(message.Headers.Action))
+					{
+						soapAction = message.Headers.Action;
+					}
+
+					if (string.IsNullOrEmpty(soapAction))
+					{
+						var headerInfo = message.Headers.FirstOrDefault(h => h.Name.ToLowerInvariant() == "action");
+
+						if (headerInfo != null)
+						{
+							soapAction = message.Headers.GetHeader<string>(headerInfo.Name, headerInfo.Namespace);
+						}
+					}
+				}
+
 				if (string.IsNullOrEmpty(soapAction) && reader != null)
 				{
 					soapAction = reader.LocalName;


### PR DESCRIPTION
Actually, it is not possible to retrieve the SOAPAction from the soap request's header. This code tries to check if the soap envelope contains any reference about what is the SOAPAction inside the header Action tag. If so, then it read the SOAPAction from the found tag.

issue: #863

About tests:

I've noticed that the following tests:

- Soap12Wsa10Header
- Soap12PingWithActionInEnvelopeHeader
- Soap12Wsa10FaultHeader

Supposed to let SoapCore retrieves the SOAPAction from the header but it retrieved that from the body. Now, this PR lets these tests work properly.