### PR TITLE
Added SOAP 1.2 Support using the DataContractSerializer

### DIFF
--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -25,36 +25,42 @@ namespace SoapCore.Tests.Wsdl
 	[TestClass]
 	public class WsdlTests
 	{
+		private const string BindingName = "BindingName";
+		private const string PortName = "PortName";
 		private readonly XNamespace _xmlSchema = "http://www.w3.org/2001/XMLSchema";
 		private readonly XNamespace _wsdlSchema = "http://schemas.xmlsoap.org/wsdl/";
 
 		private IWebHost _host;
 
-		[TestMethod]
-		public async Task CheckBindingAndPortName()
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
+		[DataRow(SoapSerializer.DataContractSerializer)]
+		public async Task CheckBindingAndPortName(SoapSerializer soapSerializer)
 		{
-			var wsdl = await GetWsdlFromMetaBodyWriter<TaskNoReturnService>(SoapSerializer.XmlSerializer, "MyBinding", "MyPort");
+			var wsdl = await GetWsdlFromMetaBodyWriter<TaskNoReturnService>(soapSerializer, BindingName, PortName);
 			var root = XElement.Parse(wsdl);
 
 			// We should have in the wsdl the definition of a complex type representing the nullable enum
-			var bindingElements = GetElements(root, _wsdlSchema + "binding").Where(a => a.Attribute("name")?.Value.Equals("MyBinding") == true).ToArray();
+			var bindingElements = GetElements(root, _wsdlSchema + "binding").Where(a => a.Attribute("name")?.Value.Equals(BindingName) == true).ToArray();
 			bindingElements.ShouldNotBeEmpty();
 
-			var portElements = GetElements(root, _wsdlSchema + "port").Where(a => a.Attribute("name")?.Value.Equals("MyPort") == true).ToArray();
+			var portElements = GetElements(root, _wsdlSchema + "port").Where(a => a.Attribute("name")?.Value.Equals(PortName) == true).ToArray();
 			portElements.ShouldNotBeEmpty();
 		}
 
-		[TestMethod]
-		public async Task CheckDefaultBindingAndPortName()
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
+		[DataRow(SoapSerializer.DataContractSerializer)]
+		public async Task CheckDefaultBindingAndPortName(SoapSerializer soapSerializer)
 		{
-			var wsdl = await GetWsdlFromMetaBodyWriter<TaskNoReturnService>(SoapSerializer.XmlSerializer);
+			var wsdl = await GetWsdlFromMetaBodyWriter<TaskNoReturnService>(soapSerializer, BindingName, PortName);
 			var root = XElement.Parse(wsdl);
 
 			// We should have in the wsdl the definition of a complex type representing the nullable enum
-			var bindingElements = GetElements(root, _wsdlSchema + "binding").Where(a => a.Attribute("name")?.Value.Equals("BasicHttpBinding_soap") == true).ToArray();
+			var bindingElements = GetElements(root, _wsdlSchema + "binding").Where(a => a.Attribute("name")?.Value.Equals(BindingName) == true).ToArray();
 			bindingElements.ShouldNotBeEmpty();
 
-			var portElements = GetElements(root, _wsdlSchema + "port").Where(a => a.Attribute("name")?.Value.Equals("BasicHttpBinding_soap") == true).ToArray();
+			var portElements = GetElements(root, _wsdlSchema + "port").Where(a => a.Attribute("name")?.Value.Equals(PortName) == true).ToArray();
 			portElements.ShouldNotBeEmpty();
 		}
 
@@ -440,13 +446,15 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(myStringElement);
 		}
 
-		[TestMethod]
-		public async Task CheckStringArrayNameWsdl()
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
+		[DataRow(SoapSerializer.DataContractSerializer)]
+		public async Task CheckStringArrayNameWsdl(SoapSerializer soapSerializer)
 		{
 			//StartService(typeof(StringListService));
 			//var wsdl = GetWsdl();
 			//StopServer();
-			var wsdl = await GetWsdlFromMetaBodyWriter<StringListService>(SoapSerializer.XmlSerializer);
+			var wsdl = await GetWsdlFromMetaBodyWriter<StringListService>(soapSerializer);
 			Trace.TraceInformation(wsdl);
 			Assert.IsNotNull(wsdl);
 
@@ -476,13 +484,15 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsTrue(matched);
 		}
 
-		[TestMethod]
-		public async Task CheckComplexTypeAndOutParameterWsdl()
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
+		[DataRow(SoapSerializer.DataContractSerializer)]
+		public async Task CheckComplexTypeAndOutParameterWsdl(SoapSerializer soapSerializer)
 		{
 			//StartService(typeof(StringListService));
 			//var wsdl = GetWsdl();
 			//StopServer();
-			var wsdl = await GetWsdlFromMetaBodyWriter<ComplexTypeAndOutParameterService>(SoapSerializer.XmlSerializer);
+			var wsdl = await GetWsdlFromMetaBodyWriter<ComplexTypeAndOutParameterService>(soapSerializer);
 			Trace.TraceInformation(wsdl);
 			Assert.IsNotNull(wsdl);
 
@@ -507,10 +517,12 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(testElementMessage);
 		}
 
-		[TestMethod]
-		public async Task CheckUnqualifiedMembersService()
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
+		[DataRow(SoapSerializer.DataContractSerializer)]
+		public async Task CheckUnqualifiedMembersService(SoapSerializer soapSerializer)
 		{
-			var wsdl = await GetWsdlFromMetaBodyWriter<UnqualifiedMembersService>(SoapSerializer.XmlSerializer);
+			var wsdl = await GetWsdlFromMetaBodyWriter<TaskNoReturnService>(soapSerializer, BindingName, PortName);
 			Trace.TraceInformation(wsdl);
 
 			var root = XElement.Parse(wsdl);
@@ -525,13 +537,15 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsTrue(allNeededAreQualified);
 		}
 
-		[TestMethod]
-		public async Task CheckDateTimeOffsetServiceWsdl()
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
+		[DataRow(SoapSerializer.DataContractSerializer)]
+		public async Task CheckDateTimeOffsetServiceWsdl(SoapSerializer soapSerializer)
 		{
 			var nm = Namespaces.CreateDefaultXmlNamespaceManager();
 			string systemNs = "http://schemas.datacontract.org/2004/07/System";
 
-			var wsdl = await GetWsdlFromMetaBodyWriter<DateTimeOffsetService>(SoapSerializer.XmlSerializer);
+			var wsdl = await GetWsdlFromMetaBodyWriter<DateTimeOffsetService>(soapSerializer);
 			var root = XElement.Parse(wsdl);
 			var responseDateElem = root.XPathSelectElement($"//xsd:element[@name='MethodResponse']/xsd:complexType/xsd:sequence/xsd:element[@name='MethodResult']", nm);
 			Assert.IsTrue(responseDateElem.ToString().Contains(systemNs));
@@ -544,10 +558,12 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNull(dayOfYearElem);
 		}
 
-		[TestMethod]
-		public async Task CheckXmlSchemaProviderTypeServiceWsdl()
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
+		[DataRow(SoapSerializer.DataContractSerializer)]
+		public async Task CheckXmlSchemaProviderTypeServiceWsdl(SoapSerializer soapSerializer)
 		{
-			var wsdl = await GetWsdlFromMetaBodyWriter<XmlSchemaProviderTypeService>(SoapSerializer.XmlSerializer);
+			var wsdl = await GetWsdlFromMetaBodyWriter<XmlSchemaProviderTypeService>(soapSerializer);
 			Trace.TraceInformation(wsdl);
 			Assert.IsNotNull(wsdl);
 
@@ -558,10 +574,12 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(responseDateElem);
 		}
 
-		[TestMethod]
-		public async Task CheckTestMultipleTypesServiceWsdl()
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
+		[DataRow(SoapSerializer.DataContractSerializer)]
+		public async Task CheckTestMultipleTypesServiceWsdl(SoapSerializer soapSerializer)
 		{
-			var wsdl = await GetWsdlFromMetaBodyWriter<TestMultipleTypesService>(SoapSerializer.XmlSerializer);
+			var wsdl = await GetWsdlFromMetaBodyWriter<TestMultipleTypesService>(soapSerializer);
 			Trace.TraceInformation(wsdl);
 			Assert.IsNotNull(wsdl);
 		}
@@ -639,7 +657,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.AreEqual(5, propElementsCount);
 		}
 
-		[TestMethod]
+		[DataTestMethod]
 		public async Task CheckXmlAnnotatedTypeServiceWsdl()
 		{
 			var wsdl = await GetWsdlFromMetaBodyWriter<XmlModelsService>(SoapSerializer.XmlSerializer);
@@ -685,7 +703,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(propAnonAttribute);
 		}
 
-		[TestMethod]
+		[DataTestMethod]
 		public async Task CheckXmlAnnotatedChoiceReturnServiceWsdl()
 		{
 			var wsdl = await GetWsdlFromMetaBodyWriter<XmlAnnotatedChoiceReturnService>(SoapSerializer.XmlSerializer);
@@ -716,7 +734,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(choiceComplexTypeElement.XPathSelectElement("//xsd:complexType/xsd:sequence/xsd:choice/xsd:element[@name='second' and @type='xsd:string']", nm));
 		}
 
-		[TestMethod]
+		[DataTestMethod]
 		public async Task CheckMessageHeadersServiceWsdl()
 		{
 			var wsdl = await GetWsdlFromMetaBodyWriter<MessageHeadersService>(SoapSerializer.XmlSerializer);
@@ -775,11 +793,11 @@ namespace SoapCore.Tests.Wsdl
 			var baseUrl = "http://tempuri.org/";
 			var xmlNamespaceManager = Namespaces.CreateDefaultXmlNamespaceManager();
 			var bodyWriter = serializer == SoapSerializer.DataContractSerializer
-				? new MetaWCFBodyWriter(service, baseUrl, "BasicHttpBinding", false) as BodyWriter
-				: new MetaBodyWriter(service, baseUrl, xmlNamespaceManager, "BasicHttpBinding", new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }) as BodyWriter;
+				? new MetaWCFBodyWriter(service, baseUrl, bindingName, false, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }) as BodyWriter
+				: new MetaBodyWriter(service, baseUrl, xmlNamespaceManager, bindingName, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }) as BodyWriter;
 			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, System.Text.Encoding.UTF8, XmlDictionaryReaderQuotas.Max, false, true, false, null, bindingName, portName);
 			var responseMessage = Message.CreateMessage(encoder.MessageVersion, null, bodyWriter);
-			responseMessage = new MetaMessage(responseMessage, service, xmlNamespaceManager, "BasicHttpBinding", false);
+			responseMessage = new MetaMessage(responseMessage, service, xmlNamespaceManager, bindingName, false);
 
 			using (var memoryStream = new MemoryStream())
 			{

--- a/src/SoapCore/Meta/MetaMessage.cs
+++ b/src/SoapCore/Meta/MetaMessage.cs
@@ -69,24 +69,19 @@ namespace SoapCore.Meta
 			writer.WriteAttributeString("name", _service.ServiceName);
 			WriteXmlnsAttribute(writer, Namespaces.WSDL_NS);
 
-			writer.WriteStartElement("Policy", Namespaces.WSP_NS);
-			writer.WriteAttributeString("Id", _xmlNamespaceManager.LookupPrefix(Namespaces.WSU_NS), $"{_bindingName}_policy");
-			writer.WriteStartElement("ExactlyOne", Namespaces.WSP_NS);
-			writer.WriteStartElement("All", Namespaces.WSP_NS);
-
 			if (_hasBasicAuthentication)
 			{
+				writer.WriteStartElement("Policy", Namespaces.WSP_NS);
+				writer.WriteAttributeString("Id", _xmlNamespaceManager.LookupPrefix(Namespaces.WSU_NS), $"{_bindingName}_{_service.GeneralContract.Name}_policy");
+				writer.WriteStartElement("ExactlyOne", Namespaces.WSP_NS);
+				writer.WriteStartElement("All", Namespaces.WSP_NS);
 				writer.WriteStartElement("BasicAuthentication", Namespaces.HTTP_NS);
-			}
-			else
-			{
 				writer.WriteStartElement("wsaw", "UsingAddressing", Namespaces.WSAW_NS);
+				writer.WriteEndElement();
+				writer.WriteEndElement();
+				writer.WriteEndElement();
+				writer.WriteEndElement();
 			}
-
-			writer.WriteEndElement();
-			writer.WriteEndElement();
-			writer.WriteEndElement();
-			writer.WriteEndElement();
 		}
 
 		protected override void OnWriteStartBody(XmlDictionaryWriter writer)

--- a/src/SoapCore/Meta/MetaMessage.cs
+++ b/src/SoapCore/Meta/MetaMessage.cs
@@ -69,18 +69,24 @@ namespace SoapCore.Meta
 			writer.WriteAttributeString("name", _service.ServiceName);
 			WriteXmlnsAttribute(writer, Namespaces.WSDL_NS);
 
+			writer.WriteStartElement("Policy", Namespaces.WSP_NS);
+			writer.WriteAttributeString("Id", _xmlNamespaceManager.LookupPrefix(Namespaces.WSU_NS), $"{_bindingName}_policy");
+			writer.WriteStartElement("ExactlyOne", Namespaces.WSP_NS);
+			writer.WriteStartElement("All", Namespaces.WSP_NS);
+
 			if (_hasBasicAuthentication)
 			{
-				writer.WriteStartElement("Policy", Namespaces.WSP_NS);
-				writer.WriteAttributeString("Id", _xmlNamespaceManager.LookupPrefix(Namespaces.WSU_NS), $"{_bindingName}_{_service.GeneralContract.Name}_policy");
-				writer.WriteStartElement("ExactlyOne", Namespaces.WSP_NS);
-				writer.WriteStartElement("All", Namespaces.WSP_NS);
 				writer.WriteStartElement("BasicAuthentication", Namespaces.HTTP_NS);
-				writer.WriteEndElement();
-				writer.WriteEndElement();
-				writer.WriteEndElement();
-				writer.WriteEndElement();
 			}
+			else
+			{
+				writer.WriteStartElement("wsaw", "UsingAddressing", Namespaces.WSAW_NS);
+			}
+
+			writer.WriteEndElement();
+			writer.WriteEndElement();
+			writer.WriteEndElement();
+			writer.WriteEndElement();
 		}
 
 		protected override void OnWriteStartBody(XmlDictionaryWriter writer)

--- a/src/SoapCore/Meta/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaWCFBodyWriter.cs
@@ -70,11 +70,12 @@ namespace SoapCore.Meta
 				  service,
 				  baseUrl,
 				  binding?.Name ?? "BasicHttpBinding_" + service.GeneralContract.Name,
-				  binding.HasBasicAuth())
+				  binding.HasBasicAuth(),
+				  new[] { new SoapBindingInfo(binding.MessageVersion ?? MessageVersion.None, null, null) })
 		{
 		}
 
-		public MetaWCFBodyWriter(ServiceDescription service, string baseUrl, string bindingName, bool hasBasicAuthentication) : base(isBuffered: true)
+		public MetaWCFBodyWriter(ServiceDescription service, string baseUrl, string bindingName, bool hasBasicAuthentication, SoapBindingInfo[] soapBindings) : base(isBuffered: true)
 		{
 			_service = service;
 			_baseUrl = baseUrl;
@@ -91,8 +92,10 @@ namespace SoapCore.Meta
 			BindingName = bindingName;
 			PortName = bindingName;
 			HasBasicAuthentication = hasBasicAuthentication;
+			SoapBindings = soapBindings;
 		}
 
+		private SoapBindingInfo[] SoapBindings { get; }
 		private bool HasBasicAuthentication { get; }
 		private string BindingName { get; }
 		private string BindingType { get; }
@@ -1058,62 +1061,64 @@ namespace SoapCore.Meta
 
 		private void AddBinding(XmlDictionaryWriter writer)
 		{
-			writer.WriteStartElement("wsdl", "binding", Namespaces.WSDL_NS);
-			writer.WriteAttributeString("name", BindingName);
-			writer.WriteAttributeString("type", "tns:" + BindingType);
-
-			if (HasBasicAuthentication)
+			foreach (var bindingInfo in SoapBindings)
 			{
+				(var soap, var soapNamespace, var qualifiedBindingName, _) = GetSoapMetaParameters(bindingInfo);
+
+				writer.WriteStartElement("wsdl", "binding", Namespaces.WSDL_NS);
+				writer.WriteAttributeString("name", BindingName);
+				writer.WriteAttributeString("type", "tns:" + BindingType);
+
 				writer.WriteStartElement("wsp", "PolicyReference", Namespaces.WSP_NS);
-				writer.WriteAttributeString("URI", $"#{BindingName}_{BindingType}_policy");
+				writer.WriteAttributeString("URI", $"#{BindingName}_policy");
 				writer.WriteEndElement();
-			}
 
-			writer.WriteStartElement("soap", "binding", Namespaces.SOAP11_NS);
-			writer.WriteAttributeString("transport", Namespaces.TRANSPORT_SCHEMA);
-			writer.WriteEndElement(); // soap:binding
+				writer.WriteStartElement(soap, "binding", soapNamespace);
+				writer.WriteAttributeString("transport", Namespaces.TRANSPORT_SCHEMA);
+				writer.WriteEndElement(); // soap:binding
 
-			foreach (var operation in _service.Operations)
-			{
-				writer.WriteStartElement("wsdl", "operation", Namespaces.WSDL_NS);
-				writer.WriteAttributeString("name", operation.Name);
-
-				writer.WriteStartElement("soap", "operation", Namespaces.SOAP11_NS);
-				writer.WriteAttributeString("soapAction", operation.SoapAction);
-				writer.WriteAttributeString("style", "document");
-				writer.WriteEndElement(); // soap:operation
-
-				writer.WriteStartElement("wsdl", "input", Namespaces.WSDL_NS);
-				writer.WriteStartElement("soap", "body", Namespaces.SOAP11_NS);
-				writer.WriteAttributeString("use", "literal");
-				writer.WriteEndElement(); // soap:body
-				writer.WriteEndElement(); // wsdl:input
-
-				if (!operation.IsOneWay)
+				foreach (var operation in _service.Operations)
 				{
-					writer.WriteStartElement("wsdl", "output", Namespaces.WSDL_NS);
-					writer.WriteStartElement("soap", "body", Namespaces.SOAP11_NS);
+					writer.WriteStartElement("wsdl", "operation", Namespaces.WSDL_NS);
+					writer.WriteAttributeString("name", operation.Name);
+
+					writer.WriteStartElement(soap, "operation", soapNamespace);
+					writer.WriteAttributeString("soapAction", operation.SoapAction);
+					writer.WriteAttributeString("style", "document");
+					writer.WriteEndElement(); // soap:operation
+
+					writer.WriteStartElement("wsdl", "input", Namespaces.WSDL_NS);
+					writer.WriteStartElement(soap, "body", soapNamespace);
 					writer.WriteAttributeString("use", "literal");
 					writer.WriteEndElement(); // soap:body
-					writer.WriteEndElement(); // wsdl:output
+					writer.WriteEndElement(); // wsdl:input
+
+					if (!operation.IsOneWay)
+					{
+						writer.WriteStartElement("wsdl", "output", Namespaces.WSDL_NS);
+						writer.WriteStartElement(soap, "body", soapNamespace);
+						writer.WriteAttributeString("use", "literal");
+						writer.WriteEndElement(); // soap:body
+						writer.WriteEndElement(); // wsdl:output
+					}
+
+					AddBindingFaults(writer, operation, soap, soapNamespace);
+
+					writer.WriteEndElement(); // wsdl:operation
 				}
 
-				AddBindingFaults(writer, operation);
-
-				writer.WriteEndElement(); // wsdl:operation
+				writer.WriteEndElement(); // wsdl:binding
 			}
-
-			writer.WriteEndElement(); // wsdl:binding
 		}
 
-		private void AddBindingFaults(XmlDictionaryWriter writer, OperationDescription operation)
+		private void AddBindingFaults(XmlDictionaryWriter writer, OperationDescription operation, string soap, string soapNamespace)
 		{
 			foreach (Type fault in operation.Faults)
 			{
 				writer.WriteStartElement("wsdl", "fault", Namespaces.WSDL_NS);
 				writer.WriteAttributeString("name", $"{fault.Name}Fault");
 
-				writer.WriteStartElement("soap", "fault", Namespaces.SOAP11_NS);
+				writer.WriteStartElement(soap, "fault", soapNamespace);
 				writer.WriteAttributeString("use", "literal");
 				writer.WriteAttributeString("name", $"{fault.Name}Fault");
 				writer.WriteEndElement(); // soap:fault
@@ -1127,16 +1132,21 @@ namespace SoapCore.Meta
 			writer.WriteStartElement("wsdl", "service", Namespaces.WSDL_NS);
 			writer.WriteAttributeString("name", _service.ServiceName);
 
-			writer.WriteStartElement("wsdl", "port", Namespaces.WSDL_NS);
-			writer.WriteAttributeString("name", PortName);
-			writer.WriteAttributeString("binding", "tns:" + BindingName);
+			foreach (var bindingInfo in SoapBindings)
+			{
+				(var soap, var soapNamespace, var qualifiedBindingName, var qualifiedPortName) = GetSoapMetaParameters(bindingInfo);
 
-			writer.WriteStartElement("soap", "address", Namespaces.SOAP11_NS);
+				writer.WriteStartElement("wsdl", "port", Namespaces.WSDL_NS);
+				writer.WriteAttributeString("name", qualifiedPortName);
+				writer.WriteAttributeString("binding", "tns:" + qualifiedBindingName);
 
-			writer.WriteAttributeString("location", _baseUrl);
-			writer.WriteEndElement(); // soap:address
+				writer.WriteStartElement(soap, "address", soapNamespace);
 
-			writer.WriteEndElement(); // wsdl:port
+				writer.WriteAttributeString("location", _baseUrl);
+				writer.WriteEndElement(); // soap:address
+
+				writer.WriteEndElement(); // wsdl:port
+			}
 		}
 
 		private void AddSchemaType(XmlDictionaryWriter writer, Type type, string name, bool isArray = false, string objectNamespace = null, bool isRequired = false)
@@ -1580,6 +1590,22 @@ namespace SoapCore.Meta
 			var baseType = type.GetTypeInfo().BaseType;
 
 			return !isArrayType && !type.IsEnum && !type.IsPrimitive && !type.IsValueType && baseType != null && !baseType.Name.Equals("Object");
+		}
+
+		private (string soapPrefix, string ns, string qualifiedBindingName, string qualifiedPortName) GetSoapMetaParameters(SoapBindingInfo bindingInfo)
+		{
+			int soapVersion = 11;
+			if (bindingInfo.MessageVersion == MessageVersion.Soap12WSAddressingAugust2004 || bindingInfo.MessageVersion == MessageVersion.Soap12WSAddressing10)
+			{
+				soapVersion = 12;
+			}
+
+			(var soapPrefix, var ns) = soapVersion == 12 ? ("soap12", Namespaces.SOAP12_NS) : ("soap", Namespaces.SOAP11_NS);
+
+			var qualifiedBindingName = !string.IsNullOrWhiteSpace(bindingInfo.BindingName) ? bindingInfo.BindingName : BindingName;
+			var qualifiedPortName = !string.IsNullOrWhiteSpace(bindingInfo.PortName) ? bindingInfo.PortName : PortName;
+
+			return (soapPrefix, ns, qualifiedBindingName, qualifiedPortName);
 		}
 	}
 }

--- a/src/SoapCore/Meta/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaWCFBodyWriter.cs
@@ -1069,10 +1069,6 @@ namespace SoapCore.Meta
 				writer.WriteAttributeString("name", BindingName);
 				writer.WriteAttributeString("type", "tns:" + BindingType);
 
-				writer.WriteStartElement("wsp", "PolicyReference", Namespaces.WSP_NS);
-				writer.WriteAttributeString("URI", $"#{BindingName}_policy");
-				writer.WriteEndElement();
-
 				writer.WriteStartElement(soap, "binding", soapNamespace);
 				writer.WriteAttributeString("transport", Namespaces.TRANSPORT_SCHEMA);
 				writer.WriteEndElement(); // soap:binding

--- a/src/SoapCore/Namespaces.cs
+++ b/src/SoapCore/Namespaces.cs
@@ -18,6 +18,7 @@ namespace SoapCore
 		public const string SERIALIZATION_NS = "http://schemas.microsoft.com/2003/10/Serialization/";
 		public const string WSP_NS = "http://schemas.xmlsoap.org/ws/2004/09/policy";
 		public const string WSAM_NS = "http://www.w3.org/2007/05/addressing/metadata";
+		public const string WSAW_NS = "http://www.w3.org/2006/05/addressing/wsdl";
 		public const string SystemData_NS = "http://schemas.datacontract.org/2004/07/System.Data";
 		public const string MSC_NS = "http://schemas.microsoft.com/ws/2005/12/wsdl/contract";
 		public const string WSU_NS = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -233,11 +233,11 @@ namespace SoapCore
 		{
 			var baseUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host + httpContext.Request.PathBase + httpContext.Request.Path;
 			var xmlNamespaceManager = GetXmlNamespaceManager(null);
-			var bindingName = "BasicHttpBinding_" + _service.GeneralContract.Name;
+			var bindingName = _options.EncoderOptions[0].BindingName + "_" + _service.GeneralContract.Name;
 
 			var bodyWriter = _options.SoapSerializer == SoapSerializer.XmlSerializer
 				? new MetaBodyWriter(_service, baseUrl, xmlNamespaceManager, bindingName, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray())
-				: (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, bindingName, _options.UseBasicAuthentication);
+				: (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, bindingName, _options.UseBasicAuthentication, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray());
 
 			//assumption that you want soap12 if your service supports that
 			var messageEncoder = _messageEncoders.FirstOrDefault(me => me.MessageVersion == MessageVersion.Soap12WSAddressing10 || me.MessageVersion == MessageVersion.Soap12WSAddressingAugust2004) ?? _messageEncoders[0];

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -233,8 +233,7 @@ namespace SoapCore
 		{
 			var baseUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host + httpContext.Request.PathBase + httpContext.Request.Path;
 			var xmlNamespaceManager = GetXmlNamespaceManager(null);
-			var bindingName = _options.EncoderOptions[0].BindingName + "_" + _service.GeneralContract.Name;
-
+			var bindingName = !string.IsNullOrWhiteSpace(_options.EncoderOptions[0].BindingName) ? _options.EncoderOptions[0].BindingName : "BasicHttpBinding_" + _service.GeneralContract.Name;
 			var bodyWriter = _options.SoapSerializer == SoapSerializer.XmlSerializer
 				? new MetaBodyWriter(_service, baseUrl, xmlNamespaceManager, bindingName, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray())
 				: (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, bindingName, _options.UseBasicAuthentication, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray());


### PR DESCRIPTION
- Updated the MetaWCFBodyWritter constructor (DataContractSerializer) to accept the SoapBindings as a parameter so we can establish which version of SOAP to use. Created supporting methods as per the MetaBodyWriter class.
- Added the missing WS-Addressing 1.0 WSDL Binding Namespace in the Namespaces.
- Moved parts of the MetaMessage outside the check for BasicAuthentication, as I believe they need to be always present.
- Updated SoapEndpointMiddleware to use the dynamic binding names instead of the hard coded HttpBinding.
- Updated all relevant tests to test using both serializers. Also moved the hard coded vales for the Binding/Port to constants.

Fixes #825 