### PR TITLE
Add support for the standalone attribute in the XML declaration.

### DIFF
--- a/src/SoapCore/CustomMessage.cs
+++ b/src/SoapCore/CustomMessage.cs
@@ -20,6 +20,8 @@ namespace SoapCore
 
 		public System.Collections.Generic.Dictionary<string, string> AdditionalEnvelopeXmlnsAttributes { get; internal set; }
 
+		public bool? StandAloneAttribute { get; set; }
+
 		public override MessageHeaders Headers => Message.Headers;
 
 		public override MessageProperties Properties => Message.Properties;
@@ -32,7 +34,15 @@ namespace SoapCore
 
 		protected override void OnWriteStartEnvelope(XmlDictionaryWriter writer)
 		{
-			writer.WriteStartDocument();
+			if (StandAloneAttribute.HasValue)
+			{
+				writer.WriteStartDocument(StandAloneAttribute.Value);
+			}
+			else
+			{
+				writer.WriteStartDocument();
+			}
+
 			var prefix = Version.Envelope.NamespacePrefix(NamespaceManager);
 			writer.WriteStartElement(prefix, "Envelope", Version.Envelope.Namespace());
 			writer.WriteXmlnsAttribute(prefix, Version.Envelope.Namespace());

--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -97,7 +97,7 @@ namespace SoapCore
 		/// Gets or sets a value indicating wheter to add the stand alone attribute in the XML declaration
 		/// <para>Defaults to false</para>
 		/// </summary>
-		public bool? StandAloneAttribute { get; set; } = false;
+		public bool? StandAloneAttribute { get; set; } = null;
 
 		/// <summary>
 		/// Gets or sets a value indicating whether to indent the Xml in responses

--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -1,8 +1,8 @@
+using SoapCore.Extensibility;
 using System;
 using System.Collections.Generic;
 using System.ServiceModel.Channels;
 using System.Xml;
-using SoapCore.Extensibility;
 
 namespace SoapCore
 {
@@ -92,6 +92,12 @@ namespace SoapCore
 		/// <para>Defaults to true</para>
 		/// </summary>
 		public bool OmitXmlDeclaration { get; set; } = true;
+
+		/// <summary>
+		/// Gets or sets a value indicating wheter to add the stand alone attribute in the XML declaration
+		/// <para>Defaults to false</para>
+		/// </summary>
+		public bool? StandAloneAttribute { get; set; } = false;
 
 		/// <summary>
 		/// Gets or sets a value indicating whether to indent the Xml in responses

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -530,6 +530,7 @@ namespace SoapCore
 			{
 				responseMessage = new T_MESSAGE
 				{
+					StandAloneAttribute = _options.StandAloneAttribute,
 					Message = Message.CreateMessage(soapMessageEncoder.MessageVersion, soapAction, bodyWriter),
 					AdditionalEnvelopeXmlnsAttributes = _options.AdditionalEnvelopeXmlnsAttributes,
 					NamespaceManager = xmlNamespaceManager
@@ -542,6 +543,7 @@ namespace SoapCore
 			{
 				responseMessage = new T_MESSAGE
 				{
+					StandAloneAttribute = _options.StandAloneAttribute,
 					Message = Message.CreateMessage(soapMessageEncoder.MessageVersion, null, bodyWriter),
 					AdditionalEnvelopeXmlnsAttributes = _options.AdditionalEnvelopeXmlnsAttributes,
 					NamespaceManager = xmlNamespaceManager

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -1,9 +1,9 @@
+using SoapCore.Extensibility;
+using SoapCore.Meta;
 using System;
 using System.Collections.Generic;
 using System.ServiceModel.Channels;
 using System.Xml;
-using SoapCore.Extensibility;
-using SoapCore.Meta;
 
 namespace SoapCore
 {
@@ -52,6 +52,8 @@ namespace SoapCore
 
 		public bool OmitXmlDeclaration { get; set; } = true;
 
+		public bool? StandAloneAttribute { get; set; } = false;
+
 		public bool IndentXml { get; set; } = true;
 
 		/// <summary>
@@ -86,6 +88,7 @@ namespace SoapCore
 				HttpPostEnabled = opt.HttpPostEnabled,
 				HttpsPostEnabled = opt.HttpsPostEnabled,
 				OmitXmlDeclaration = opt.OmitXmlDeclaration,
+				StandAloneAttribute = opt.StandAloneAttribute,
 				IndentXml = opt.IndentXml,
 				XmlNamespacePrefixOverrides = opt.XmlNamespacePrefixOverrides,
 				WsdlFileOptions = opt.WsdlFileOptions,

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -52,7 +52,7 @@ namespace SoapCore
 
 		public bool OmitXmlDeclaration { get; set; } = true;
 
-		public bool? StandAloneAttribute { get; set; } = false;
+		public bool? StandAloneAttribute { get; set; } = null;
 
 		public bool IndentXml { get; set; } = true;
 


### PR DESCRIPTION
In the response message we need support for the standalone attribute in the XML declaration. Like ```<?xml version="1.0" encoding="utf-8" standalone="yes"?>.```

The PR supports:

-  no standalone attribute,
-  the value yes in the standalone attribute 
-  the value no in the standalone attribute.