### PR TITLE
XmlNode/XmlElement as an Input Parameter

### DIFF
--- a/src/SoapCore.Tests/ITestService.cs
+++ b/src/SoapCore.Tests/ITestService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.ServiceModel;
 using System.Threading.Tasks;
+using System.Xml;
 using Microsoft.AspNetCore.Mvc;
 using SoapCore.Tests.Model;
 
@@ -94,5 +95,11 @@ namespace SoapCore.Tests
 		[ServiceKnownType("GetKnownTypes", typeof(TestServiceKnownTypesProvider))]
 		[OperationContract]
 		IComplexTreeModelInput GetComplexModelInputFromKnownTypeProvider(ComplexModelInput value);
+
+		[OperationContract]
+		XmlElement ReturnXmlElement();
+
+		[OperationContract]
+		XmlElement XmlElementInput(XmlElement input);
 	}
 }

--- a/src/SoapCore.Tests/IntegrationTests.cs
+++ b/src/SoapCore.Tests/IntegrationTests.cs
@@ -4,6 +4,7 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SoapCore.Tests.Model;
@@ -224,6 +225,26 @@ namespace SoapCore.Tests
 			var output = client.GetComplexModelInputFromKnownTypeProvider(input);
 			Assert.IsInstanceOfType(output, typeof(ComplexTreeModelInput));
 			Assert.AreEqual(input.StringProperty, output.Item.StringProperty);
+		}
+
+		[TestMethod]
+		public void ReturnXmlElement()
+		{
+			var client = CreateClient();
+			var output = client.ReturnXmlElement();
+			Assert.IsInstanceOfType(output, typeof(XmlElement));
+			Assert.AreEqual(output.OuterXml, "<TestXml xmlns=\"\" />");
+		}
+
+		[TestMethod]
+		public void XmlElemetInput()
+		{
+			var client = CreateClient();
+			XmlDocument xdInput = new XmlDocument();
+			xdInput.LoadXml("<XmlTestInput/>");
+			var output = client.XmlElementInput(xdInput.DocumentElement);
+			Assert.IsInstanceOfType(output, typeof(XmlElement));
+			Assert.IsTrue(output.OuterXml.Contains("Success"));
 		}
 
 		[TestMethod]

--- a/src/SoapCore.Tests/TestService.cs
+++ b/src/SoapCore.Tests/TestService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ServiceModel;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 using Microsoft.AspNetCore.Mvc;
 using SoapCore.Tests.Model;
 
@@ -195,6 +196,28 @@ namespace SoapCore.Tests
 			{
 				Item = value
 			};
+		}
+
+		public XmlElement ReturnXmlElement()
+		{
+			XmlDocument xdOutput = new XmlDocument();
+			xdOutput.LoadXml("<TestXml/>");
+			return xdOutput.DocumentElement;
+		}
+
+		public XmlElement XmlElementInput(XmlElement input)
+		{
+			XmlDocument xdOutput = new XmlDocument();
+			if (input != null)
+			{
+				xdOutput.LoadXml("<Success/>");
+			}
+			else
+			{
+				xdOutput.LoadXml("<Failed/>");
+			}
+
+			return xdOutput.DocumentElement;
 		}
 	}
 }

--- a/src/SoapCore.Tests/XmlNodeInputOutput/IXmlNodeInputOutput.cs
+++ b/src/SoapCore.Tests/XmlNodeInputOutput/IXmlNodeInputOutput.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Text;
+using System.Xml;
+
+namespace SoapCore.Tests.XmlNodeInputOutput
+{
+	[ServiceContract]
+	public interface IXmlNodeInputOutput
+	{
+		[OperationContract]
+		XmlElement ProcessRequest(string login, string password, XmlElement requestXml);
+
+		[OperationContract]
+		XmlElement GetRequest();
+	}
+}

--- a/src/SoapCore.Tests/XmlNodeInputOutput/Startup.cs
+++ b/src/SoapCore.Tests/XmlNodeInputOutput/Startup.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace SoapCore.Tests.XmlNodeInputOutput
+{
+	public class Startup
+	{
+		public void ConfigureServices(IServiceCollection services)
+		{
+			services.AddSoapCore();
+			services.TryAddSingleton<IXmlNodeInputOutput, XmlNodeInputOutput>();
+			services.AddMvc();
+		}
+
+		public void Configure(IApplicationBuilder app)
+		{
+			app.UseRouting();
+
+			app.UseEndpoints(x =>
+			{
+				x.UseSoapEndpoint<IXmlNodeInputOutput>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+				x.UseSoapEndpoint<IXmlNodeInputOutput>("/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
+			});
+		}
+	}
+}

--- a/src/SoapCore.Tests/XmlNodeInputOutput/XmlNodeInputOutput.cs
+++ b/src/SoapCore.Tests/XmlNodeInputOutput/XmlNodeInputOutput.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+
+namespace SoapCore.Tests.XmlNodeInputOutput
+{
+	public class XmlNodeInputOutput : IXmlNodeInputOutput
+	{
+		public XmlNodeInputOutput()
+		{
+		}
+
+		public XmlElement ProcessRequest(string login, string password, XmlElement requestXml)
+		{
+			if (password == "Password")
+			{
+				return requestXml;
+			}
+			else
+			{
+				XmlDocument xdError = new XmlDocument();
+				xdError.LoadXml("<Error><Message>Incorrect Password</Message></Error>");
+				return xdError.DocumentElement;
+			}
+		}
+
+		public XmlElement GetRequest()
+		{
+			XmlDocument xdResponse = new XmlDocument();
+			xdResponse.LoadXml("<Response><Message>A response</Message></Response>");
+			return xdResponse.DocumentElement;
+		}
+	}
+}

--- a/src/SoapCore.Tests/XmlNodeInputOutput/XmlNodeInputOutputTests.cs
+++ b/src/SoapCore.Tests/XmlNodeInputOutput/XmlNodeInputOutputTests.cs
@@ -1,0 +1,75 @@
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SoapCore.Tests.XmlNodeInputOutput
+{
+	/*
+	 * This test refers to issue https://github.com/DigDes/SoapCore/issues/908
+	 * User has a service with an XmlNode parameter and the value sent to the function is always null.
+	 */
+
+	[TestClass]
+	public class XmlNodeInputOutputTests
+	{
+		[TestMethod]
+		public async Task SendXmlInputGetXmlOutputAsync()
+		{
+			string xmlInput = "<Request><Input>Hello</Input><Type>Test</Type></Request>",
+				strLogin = "Login",
+				strPassword = "Password";
+			var body = $@"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"">
+  <soapenv:Body>
+    <ProcessRequest xmlns=""http://tempuri.org/"">
+      <login>{strLogin}</login>
+      <password>{strPassword}</password>
+      <requestXml>{xmlInput}</requestXml>
+   </ProcessRequest>
+  </soapenv:Body>
+</soapenv:Envelope>
+";
+			using (var host = CreateTestHost())
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body, Encoding.UTF8, "text/xml"))
+			using (var res = host.CreateRequest("/Service.svc").AddHeader("SOAPAction", @"""ProcessRequest""").And(msg => msg.Content = content).PostAsync().Result)
+			{
+				res.EnsureSuccessStatusCode();
+
+				var response = await res.Content.ReadAsStringAsync();
+				Assert.IsTrue(response.Replace("\r\n", string.Empty).Replace("  ", string.Empty).Contains(xmlInput));
+			}
+		}
+
+		[TestMethod]
+		public async Task GetXmlOutputAsync()
+		{
+			var body = $@"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"">
+  <soapenv:Body>
+    <GetRequest xmlns=""http://tempuri.org/"">      
+   </GetRequest>
+  </soapenv:Body>
+</soapenv:Envelope>
+";
+			using (var host = CreateTestHost())
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body, Encoding.UTF8, "text/xml"))
+			using (var res = host.CreateRequest("/Service.svc").AddHeader("SOAPAction", @"""GetRequest""").And(msg => msg.Content = content).PostAsync().Result)
+			{
+				res.EnsureSuccessStatusCode();
+
+				var response = await res.Content.ReadAsStringAsync();
+				Assert.IsTrue(response.Contains("A response"));
+			}
+		}
+
+		private TestServer CreateTestHost()
+		{
+			var webHostBuilder = new WebHostBuilder()
+				.UseStartup<Startup>();
+			return new TestServer(webHostBuilder);
+		}
+	}
+}

--- a/src/SoapCore.Tests/XmlNodeInputOutput/XmlNodeInputOutputTests.cs
+++ b/src/SoapCore.Tests/XmlNodeInputOutput/XmlNodeInputOutputTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
@@ -39,7 +40,9 @@ namespace SoapCore.Tests.XmlNodeInputOutput
 				res.EnsureSuccessStatusCode();
 
 				var response = await res.Content.ReadAsStringAsync();
-				Assert.IsTrue(response.Replace("\r\n", string.Empty).Replace("  ", string.Empty).Contains(xmlInput));
+
+				//XML comes back as formatted, need to clear any newlines and replace any double spaces
+				Assert.IsTrue(response.Replace(System.Environment.NewLine, string.Empty).Replace("  ", string.Empty).Contains(xmlInput));
 			}
 		}
 

--- a/src/SoapCore/SerializerHelper.cs
+++ b/src/SoapCore/SerializerHelper.cs
@@ -1,10 +1,12 @@
 using System;
 using System.CodeDom;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Xml;
 using System.Xml.Serialization;
 using Microsoft.CSharp;
 
@@ -88,6 +90,14 @@ namespace SoapCore
 			{
 				xmlReader.Read();
 				return new MemoryStream(xmlReader.ReadContentAsBase64(), false);
+			}
+
+			if (elementType == typeof(XmlElement) || elementType == typeof(XmlNode))
+			{
+				var xmlDoc = new XmlDocument();
+				xmlDoc.LoadXml(xmlReader.ReadInnerXml());
+				var xmlNode = xmlDoc.FirstChild;
+				return xmlNode;
 			}
 
 			return serializer.Deserialize(xmlReader);


### PR DESCRIPTION
I have recently experienced the Null value described in the issue https://github.com/DigDes/SoapCore/issues/908 and decided to see if I could follow the suggested changes.  In this pull request, I have added the suggested fix from @andersjonsson and then I also added a few Unit Tests for it.  

In the integration tests, we have an XmlElement return type only and then a second test with both an XmlElement input and an XmlElement return time. 

I have also added a new folder called XmlNodeInputOutputTests for the purpose of testing the XmlElement functions as a SOAP function vs a ChannelFactory object.  I found the code is not quite happy with an XmlNode return type (the Test Server returns a message stating that it didn't get enough to consider a valid response).  

Thank you,

Raymond Mimick