### PR TITLE
Update SoapEndpointMiddleware.cs with Request.PathBase

### DIFF
--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -983,7 +983,7 @@ namespace SoapCore
 			}
 			else
 			{
-				meta.ServerUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host + "/";
+				meta.ServerUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host + httpContext.Request.PathBase + "/";
 			}
 
 			string xsdfile = httpContext.Request.Query["name"];

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -1039,7 +1039,7 @@ namespace SoapCore
 			}
 			else
 			{
-				meta.ServerUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host + "/";
+				meta.ServerUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host + httpContext.Request.PathBase + "/";
 			}
 
 			string wsdlfile = mapping.WsdlFile;


### PR DESCRIPTION
To generate correct ServerUrl when hosting the soap site under a existing site as an application you would need to also have the Request.PathBase within the ServerUrl generation.

Example hosting a SoapCore site under default website locally (http://localhost) in a application with path trunk/sopcoresite without the Request.PathBase the location in wsdl is generated incorrectly.

http://localhost/trunk/soapcoresite/checkin.asmx?wsdl 
location="http://localhost/checkin.asmx"

With Request.PathBase it will set the correct location. 
location="http://localhost/trunk/soapcoresite/checkin.asmx"

![localhost_trunk_soapcoresite_checkin asmx_wsdl](https://github.com/DigDes/SoapCore/assets/149155699/8b40c47e-0bb2-44dc-8b8c-f2f2dc54feff)
![localhost_trunk_soapcoresite_checkin asmx_wsdl-PathBase](https://github.com/DigDes/SoapCore/assets/149155699/c1a1d949-6ee2-4d6c-8b14-3ac6dad0b8f1)
