### PR TITLE
bugfix: complex type with a member of a complex type decorated per XmlElementAttribute with custom name breaks custom names of the members specified per XmlElementAttributes of the sub-complex type

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/ComplexComplexType.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ComplexComplexType.cs
@@ -1,0 +1,10 @@
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	public class ComplexComplexType
+	{
+		[XmlElement(ElementName = "complex")]
+		public ComplexType ComplexType { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/ComplexType.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ComplexType.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Xml.Serialization;
 
 namespace SoapCore.Tests.Wsdl.Services

--- a/src/SoapCore.Tests/Wsdl/Services/IComplexComplexTypeWithCustomXmlNamesService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IComplexComplexTypeWithCustomXmlNamesService.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface IComplexComplexTypeWithCustomXmlNamesService
+	{
+		[OperationContract]
+		ComplexComplexType Method(out string message);
+	}
+
+	public class ComplexComplexTypeWithCustomXmlNamesService : IComplexComplexTypeWithCustomXmlNamesService
+	{
+		public ComplexComplexType Method(out string message)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/IComplexTypeAndOutParameterService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IComplexTypeAndOutParameterService.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.ServiceModel;
-using System.Text;
 
 namespace SoapCore.Tests.Wsdl.Services
 {

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -550,6 +550,50 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[DataTestMethod]
+		public async Task CheckComplexComplexTypeWithCustomXmlNamesWsdl()
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<ComplexComplexTypeWithCustomXmlNamesService>(SoapSerializer.XmlSerializer);
+			Trace.TraceInformation(wsdl);
+			Assert.IsNotNull(wsdl);
+
+			var root = XElement.Parse(wsdl);
+
+			//loading definition of ComplexComplexType
+			var testComplexComplexType = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value == "ComplexComplexType");
+			Assert.IsNotNull(testComplexComplexType);
+
+			//checking sequence to be there
+			var testSequenceOfComplexComplexType = GetElements(testComplexComplexType, _xmlSchema + "sequence").SingleOrDefault();
+			Assert.IsNotNull(testSequenceOfComplexComplexType);
+
+			//checking custom name specified per XmlElementAttribute is used
+			var testElementOfComplexComplexType = GetElements(testSequenceOfComplexComplexType, _xmlSchema + "element").SingleOrDefault(a => a.Attribute("name").Value == "complex");
+			Assert.IsNotNull(testElementOfComplexComplexType);
+
+			//loading definition of ComplexType
+			var testComplexType = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value == "ComplexType");
+			Assert.IsNotNull(testComplexType);
+
+			//checking sequence to be there
+			var testSequenceOfComplexType = GetElements(testComplexType, _xmlSchema + "sequence").SingleOrDefault();
+			Assert.IsNotNull(testSequenceOfComplexType);
+
+			//checking custom names specified per XmlElementAttribute are used
+			var testElementWithCustomName = GetElements(testSequenceOfComplexType, _xmlSchema + "element").SingleOrDefault(a => a.Attribute("name").Value == "stringprop");
+			Assert.IsNotNull(testElementWithCustomName);
+
+			testElementWithCustomName = GetElements(testSequenceOfComplexType, _xmlSchema + "element").SingleOrDefault(a => a.Attribute("name").Value == "mybytes");
+			Assert.IsNotNull(testElementWithCustomName);
+
+			//checking both properties without custom names to use the same names as properties in the ComplexType class
+			var testElementWithDefaultName = GetElements(testSequenceOfComplexType, _xmlSchema + "element").SingleOrDefault(a => a.Attribute("name").Value == "IntProperty");
+			Assert.IsNotNull(testElementWithDefaultName);
+
+			testElementWithDefaultName = GetElements(testSequenceOfComplexType, _xmlSchema + "element").SingleOrDefault(a => a.Attribute("name").Value == "MyGuid");
+			Assert.IsNotNull(testElementWithDefaultName);
+		}
+
+		[DataTestMethod]
 		[DataRow(SoapSerializer.XmlSerializer)]
 		public async Task CheckOccuranceOfStringType(SoapSerializer soapSerializer)
 		{

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -921,7 +921,7 @@ namespace SoapCore.Meta
 					}
 				}
 
-				AddSchemaType(writer, toBuild, parentTypeToBuild.ChildElementName ?? elementNameFromAttribute ?? member.Name, isArray: createListWithoutProxyType, isListWithoutWrapper: createListWithoutProxyType, isUnqualified: isUnqualified, defaultValue: defaultValue);
+				AddSchemaType(writer, toBuild, elementNameFromAttribute ?? member.Name ?? parentTypeToBuild.ChildElementName, isArray: createListWithoutProxyType, isListWithoutWrapper: createListWithoutProxyType, isUnqualified: isUnqualified, defaultValue: defaultValue);
 			}
 		}
 


### PR DESCRIPTION
Having a complex type (please see ComplexComplexType in the suppled unit test CheckComplexComplexTypeWithCustomXmlNamesWsdl) with a member being itself a complex type (ComplexType), which is configured to have a custom name 'complex' specified by XmlElement, on WSDL generation with XmlSerializer overwrites the custom names and property names, specified by ComplexType, by the name 'complex', producing following definition

<xsd:complexType name="ComplexType">
        <xsd:sequence>
          <xsd:element minOccurs="1" maxOccurs="1" name="complex" type="xsd:int" />
          <xsd:element minOccurs="0" maxOccurs="1" name="complex" type="xsd:string" />
          <xsd:element minOccurs="0" maxOccurs="1" name="complex" type="xsd:base64Binary" />
          <xsd:element minOccurs="1" maxOccurs="1" name="complex" type="xsd:string" />
        </xsd:sequence>
      </xsd:complexType>

correct would be (and is achieved by this fix)

<xsd:complexType name="ComplexType">
        <xsd:sequence>
          <xsd:element minOccurs="1" maxOccurs="1" name="IntProperty" type="xsd:int" />
          <xsd:element minOccurs="0" maxOccurs="1" name="stringprop" type="xsd:string" />
          <xsd:element minOccurs="0" maxOccurs="1" name="mybytes" type="xsd:base64Binary" />
          <xsd:element minOccurs="1" maxOccurs="1" name="MyGuid" type="xsd:string" />
        </xsd:sequence>
      </xsd:complexType>