### PR TITLE
String and Byte[] are special-cases since they are built in types tha…

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/ComplexType.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ComplexType.cs
@@ -10,5 +10,7 @@ namespace SoapCore.Tests.Wsdl.Services
 		public int IntProperty { get; set; }
 		[XmlElement(ElementName = "stringprop")]
 		public string StringProperty { get; set; }
+		[XmlElement(ElementName = "mybytes")]
+		public byte[] ByteArrayProperty { get; set; }
 	}
 }

--- a/src/SoapCore.Tests/Wsdl/Services/ComplexType.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ComplexType.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Xml.Serialization;
 
 namespace SoapCore.Tests.Wsdl.Services
 {
 	public class ComplexType
 	{
 		public int IntProperty { get; set; }
+		[XmlElement(ElementName = "stringprop")]
+		public string StringProperty { get; set; }
 	}
 }

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -526,7 +526,27 @@ namespace SoapCore.Tests.Wsdl
 			var wsdl = await GetWsdlFromMetaBodyWriter<ComplexTypeAndOutParameterService>(soapSerializer);
 			Trace.TraceInformation(wsdl);
 			Assert.IsNotNull(wsdl);
-			Assert.IsTrue(wsdl.Contains("xsd:string"));
+
+			var root = XElement.Parse(wsdl);
+
+			// Check that method response element exists for xmlserializer meta
+			var testComplexType = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value == "ComplexType");
+			Assert.IsNotNull(testComplexType);
+
+			var testSequence = GetElements(testComplexType, _xmlSchema + "sequence").SingleOrDefault();
+			Assert.IsNotNull(testSequence);
+
+			var testElements = GetElements(testSequence, _xmlSchema + "element").ToArray();
+			var stringprop = testElements.SingleOrDefault(a => a.Attribute("name").Value == "stringprop");
+			var byteprop = testElements.SingleOrDefault(a => a.Attribute("name").Value == "mybytes");
+
+			Assert.IsNotNull(stringprop);
+			Assert.IsTrue(stringprop.Attribute("minOccurs").Value == "0");
+			Assert.IsTrue(stringprop.Attribute("maxOccurs").Value == "1");
+
+			Assert.IsNotNull(byteprop);
+			Assert.IsTrue(byteprop.Attribute("minOccurs").Value == "0");
+			Assert.IsTrue(byteprop.Attribute("maxOccurs").Value == "1");
 		}
 
 		[DataTestMethod]

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -710,7 +710,7 @@ namespace SoapCore.Tests.Wsdl
 			var referenceToExistingDynamicType = root.XPathSelectElement("//xsd:complexType[@name='TestResponseType']/xsd:sequence/xsd:element[@name='DataList3' and @type='tns:ArrayOfTestDataTypeData']", nm);
 			Assert.IsNotNull(referenceToExistingDynamicType);
 
-			var selfContainedType = root.XPathSelectElement("//xsd:complexType[@name='TestResponseType']/xsd:sequence/xsd:element[@name='Data' and @minOccurs='0'and @maxOccurs='unbounded' and not(@type)]", nm);
+			var selfContainedType = root.XPathSelectElement("//xsd:complexType[@name='TestResponseType']/xsd:sequence/xsd:element[@name='Data3' and @minOccurs='0'and @maxOccurs='unbounded' and not(@type)]", nm);
 			Assert.IsNotNull(selfContainedType);
 
 			var dynamicTypeElement = root.XPathSelectElement("//xsd:complexType[@name='ArrayOfTestDataTypeData']/xsd:sequence/xsd:element[@name='Data']", nm);

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -518,6 +518,19 @@ namespace SoapCore.Tests.Wsdl
 
 		[DataTestMethod]
 		[DataRow(SoapSerializer.XmlSerializer)]
+		public async Task CheckOccuranceOfStringType(SoapSerializer soapSerializer)
+		{
+			//StartService(typeof(StringListService));
+			//var wsdl = GetWsdl();
+			//StopServer();
+			var wsdl = await GetWsdlFromMetaBodyWriter<ComplexTypeAndOutParameterService>(soapSerializer);
+			Trace.TraceInformation(wsdl);
+			Assert.IsNotNull(wsdl);
+			Assert.IsTrue(wsdl.Contains("xsd:string"));
+		}
+
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
 		[DataRow(SoapSerializer.DataContractSerializer)]
 		public async Task CheckUnqualifiedMembersService(SoapSerializer soapSerializer)
 		{

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -846,9 +846,11 @@ namespace SoapCore.Meta
 
 			var elementItem = member.GetCustomAttribute<XmlElementAttribute>();
 			bool isUnqualified = elementItem?.Form == XmlSchemaForm.Unqualified;
+			string elementNameFromAttribute = null;
 			if (elementItem != null && !string.IsNullOrWhiteSpace(elementItem.ElementName))
 			{
-				toBuild.ChildElementName = elementItem.ElementName;
+				elementNameFromAttribute = elementItem.ElementName;
+				toBuild.ChildElementName = elementNameFromAttribute;
 				createListWithoutProxyType = toBuild.Type.IsEnumerableType();
 			}
 
@@ -889,7 +891,7 @@ namespace SoapCore.Meta
 						defaultValue = defaultAttributeValue.ToString();
 					}
 				}
-				AddSchemaType(writer, toBuild, parentTypeToBuild.ChildElementName ?? member.Name, isArray: createListWithoutProxyType, isListWithoutWrapper: createListWithoutProxyType, isUnqualified: isUnqualified, defaultValue: defaultValue);
+				AddSchemaType(writer, toBuild, parentTypeToBuild.ChildElementName ?? elementNameFromAttribute ?? member.Name, isArray: createListWithoutProxyType, isListWithoutWrapper: createListWithoutProxyType, isUnqualified: isUnqualified, defaultValue: defaultValue);
 			}
 		}
 

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -989,7 +989,7 @@ namespace SoapCore.Meta
 				{
 					// skip occurence
 				}
-				else if (isArray)
+				else if (isArray && type.Name != "String" && type.Name != "Byte[]")
 				{
 					writer.WriteAttributeString("minOccurs", "0");
 					writer.WriteAttributeString("maxOccurs", "unbounded");


### PR DESCRIPTION
…t C# sees as enumerable. They should not be unbounded in the wsdl since that would cause clients to generate byte[] as byte[][] etc.

fixes #959

Also added support for ElementName-property of XmlElementAttribute. There are lots of scenarios around this attribute that are still not supported