### PR TITLE
Default MaxSoapHeaderSize of 0x10000 moved to SoapEncoderOptions so it can be overridden

### DIFF
--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -31,7 +31,7 @@ namespace SoapCore.MessageEncoder
 		private readonly bool _supportXmlDictionaryReader;
 		private readonly bool _checkXmlCharacters;
 
-		public SoapMessageEncoder(MessageVersion version, Encoding writeEncoding, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool indentXml, bool checkXmlCharacters, XmlNamespaceManager xmlNamespaceOverrides, string bindingName, string portName)
+		public SoapMessageEncoder(MessageVersion version, Encoding writeEncoding, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool indentXml, bool checkXmlCharacters, XmlNamespaceManager xmlNamespaceOverrides, string bindingName, string portName, int maxSoapHeaderSize = SoapMessageEncoderDefaults.MaxSoapHeaderSizeDefault)
 		{
 			_indentXml = indentXml;
 			_omitXmlDeclaration = omitXmlDeclaration;
@@ -53,6 +53,7 @@ namespace SoapCore.MessageEncoder
 
 			ReaderQuotas = new XmlDictionaryReaderQuotas();
 			(quotas ?? XmlDictionaryReaderQuotas.Max).CopyTo(ReaderQuotas);
+			MaxSoapHeaderSize = maxSoapHeaderSize;
 
 			MediaType = GetMediaType(version);
 			CharSet = SoapMessageEncoderDefaults.EncodingToCharSet(writeEncoding);
@@ -73,6 +74,8 @@ namespace SoapCore.MessageEncoder
 		public MessageVersion MessageVersion { get; }
 
 		public XmlDictionaryReaderQuotas ReaderQuotas { get; }
+
+		public int MaxSoapHeaderSize { get; }
 
 		public XmlNamespaceManager XmlNamespaceOverrides { get; }
 

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoderDefaults.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoderDefaults.cs
@@ -9,6 +9,7 @@ namespace SoapCore.MessageEncoder
 {
 	internal class SoapMessageEncoderDefaults
 	{
+		public const int MaxSoapHeaderSizeDefault = 0x10000;
 		public static readonly Encoding[] SupportedEncodings = { DefaultEncodings.UTF8, DefaultEncodings.Unicode, DefaultEncodings.BigEndianUnicode };
 
 		// Desktop: System.ServiceModel.Configuration.ConfigurationStrings.Soap12WSAddressing10;

--- a/src/SoapCore/SoapEncoderOptions.cs
+++ b/src/SoapCore/SoapEncoderOptions.cs
@@ -14,6 +14,8 @@ namespace SoapCore
 
 		public XmlNamespaceManager XmlNamespaceOverrides { get; set; } = null;
 
+		public int MaxSoapHeaderSize { get; set; } = MessageEncoder.SoapMessageEncoderDefaults.MaxSoapHeaderSizeDefault;
+
 		internal static SoapEncoderOptions[] ToArray(SoapEncoderOptions options)
 		{
 			return options is null ? null : new[] { options };

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -73,7 +73,7 @@ namespace SoapCore
 
 			for (var i = 0; i < options.EncoderOptions.Length; i++)
 			{
-				_messageEncoders[i] = new SoapMessageEncoder(options.EncoderOptions[i].MessageVersion, options.EncoderOptions[i].WriteEncoding, options.EncoderOptions[i].ReaderQuotas, options.OmitXmlDeclaration, options.IndentXml, options.CheckXmlCharacters, options.EncoderOptions[i].XmlNamespaceOverrides, options.EncoderOptions[i].BindingName, options.EncoderOptions[i].PortName);
+				_messageEncoders[i] = new SoapMessageEncoder(options.EncoderOptions[i].MessageVersion, options.EncoderOptions[i].WriteEncoding, options.EncoderOptions[i].ReaderQuotas, options.OmitXmlDeclaration, options.IndentXml, options.CheckXmlCharacters, options.EncoderOptions[i].XmlNamespaceOverrides, options.EncoderOptions[i].BindingName, options.EncoderOptions[i].PortName, options.EncoderOptions[i].MaxSoapHeaderSize);
 			}
 		}
 
@@ -218,14 +218,14 @@ namespace SoapCore
 					if (messageEncoder.IsContentTypeSupported(multipartSection.ContentType, true)
 						|| messageEncoder.IsContentTypeSupported(multipartSection.ContentType, false))
 					{
-						return await messageEncoder.ReadMessageAsync(multipartSection.Body, 0x10000, multipartSection.ContentType);
+						return await messageEncoder.ReadMessageAsync(multipartSection.Body, messageEncoder.MaxSoapHeaderSize, multipartSection.ContentType);
 					}
 				}
 			}
 #if !NETCOREAPP3_0_OR_GREATER
-			return await messageEncoder.ReadMessageAsync(httpContext.Request.Body, 0x10000, httpContext.Request.ContentType);
+			return await messageEncoder.ReadMessageAsync(httpContext.Request.Body, messageEncoder.MaxSoapHeaderSize, httpContext.Request.ContentType);
 #else
-			return await messageEncoder.ReadMessageAsync(httpContext.Request.BodyReader, 0x10000, httpContext.Request.ContentType);
+			return await messageEncoder.ReadMessageAsync(httpContext.Request.BodyReader, messageEncoder.MaxSoapHeaderSize, httpContext.Request.ContentType);
 #endif
 		}
 


### PR DESCRIPTION
Default stays the same.

We have some users on test environment with SAML tokens > 64kB so need to up the limit here.