### PR TITLE
Added more flexibility to handle encodings 

### DIFF
--- a/src/SoapCore.Tests/IntegrationTests.cs
+++ b/src/SoapCore.Tests/IntegrationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -317,7 +318,7 @@ namespace SoapCore.Tests
 		private ITestService CreateSoap12Client()
 		{
 			var transport = new HttpTransportBindingElement();
-			var textencoding = new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, System.Text.Encoding.UTF8);
+			var textencoding = new TextMessageEncodingBindingElement(MessageVersion.Soap12WSAddressing10, Encoding.UTF8);
 			var binding = new CustomBinding(textencoding, transport);
 			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:5050/Service.svc", "localhost")));
 			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);

--- a/src/SoapCore.Tests/Startup.cs
+++ b/src/SoapCore.Tests/Startup.cs
@@ -127,6 +127,42 @@ namespace SoapCore.Tests
 
 				app.UseSoapEndpoint<TestService>("/WSA11ISO88591Service.svc", soapEncodingOptions, SoapSerializer.DataContractSerializer);
 			});
+
+			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("asmx"), app2 =>
+			{
+				app2.UseRouting();
+
+				var soapEncodingOptions = new SoapEncoderOptions
+				{
+					MessageVersion = MessageVersion.Soap11,
+					WriteEncoding = Encoding.UTF8,
+					ReadEncoding = Encoding.GetEncoding("ISO-8859-1"),
+					OverwriteResponseContentType = false
+				};
+
+				app2.UseSoapEndpoint<TestService>(opt =>
+				{
+					opt.Path = "/ServiceWithDifferentEncodings.asmx";
+					opt.EncoderOptions = new[] { soapEncodingOptions };
+					opt.OmitXmlDeclaration = false;
+					opt.SoapSerializer = SoapSerializer.XmlSerializer;
+				});
+			});
+
+			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("asmx"), app2 =>
+			{
+				app2.UseRouting();
+
+				var soapEncodingOptions = new SoapEncoderOptions
+				{
+					MessageVersion = MessageVersion.Soap11,
+					WriteEncoding = Encoding.UTF8,
+					ReadEncoding = Encoding.GetEncoding("ISO-8859-1"),
+					OverwriteResponseContentType = true
+				};
+
+				app2.UseSoapEndpoint<TestService>("/ServiceWithOverwrittenContentType.asmx", soapEncodingOptions, SoapSerializer.XmlSerializer);
+			});
 		}
 #endif
 	}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.ServiceModel.Channels;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -855,7 +856,7 @@ namespace SoapCore.Tests.Wsdl
 			var bodyWriter = serializer == SoapSerializer.DataContractSerializer
 				? new MetaWCFBodyWriter(service, baseUrl, defaultBindingName, false, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }) as BodyWriter
 				: new MetaBodyWriter(service, baseUrl, xmlNamespaceManager, defaultBindingName, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }) as BodyWriter;
-			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, System.Text.Encoding.UTF8, XmlDictionaryReaderQuotas.Max, false, true, false, null, bindingName, portName);
+			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, Encoding.UTF8, Encoding.UTF8, false, XmlDictionaryReaderQuotas.Max, false, true, false, null, bindingName, portName);
 			var responseMessage = Message.CreateMessage(encoder.MessageVersion, null, bodyWriter);
 			responseMessage = new MetaMessage(responseMessage, service, xmlNamespaceManager, defaultBindingName, false);
 

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -24,8 +24,8 @@ namespace SoapCore.MessageEncoder
 		internal const string Soap12MediaType = "application/soap+xml";
 		private const string XmlMediaType = "application/xml";
 
-		private readonly Encoding _readEncoding;
 		private readonly Encoding _writeEncoding;
+		private readonly Encoding _readEncoding;
 		private readonly bool _overwriteResponseContentType;
 		private readonly bool _optimizeWriteForUtf8;
 		private readonly bool _omitXmlDeclaration;
@@ -33,7 +33,7 @@ namespace SoapCore.MessageEncoder
 		private readonly bool _supportXmlDictionaryReader;
 		private readonly bool _checkXmlCharacters;
 
-		public SoapMessageEncoder(MessageVersion version, Encoding readEncoding, Encoding writeEncoding, bool overwriteResponseContentType, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool indentXml, bool checkXmlCharacters, XmlNamespaceManager xmlNamespaceOverrides, string bindingName, string portName, int maxSoapHeaderSize = SoapMessageEncoderDefaults.MaxSoapHeaderSizeDefault)
+		public SoapMessageEncoder(MessageVersion version, Encoding writeEncoding, Encoding readEncoding, bool overwriteResponseContentType, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool indentXml, bool checkXmlCharacters, XmlNamespaceManager xmlNamespaceOverrides, string bindingName, string portName, int maxSoapHeaderSize = SoapMessageEncoderDefaults.MaxSoapHeaderSizeDefault)
 		{
 			_indentXml = indentXml;
 			_omitXmlDeclaration = omitXmlDeclaration;
@@ -41,20 +41,20 @@ namespace SoapCore.MessageEncoder
 			BindingName = bindingName;
 			PortName = portName;
 
-			if (readEncoding == null)
-			{
-				throw new ArgumentNullException(nameof(readEncoding));
-			}
-
 			if (writeEncoding == null)
 			{
 				throw new ArgumentNullException(nameof(writeEncoding));
 			}
 
+			if (readEncoding == null)
+			{
+				throw new ArgumentNullException(nameof(readEncoding));
+			}
+
 			_supportXmlDictionaryReader = SoapMessageEncoderDefaults.TryValidateEncoding(readEncoding, out _);
 
-			_readEncoding = readEncoding;
 			_writeEncoding = writeEncoding;
+			_readEncoding = readEncoding;
 			_optimizeWriteForUtf8 = IsUtf8Encoding(writeEncoding);
 
 			_overwriteResponseContentType = overwriteResponseContentType;

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -24,14 +24,16 @@ namespace SoapCore.MessageEncoder
 		internal const string Soap12MediaType = "application/soap+xml";
 		private const string XmlMediaType = "application/xml";
 
+		private readonly Encoding _readEncoding;
 		private readonly Encoding _writeEncoding;
+		private readonly bool _overwriteResponseContentType;
 		private readonly bool _optimizeWriteForUtf8;
 		private readonly bool _omitXmlDeclaration;
 		private readonly bool _indentXml;
 		private readonly bool _supportXmlDictionaryReader;
 		private readonly bool _checkXmlCharacters;
 
-		public SoapMessageEncoder(MessageVersion version, Encoding writeEncoding, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool indentXml, bool checkXmlCharacters, XmlNamespaceManager xmlNamespaceOverrides, string bindingName, string portName, int maxSoapHeaderSize = SoapMessageEncoderDefaults.MaxSoapHeaderSizeDefault)
+		public SoapMessageEncoder(MessageVersion version, Encoding readEncoding, Encoding writeEncoding, bool overwriteResponseContentType, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool indentXml, bool checkXmlCharacters, XmlNamespaceManager xmlNamespaceOverrides, string bindingName, string portName, int maxSoapHeaderSize = SoapMessageEncoderDefaults.MaxSoapHeaderSizeDefault)
 		{
 			_indentXml = indentXml;
 			_omitXmlDeclaration = omitXmlDeclaration;
@@ -39,15 +41,23 @@ namespace SoapCore.MessageEncoder
 			BindingName = bindingName;
 			PortName = portName;
 
+			if (readEncoding == null)
+			{
+				throw new ArgumentNullException(nameof(readEncoding));
+			}
+
 			if (writeEncoding == null)
 			{
 				throw new ArgumentNullException(nameof(writeEncoding));
 			}
 
-			_supportXmlDictionaryReader = SoapMessageEncoderDefaults.TryValidateEncoding(writeEncoding, out _);
+			_supportXmlDictionaryReader = SoapMessageEncoderDefaults.TryValidateEncoding(readEncoding, out _);
 
+			_readEncoding = readEncoding;
 			_writeEncoding = writeEncoding;
 			_optimizeWriteForUtf8 = IsUtf8Encoding(writeEncoding);
+
+			_overwriteResponseContentType = overwriteResponseContentType;
 
 			MessageVersion = version ?? throw new ArgumentNullException(nameof(version));
 
@@ -144,12 +154,13 @@ namespace SoapCore.MessageEncoder
 			XmlReader reader;
 			if (_supportXmlDictionaryReader)
 			{
-				reader = XmlDictionaryReader.CreateTextReader(stream, _writeEncoding, ReaderQuotas, dictionaryReader => { });
+				reader = XmlDictionaryReader.CreateTextReader(stream, _readEncoding, ReaderQuotas, dictionaryReader => { });
 			}
 			else
 			{
-				var streamReaderWithEncoding = new StreamReader(stream, _writeEncoding);
-				reader = XmlReader.Create(streamReaderWithEncoding, new XmlReaderSettings() { IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit, CloseInput = true });
+				var streamReaderWithEncoding = new StreamReader(stream, _readEncoding);
+				var xmlReaderSettings = new XmlReaderSettings() { IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit, CloseInput = true };
+				reader = XmlReader.Create(streamReaderWithEncoding, xmlReaderSettings);
 			}
 
 			Message message = Message.CreateMessage(reader, maxSizeOfHeaders, MessageVersion);
@@ -199,6 +210,11 @@ namespace SoapCore.MessageEncoder
 
 				//Set Content-length in Response
 				httpContext.Response.ContentLength = soapMessage.Length;
+
+				if (_overwriteResponseContentType)
+				{
+					httpContext.Response.ContentType = ContentType;
+				}
 
 				await pipeWriter.WriteAsync(soapMessage);
 				await pipeWriter.FlushAsync();

--- a/src/SoapCore/SoapEncoderOptions.cs
+++ b/src/SoapCore/SoapEncoderOptions.cs
@@ -7,7 +7,9 @@ namespace SoapCore
 	public class SoapEncoderOptions
 	{
 		public MessageVersion MessageVersion { get; set; } = MessageVersion.Soap11;
+		public Encoding ReadEncoding { get; set; } = DefaultEncodings.UTF8;
 		public Encoding WriteEncoding { get; set; } = DefaultEncodings.UTF8;
+		public bool OverwriteResponseContentType { get; set; }
 		public XmlDictionaryReaderQuotas ReaderQuotas { get; set; } = XmlDictionaryReaderQuotas.Max;
 		public string BindingName { get; set; } = null;
 		public string PortName { get; set; } = null;

--- a/src/SoapCore/SoapEncoderOptions.cs
+++ b/src/SoapCore/SoapEncoderOptions.cs
@@ -6,9 +6,18 @@ namespace SoapCore
 {
 	public class SoapEncoderOptions
 	{
+		private Encoding _readEncoding;
+
 		public MessageVersion MessageVersion { get; set; } = MessageVersion.Soap11;
-		public Encoding ReadEncoding { get; set; } = DefaultEncodings.UTF8;
+
 		public Encoding WriteEncoding { get; set; } = DefaultEncodings.UTF8;
+
+		public Encoding ReadEncoding
+		{
+			get => _readEncoding ?? WriteEncoding;
+			set => _readEncoding = value;
+		}
+
 		public bool OverwriteResponseContentType { get; set; }
 		public XmlDictionaryReaderQuotas ReaderQuotas { get; set; } = XmlDictionaryReaderQuotas.Max;
 		public string BindingName { get; set; } = null;

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -74,7 +74,7 @@ namespace SoapCore
 			for (var i = 0; i < options.EncoderOptions.Length; i++)
 			{
 				var encoderOptions = options.EncoderOptions[i];
-				_messageEncoders[i] = new SoapMessageEncoder(encoderOptions.MessageVersion, encoderOptions.ReadEncoding, encoderOptions.WriteEncoding, encoderOptions.OverwriteResponseContentType,  encoderOptions.ReaderQuotas, options.OmitXmlDeclaration, options.IndentXml, options.CheckXmlCharacters, encoderOptions.XmlNamespaceOverrides, encoderOptions.BindingName, encoderOptions.PortName, encoderOptions.MaxSoapHeaderSize);
+				_messageEncoders[i] = new SoapMessageEncoder(encoderOptions.MessageVersion, encoderOptions.WriteEncoding, encoderOptions.ReadEncoding, encoderOptions.OverwriteResponseContentType,  encoderOptions.ReaderQuotas, options.OmitXmlDeclaration, options.IndentXml, options.CheckXmlCharacters, encoderOptions.XmlNamespaceOverrides, encoderOptions.BindingName, encoderOptions.PortName, encoderOptions.MaxSoapHeaderSize);
 			}
 		}
 

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -73,7 +73,8 @@ namespace SoapCore
 
 			for (var i = 0; i < options.EncoderOptions.Length; i++)
 			{
-				_messageEncoders[i] = new SoapMessageEncoder(options.EncoderOptions[i].MessageVersion, options.EncoderOptions[i].WriteEncoding, options.EncoderOptions[i].ReaderQuotas, options.OmitXmlDeclaration, options.IndentXml, options.CheckXmlCharacters, options.EncoderOptions[i].XmlNamespaceOverrides, options.EncoderOptions[i].BindingName, options.EncoderOptions[i].PortName, options.EncoderOptions[i].MaxSoapHeaderSize);
+				var encoderOptions = options.EncoderOptions[i];
+				_messageEncoders[i] = new SoapMessageEncoder(encoderOptions.MessageVersion, encoderOptions.ReadEncoding, encoderOptions.WriteEncoding, encoderOptions.OverwriteResponseContentType,  encoderOptions.ReaderQuotas, options.OmitXmlDeclaration, options.IndentXml, options.CheckXmlCharacters, encoderOptions.XmlNamespaceOverrides, encoderOptions.BindingName, encoderOptions.PortName, encoderOptions.MaxSoapHeaderSize);
 			}
 		}
 


### PR DESCRIPTION
Added more flexibility to handle encodings for the issue - #918:
- Possibility to define different read/write encodings
- Possibility to overwrite response ContentType to be same as write encoding, which might be different than request encoding

It's needed to support legacy clients, which were able to use different encodings/charsets/contenttypes for request and response.
I.e. client could send a request with Windows-1252 encoding, and then expect to get a response with UTF-8. In that case response content type should be same as response encoding, not as request encoding.