### PR TITLE
support for FaultContractAttribute in service definition wsdl generated by XmlSerializer

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/FailedOperation.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/FailedOperation.cs
@@ -1,0 +1,11 @@
+using System.Runtime.Serialization;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[DataContract]
+	public class FailedOperation
+	{
+		[DataMember]
+		public string Message { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/IServiceWithFaultContracts.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IServiceWithFaultContracts.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface IServiceWithFaultContracts
+	{
+		[OperationContract]
+		[FaultContract(typeof(OperationFault))]
+		EnumWithCustomNames? GetEnum(string text);
+
+		[OperationContract]
+		[FaultContract(typeof(FailedOperation))]
+		ComplexType LoadComplexType(out string message);
+	}
+
+	public class ServiceWithFaultContracts : IServiceWithFaultContracts
+	{
+		public EnumWithCustomNames? GetEnum(string text)
+		{
+			throw new NotImplementedException();
+		}
+
+		public ComplexType LoadComplexType(out string message)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/OperationFault.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/OperationFault.cs
@@ -1,0 +1,14 @@
+using System.Runtime.Serialization;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[DataContract]
+	public class OperationFault
+	{
+		[DataMember]
+		public string Code { get; set; }
+
+		[DataMember]
+		public string Message { get; set; }
+	}
+}


### PR DESCRIPTION
To achieve similar behavior with DataContract serializer, it will be ensured, that the naming of fault contract message ends with suffix Fault - if the class ends with Fault, the name remains, otherwise the suffix is added.

For each specified FaultContract attribute

- an element is added 
`<xsd:element name="OperationFault" nillable="true" type="tns:OperationFault" />`

- a corresponding complex type is specified 
```
      <xsd:complexType name="OperationFault">
        <xsd:sequence>
          <xsd:element minOccurs="0" maxOccurs="1" name="Code" type="xsd:string" />
          <xsd:element minOccurs="0" maxOccurs="1" name="Message" type="xsd:string" />
        </xsd:sequence>
      </xsd:complexType>
```
- fault is added after input and output messages under portType -> operation
`<wsdl:fault name="OperationFault" message="tns:IServiceWithFaultContracts_GetEnum_OperationFault_FaultMessage" />`

-  fault is added after input and output messages under binding -> operation
```
      <wsdl:fault name="OperationFault">
        <soap:fault use="literal" name="OperationFault" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" />
      </wsdl:fault>
```
