### PR TITLE
Remove CancellationToken for async methods from wsdl

### DIFF
--- a/src/SoapCore/Meta/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaWCFBodyWriter.cs
@@ -190,6 +190,8 @@ namespace SoapCore.Meta
 		{
 			foreach (var parameterInfo in parameterInfos)
 			{
+				if (parameterInfo.Parameter.ParameterType.FullName == "System.Threading.CancellationToken")
+					continue;
 				var elementAttribute = parameterInfo.Parameter.GetCustomAttribute<XmlElementAttribute>();
 				var parameterName = !string.IsNullOrEmpty(elementAttribute?.ElementName)
 										? elementAttribute.ElementName
@@ -268,6 +270,8 @@ namespace SoapCore.Meta
 				{
 					var type = parameter.Parameter.ParameterType;
 					var typeInfo = type.GetTypeInfo();
+					if (typeInfo.FullName == "System.Threading.CancellationToken")
+						continue;
 					if (typeInfo.IsByRef)
 					{
 						type = typeInfo.GetElementType();


### PR DESCRIPTION
Avoid adding CancellationToken in method parameters for asynchronous methods and adding type to type declarations.
