### PR TITLE
Remove import contract namespace as this results in a stack overflow

### DIFF
--- a/src/SoapCore/Meta/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaWCFBodyWriter.cs
@@ -308,7 +308,7 @@ namespace SoapCore.Meta
 
 			var groupedByNamespace = _complexTypeToBuild.GroupBy(x => x.Value).ToDictionary(x => x.Key, x => x.Select(k => k.Key));
 
-			foreach (var @namespace in groupedByNamespace.Keys.Where(x => x != null && x != _service.ServiceType.Namespace).Distinct())
+			foreach (var @namespace in groupedByNamespace.Keys.Where(x => x != null && x != _service.ServiceType.Namespace && x != contract.Namespace).Distinct())
 			{
 				writer.WriteStartElement("xs", "import", Namespaces.XMLNS_XSD);
 				writer.WriteAttributeString("namespace", @namespace);


### PR DESCRIPTION
Exclude contract namespace import, as this results in a stack overflow error in some parsers.

Example, before:
...
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ser="http://schemas.microsoft.com/2003/10/Serialization/" elementFormDefault="qualified" targetNamespace="http://iteco.ru/esz/EszServer/MpguSearchService">
			<xs:import namespace="http://iteco.ru/esz/EszServer/MpguSearchService" />
			<xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
...

after :
...
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ser="http://schemas.microsoft.com/2003/10/Serialization/" elementFormDefault="qualified" targetNamespace="http://iteco.ru/esz/EszServer/MpguSearchService">
			<xs:import namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
...