### PR TITLE
Only append schemaLocation when XsdFolder defined

### DIFF
--- a/src/SoapCore/Meta/MetaFromFile.cs
+++ b/src/SoapCore/Meta/MetaFromFile.cs
@@ -89,13 +89,16 @@ namespace SoapCore.Meta
 							{
 								if (importOrIncludeNode.Name == ImportNodeName(importOrIncludeNode) || importOrIncludeNode.Name == IncludeNodeName(importOrIncludeNode))
 								{
-									if (importOrIncludeNode.Attributes["schemaLocation"] == null)
+									if (XsdFolder != null)
 									{
-										importOrIncludeNode.Attributes.Append(xmlDoc.CreateAttribute("schemaLocation"));
-									}
+										if (importOrIncludeNode.Attributes["schemaLocation"] == null)
+										{
+											importOrIncludeNode.Attributes.Append(xmlDoc.CreateAttribute("schemaLocation"));
+										}
 
-									string name = importOrIncludeNode.Attributes["schemaLocation"].InnerText;
-									importOrIncludeNode.Attributes["schemaLocation"].InnerText = SchemaLocation() + "&name=" + name.Replace("./", string.Empty);
+										string name = importOrIncludeNode.Attributes["schemaLocation"].InnerText;
+										importOrIncludeNode.Attributes["schemaLocation"].InnerText = SchemaLocation() + "&name=" + name.Replace("./", string.Empty);
+									}
 								}
 							}
 						}


### PR DESCRIPTION
Adding XSD's are optional, but the current behavior of the "Using with external WSDL / XSD schemas" feature will always append a schemaLocation to "importOrIncludeNode(s)," even when XSD's are explicitly omitted. The value produced for the schemaLocation attribute is then invalid and looks something like **http://localhost:5000/Service.asmx?xsd&name=** which is invalid.

This change proposes only appending schemaLocation when we know at least the schemaLocation directory has been defined by the client.