### PR TITLE
Add support for faultactor field in case of Soap Fault

### DIFF
--- a/src/SoapCore/FaultBodyWriter.cs
+++ b/src/SoapCore/FaultBodyWriter.cs
@@ -125,6 +125,12 @@ namespace SoapCore
 				{
 					writer.WriteElementString("faultcode", "s:Client");
 				}
+
+				var actor = faultException.CreateMessageFault()?.Actor;
+				if (!string.IsNullOrWhiteSpace(actor))
+                {
+                    writer.WriteElementString ("faultactor", actor);
+                }
 			}
 			else
 			{


### PR DESCRIPTION
Fixed: The faultactor field is not populated if the Actor is set in the MessageFault
Check the field in the schema here: https://schemas.xmlsoap.org/soap/envelope/