### PR TITLE
support for XmlEnumAttribute specifiying custom names for enum members

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/EnumWithCustomNames.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/EnumWithCustomNames.cs
@@ -1,0 +1,15 @@
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	public enum EnumWithCustomNames
+	{
+		[XmlEnum("F")]
+		FirstEnumMember,
+
+		[XmlEnum("S")]
+		SecondEnumMember,
+
+		ThirdEnumMember
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/IEnumWithCustomNamesService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IEnumWithCustomNamesService.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface IEnumWithCustomNamesService
+	{
+		[OperationContract]
+		EnumWithCustomNames? GetEnum(string text);
+	}
+
+	public class EnumWithCustomNamesService : IEnumWithCustomNamesService
+	{
+		public EnumWithCustomNames? GetEnum(string text)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -594,6 +594,36 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[DataTestMethod]
+		public async Task CheckEnumWithCustomNamesXmlSerializedWsdl()
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<EnumWithCustomNamesService>(SoapSerializer.XmlSerializer);
+			Trace.TraceInformation(wsdl);
+			Assert.IsNotNull(wsdl);
+
+			var root = XElement.Parse(wsdl);
+
+			//loading definition of EnumWithCustomNames
+			var enumWithCustomNamesElement = GetElements(root, _xmlSchema + "simpleType").FirstOrDefault(a => a.Attribute("name")?.Value.Equals("EnumWithCustomNames") == true);
+			Assert.IsNotNull(enumWithCustomNamesElement);
+
+			//checking restriction to be there
+			var testRestrictionOfEnumWithCustomNames = GetElements(enumWithCustomNamesElement, _xmlSchema + "restriction").SingleOrDefault();
+			Assert.IsNotNull(testRestrictionOfEnumWithCustomNames);
+
+			//checking enumeration elements to be there
+			var testEnumerationElements = GetElements(testRestrictionOfEnumWithCustomNames, _xmlSchema + "enumeration").ToList();
+			Assert.IsNotNull(testEnumerationElements);
+			Assert.AreEqual(3, testEnumerationElements.Count);
+
+			//checking custom names specified per XmlEnumAttribute are used
+			Assert.IsNotNull(testEnumerationElements.SingleOrDefault(e => e.FirstAttribute?.Value == "F"));
+			Assert.IsNotNull(testEnumerationElements.SingleOrDefault(e => e.FirstAttribute?.Value == "S"));
+
+			//checking default name specified by enum member
+			Assert.IsNotNull(testEnumerationElements.SingleOrDefault(e => e.FirstAttribute?.Value == "ThirdEnumMember"));
+		}
+
+		[DataTestMethod]
 		[DataRow(SoapSerializer.XmlSerializer)]
 		public async Task CheckOccuranceOfStringType(SoapSerializer soapSerializer)
 		{

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -462,10 +462,27 @@ namespace SoapCore.Meta
 					writer.WriteStartElement("restriction", Namespaces.XMLNS_XSD);
 					writer.WriteAttributeString("base", $"{_xmlNamespaceManager.LookupPrefix(Namespaces.XMLNS_XSD)}:string");
 
-					foreach (var value in Enum.GetValues(toBuild))
+					var membersWithCustomNames = toBuild.GetMembersWithAttribute<XmlEnumAttribute>();
+					foreach (var value in Enum.GetNames(toBuild))
 					{
+						var xmlEnumAttribute = membersWithCustomNames
+												.FirstOrDefault(m => m.Name == value)?
+												.CustomAttributes
+												.FirstOrDefault(c => c.AttributeType == typeof(XmlEnumAttribute));
+						var nameFromAttribute = (xmlEnumAttribute?
+													.ConstructorArguments?
+													.FirstOrDefault()
+													.Value
+												??
+												xmlEnumAttribute?
+													.NamedArguments?
+													.FirstOrDefault(a => a.MemberName == "Name")
+													.TypedValue
+													.Value)?
+												.ToString();
+
 						writer.WriteStartElement("enumeration", Namespaces.XMLNS_XSD);
-						writer.WriteAttributeString("value", value.ToString());
+						writer.WriteAttributeString("value", nameFromAttribute ?? value);
 						writer.WriteEndElement(); // enumeration
 					}
 


### PR DESCRIPTION
Feature request: support for XmlEnumAttribute to be able to specifiy custom names for enum members

for the example enum, used in test CheckEnumWithCustomNamesXmlSerializedWsdl

```
public enum EnumWithCustomNames
	{
		[XmlEnum("F")]
		FirstEnumMember,

		[XmlEnum("S")]
		SecondEnumMember,

		ThirdEnumMember
	}

```
the expected output would be

```
<xsd:simpleType name="EnumWithCustomNames">
        <xsd:restriction base="xsd:string">
          <xsd:enumeration value="F" />
          <xsd:enumeration value="S" />
          <xsd:enumeration value="ThirdEnumMember" />
        </xsd:restriction>
      </xsd:simpleType>
```