### PR TITLE
Added encoding explicitly when XmlReader is created for non-utf-8 cases

### DIFF
--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -148,15 +148,8 @@ namespace SoapCore.MessageEncoder
 			}
 			else
 			{
-				var xmlReaderSettings = new XmlReaderSettings()
-				{
-					IgnoreWhitespace = true,
-					DtdProcessing = DtdProcessing.Prohibit,
-					CloseInput = true
-				};
-
 				var streamReaderWithEncoding = new StreamReader(stream, _writeEncoding);
-				reader = XmlReader.Create(streamReaderWithEncoding, xmlReaderSettings);
+				reader = XmlReader.Create(streamReaderWithEncoding, new XmlReaderSettings() { IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit, CloseInput = true });
 			}
 
 			Message message = Message.CreateMessage(reader, maxSizeOfHeaders, MessageVersion);

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -141,9 +141,23 @@ namespace SoapCore.MessageEncoder
 				throw new ArgumentNullException(nameof(stream));
 			}
 
-			XmlReader reader = _supportXmlDictionaryReader ?
-			 	XmlDictionaryReader.CreateTextReader(stream, _writeEncoding, ReaderQuotas, dictionaryReader => { }) :
-				XmlReader.Create(stream, new XmlReaderSettings() { IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit });
+			XmlReader reader;
+			if (_supportXmlDictionaryReader)
+			{
+				reader = XmlDictionaryReader.CreateTextReader(stream, _writeEncoding, ReaderQuotas, dictionaryReader => { });
+			}
+			else
+			{
+				var xmlReaderSettings = new XmlReaderSettings()
+				{
+					IgnoreWhitespace = true,
+					DtdProcessing = DtdProcessing.Prohibit,
+					CloseInput = true
+				};
+
+				var streamReaderWithEncoding = new StreamReader(stream, _writeEncoding);
+				reader = XmlReader.Create(streamReaderWithEncoding, xmlReaderSettings);
+			}
 
 			Message message = Message.CreateMessage(reader, maxSizeOfHeaders, MessageVersion);
 


### PR DESCRIPTION
A fix for #918, when encoding should be specified explicitly if web service should work with encodings other than utf-8 (or any other utf encodings). It's an improvement for a previous fix for ISO-8859-1 support (#429).

It creates a new `StreamReader` on top of existing `stream`, which might look like a hack. However in fact initial `stream` is coming from some .NET internals like `HttpContext.Request.Body` and as much as I understand - by default it's always UTF-8 nowadays. I didn't find any better way to switch the encoding for the underlying stream.
In addition I added `CloseInput = true` property on `XmlReaderSettings`, which should handle and close additionally created `StreamReader`.