### PR TITLE
More namespace flexibility

### DIFF
--- a/src/SoapCore/ServiceBodyWriter.cs
+++ b/src/SoapCore/ServiceBodyWriter.cs
@@ -116,9 +116,7 @@ namespace SoapCore
 					: xmlRootAttr.ElementName));
 
 				var xmlNs = _operation.ReturnNamespace ?? messageContractAttribute?.WrapperNamespace
-					?? (string.IsNullOrWhiteSpace(xmlRootAttr?.Namespace)
-					? _serviceNamespace
-					: xmlRootAttr.Namespace);
+					?? (xmlRootAttr?.Namespace ?? _serviceNamespace);
 
 				if (_operation.ReturnsChoice)
 				{


### PR DESCRIPTION
For back compatibility, it might be needed to have an empty xmlns="" for the first tag.
This change will allow it to do in case if namespace is specified and set to empty string (Namespace="")
In case it is not specified or set to null would be displayed service namespace (like it is done currently)