### PR TITLE
Refactored encoding used for reading to respect ContentType header

### DIFF
--- a/src/SoapCore.Tests/Startup.cs
+++ b/src/SoapCore.Tests/Startup.cs
@@ -136,7 +136,6 @@ namespace SoapCore.Tests
 				{
 					MessageVersion = MessageVersion.Soap11,
 					WriteEncoding = Encoding.UTF8,
-					ReadEncoding = Encoding.GetEncoding("ISO-8859-1"),
 					OverwriteResponseContentType = false
 				};
 
@@ -157,7 +156,6 @@ namespace SoapCore.Tests
 				{
 					MessageVersion = MessageVersion.Soap11,
 					WriteEncoding = Encoding.UTF8,
-					ReadEncoding = Encoding.GetEncoding("ISO-8859-1"),
 					OverwriteResponseContentType = true
 				};
 

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -856,7 +856,7 @@ namespace SoapCore.Tests.Wsdl
 			var bodyWriter = serializer == SoapSerializer.DataContractSerializer
 				? new MetaWCFBodyWriter(service, baseUrl, defaultBindingName, false, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }) as BodyWriter
 				: new MetaBodyWriter(service, baseUrl, xmlNamespaceManager, defaultBindingName, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }) as BodyWriter;
-			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, Encoding.UTF8, Encoding.UTF8, false, XmlDictionaryReaderQuotas.Max, false, true, false, null, bindingName, portName);
+			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, Encoding.UTF8, false, XmlDictionaryReaderQuotas.Max, false, true, false, null, bindingName, portName);
 			var responseMessage = Message.CreateMessage(encoder.MessageVersion, null, bodyWriter);
 			responseMessage = new MetaMessage(responseMessage, service, xmlNamespaceManager, defaultBindingName, false);
 

--- a/src/SoapCore/DefaultEncodings.cs
+++ b/src/SoapCore/DefaultEncodings.cs
@@ -9,5 +9,6 @@ namespace SoapCore
 		public static Encoding UTF8 => new UTF8Encoding(false);
 		public static Encoding Unicode => new UnicodeEncoding(false, false);
 		public static Encoding BigEndianUnicode => new UnicodeEncoding(true, false);
+		public static Encoding Iso88591 => Encoding.GetEncoding("ISO8859-1");
 	}
 }

--- a/src/SoapCore/SoapEncoderOptions.cs
+++ b/src/SoapCore/SoapEncoderOptions.cs
@@ -6,17 +6,9 @@ namespace SoapCore
 {
 	public class SoapEncoderOptions
 	{
-		private Encoding _readEncoding;
-
 		public MessageVersion MessageVersion { get; set; } = MessageVersion.Soap11;
 
 		public Encoding WriteEncoding { get; set; } = DefaultEncodings.UTF8;
-
-		public Encoding ReadEncoding
-		{
-			get => _readEncoding ?? WriteEncoding;
-			set => _readEncoding = value;
-		}
 
 		public bool OverwriteResponseContentType { get; set; }
 		public XmlDictionaryReaderQuotas ReaderQuotas { get; set; } = XmlDictionaryReaderQuotas.Max;

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -74,7 +74,7 @@ namespace SoapCore
 			for (var i = 0; i < options.EncoderOptions.Length; i++)
 			{
 				var encoderOptions = options.EncoderOptions[i];
-				_messageEncoders[i] = new SoapMessageEncoder(encoderOptions.MessageVersion, encoderOptions.WriteEncoding, encoderOptions.ReadEncoding, encoderOptions.OverwriteResponseContentType,  encoderOptions.ReaderQuotas, options.OmitXmlDeclaration, options.IndentXml, options.CheckXmlCharacters, encoderOptions.XmlNamespaceOverrides, encoderOptions.BindingName, encoderOptions.PortName, encoderOptions.MaxSoapHeaderSize);
+				_messageEncoders[i] = new SoapMessageEncoder(encoderOptions.MessageVersion, encoderOptions.WriteEncoding, encoderOptions.OverwriteResponseContentType,  encoderOptions.ReaderQuotas, options.OmitXmlDeclaration, options.IndentXml, options.CheckXmlCharacters, encoderOptions.XmlNamespaceOverrides, encoderOptions.BindingName, encoderOptions.PortName, encoderOptions.MaxSoapHeaderSize);
 			}
 		}
 


### PR DESCRIPTION
It's one more stabilization fix for legacy non-utf-8 clients, started in #918.

It's a refactoring of changes done in #921. Actually it was a bad idea to set a fixed `readEncoding`, it should respect what client is requesting. One client can work with windows-1252/ISO-8859-1, another client might work with utf-8. The way to determine it - is "ContentType" header sent with the request from the client.
So I refactored encoding used for reading to respect "ContentType" header in the request, which should have charset/encoding in it (example - `Content-Type: text/xml; charset=windows-1252`).
If it's not present or some faulty one - it should fallback to previous behavior or just take default encoding (which is utf-8).