### PR TITLE
Wsdl schema mapping improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,22 +78,26 @@ To use it, add a setting like this to appsettings
 ```csharp
  "FileWSDL": {
     "UrlOverride": "",
+    "VirtualPath": "",
     "WebServiceWSDLMapping": {
-      "Service.asmx": {
+      "Service.asmx": { ,
+        "UrlOverride": "Management/Service.asmx",
         "WsdlFile": "snapshotpull.wsdl",
         "SchemaFolder": "Schemas",
         "WsdlFolder": "Schemas"
       }
-    },
-    "VirtualPath": ""
+    }
 ```
 
 * UrlOverride - can be used to override the URL in the service description. This can be useful if you are behind a firewall.
-* Service.asmx - is the endpoint of the service you expose. You can have more than one.
-* WsdlFile - is the name of the WSDL on disc.
-* SchemaFolder - if you import XSD from WSDL, this is the folder where the Schemas are stored on disc.
-* WsdlFolder - is the folder that the WSDL file is stored on disc.
-* VirualPath - can be used if you like to add a path between the base URL and service.
+* VirualPath - can be used if you like to add a path between the base URL and service. 
+* WebServiceWSDLMapping
+  * UrlOverride - can be used to override the URL for a specific WSDL mapping. This can be useful if you want to host different services under different folder.
+  * Service.asmx - is the endpoint of the service you expose. You can have more than one.
+  * WsdlFile - is the name of the WSDL on disc.
+  * SchemaFolder - if you import XSD from WSDL, this is the folder where the Schemas are stored on disc.
+  * WsdlFolder - is the folder that the WSDL file is stored on disc.
+
 
 To read the setting you can do the following
 
@@ -101,8 +105,11 @@ In Startup.cs:
 
 
 ```csharp
-
 var settings = Configuration.GetSection("FileWSDL").Get<WsdlFileOptions>();
+
+// For case-insensitive mapping, if you are using "SoapCoreOptions.CaseInsensitivePath = true" - otherwise URLs with different casing won't be mapped correctly
+//var settings = Configuration.GetSection("FileWSDL").Get<WsdlFileOptionsCaseInsensitive>();
+
 settings.AppPath = env.ContentRootPath; // The hosting environment root path
 ...
 

--- a/src/SoapCore.Tests/WsdlFromFile/Startup.cs
+++ b/src/SoapCore.Tests/WsdlFromFile/Startup.cs
@@ -43,7 +43,8 @@ namespace SoapCore.Tests.WsdlFromFile
 						{
 							SchemaFolder = "/WsdlFromFile/WSDL",
 							WsdlFile = _wsdlFile,
-							WSDLFolder = "/WsdlFromFile/WSDL"
+							WSDLFolder = "/WsdlFromFile/WSDL",
+							UrlOverride = "Management/Service.asmx"
 						}
 					}
 				},
@@ -69,7 +70,8 @@ namespace SoapCore.Tests.WsdlFromFile
 						{
 							SchemaFolder = "/WsdlFromFile/WSDL",
 							WsdlFile = _wsdlFile,
-							WSDLFolder = "/WsdlFromFile/WSDL"
+							WSDLFolder = "/WsdlFromFile/WSDL",
+							UrlOverride = "Management/Service.asmx"
 						}
 					}
 				},

--- a/src/SoapCore.Tests/WsdlFromFile/WsdlIncludeTests.cs
+++ b/src/SoapCore.Tests/WsdlFromFile/WsdlIncludeTests.cs
@@ -41,7 +41,7 @@ namespace SoapCore.Tests.WsdlFromFile
 			var addresses = _host.ServerFeatures.Get<IServerAddressesFeature>();
 			var address = addresses.Addresses.Single();
 
-			string url = address + "/Service.asmx?xsd&name=echoInclude.xsd";
+			string url = address + "/Management/Service.asmx?xsd&name=echoInclude.xsd";
 
 			Assert.IsNotNull(element);
 			Assert.AreEqual(url, element.Attributes["schemaLocation"]?.Value);

--- a/src/SoapCore.Tests/WsdlFromFile/WsdlTests.cs
+++ b/src/SoapCore.Tests/WsdlFromFile/WsdlTests.cs
@@ -75,7 +75,7 @@ namespace SoapCore.Tests.WsdlFromFile
 			var addresses = _host.ServerFeatures.Get<IServerAddressesFeature>();
 			var address = addresses.Addresses.Single();
 
-			string url = address + "/Service.asmx";
+			string url = address + "/Management/Service.asmx";
 			Assert.IsNotNull(element);
 			Assert.AreEqual(element.Attributes["location"]?.Value, url);
 		}
@@ -100,7 +100,7 @@ namespace SoapCore.Tests.WsdlFromFile
 			var addresses = _host.ServerFeatures.Get<IServerAddressesFeature>();
 			var address = addresses.Addresses.Single();
 
-			string url = address + "/Service.asmx?xsd&name=DATEXII_3_MessageContainer.xsd";
+			string url = address + "/Management/Service.asmx?xsd&name=DATEXII_3_MessageContainer.xsd";
 
 			Assert.IsNotNull(element);
 			Assert.AreEqual(element.Attributes["namespace"]?.Value, "http://datex2.eu/schema/3/messageContainer");

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -957,14 +957,24 @@ namespace SoapCore
 		private async Task ProcessMetaFromFile(HttpContext httpContext, bool showDocumentation)
 		{
 			var meta = new MetaFromFile();
+
+			var url = httpContext.Request.Path.Value.Replace("/", string.Empty);
+
+			WebServiceWSDLMapping mapping = _options.WsdlFileOptions.WebServiceWSDLMapping[url];
+
 			if (!string.IsNullOrEmpty(_options.WsdlFileOptions.VirtualPath))
 			{
 				meta.CurrentWebServer = _options.WsdlFileOptions.VirtualPath + "/";
 			}
 
-			meta.CurrentWebService = httpContext.Request.Path.Value.Replace("/", string.Empty);
-
-			WebServiceWSDLMapping mapping = _options.WsdlFileOptions.WebServiceWSDLMapping[meta.CurrentWebService];
+			if (string.IsNullOrEmpty(mapping.UrlOverride))
+			{
+				meta.CurrentWebService = url;
+			}
+			else
+			{
+				meta.CurrentWebService = mapping.UrlOverride;
+			}
 
 			meta.XsdFolder = mapping.SchemaFolder;
 			meta.WSDLFolder = mapping.WSDLFolder;

--- a/src/SoapCore/WSDLFileOptions.cs
+++ b/src/SoapCore/WSDLFileOptions.cs
@@ -1,13 +1,18 @@
+using System;
 using System.Collections.Generic;
-using SoapCore.Meta;
 
 namespace SoapCore
 {
 	public class WsdlFileOptions
 	{
-		public Dictionary<string, WebServiceWSDLMapping> WebServiceWSDLMapping { get; set; }
+		public virtual Dictionary<string, WebServiceWSDLMapping> WebServiceWSDLMapping { get; set; } = new Dictionary<string, WebServiceWSDLMapping>();
 		public string UrlOverride { get; set; }
 		public string VirtualPath { get; set; }
 		public string AppPath { get; set; }
+	}
+
+	public class WsdlFileOptionsCaseInsensitive : WsdlFileOptions
+	{
+		public override Dictionary<string, WebServiceWSDLMapping> WebServiceWSDLMapping { get; set; } = new Dictionary<string, WebServiceWSDLMapping>(StringComparer.OrdinalIgnoreCase);
 	}
 }

--- a/src/SoapCore/WebServiceWSDLMapping.cs
+++ b/src/SoapCore/WebServiceWSDLMapping.cs
@@ -4,10 +4,11 @@ using System.Text;
 
 namespace SoapCore
 {
-    public class WebServiceWSDLMapping
-    {
-        public string WsdlFile { get; set; }
-        public string WSDLFolder { get; set; }
-        public string SchemaFolder { get; set; }
-    }
+	public class WebServiceWSDLMapping
+	{
+		public string UrlOverride { get; set; }
+		public string WsdlFile { get; set; }
+		public string WSDLFolder { get; set; }
+		public string SchemaFolder { get; set; }
+	}
 }


### PR DESCRIPTION
Added some improvements for external WSDL schemas support:

- `WsdlFileOptionsCaseInsensitive` options - to use with case-insensitive mapping. Without it, even if you use `SoapCoreOptions.CaseInsensitivePath = true` - external WSDL schemas would fail to map by `HttpContext.Request.Path`.
- `UrlOverride` property to `WebServiceWSDLMapping`. It's needed to be able to host services under different folders. For example if you have one service hosted like - https://localhost:5001/Management/Service.asmx, and another one - as https://localhost:5001/Orders/Customers.asmx. I didn't manage to achieve this goal with existing `UrlOverride`, `VirtualPath`, `AppPath` properties in `WsdlFileOptions`.

**Short afterword:** I hope the goals I was trying to achieve are clear. As about implementation - I'm ready to do additional changes in case someone has any better ideas or if there are some general issues or inconsistencies with the nature of SoapCore.
For now I tried to be cautious and add functionality on top. If it would be mine own project - then, for example I perhaps `WsdlFileOptionsCaseInsensitive` could just replace `WsdlFileOptions`, because it's just would be more flexible. However I didn't want to introduce any potential breaking changes.