### PR TITLE
Depend on ASP.NET 2.1 packages for netstandard2.0 package

### DIFF
--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -29,10 +29,10 @@
 
 	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'netstandard2.1'">
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.38" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
 		<PackageReference Include="System.IO.Pipelines" Version="4.7.0" />
 		<PackageReference Include="System.CodeDom" Version="4.7.0" />
 	</ItemGroup>
@@ -59,7 +59,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.38" />
 		<PackageReference Include="System.ServiceModel.Http" Version="4.8.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
SoapCore depends on Microsoft.AspNetCore.Http 2.2.0. This version is not supported anymore by Microsoft. When looking at https://www.nuget.org/packages/Microsoft.AspNetCore.Http, you can see that the newest version 2.2.2 from the 2.2 branch is from 2019, but the newest version 2.1.34 from the 2.1 branch is from 2022. The version 2.2.2 is marked as deprecated, but version 2.1.34 is not.

In this link you can see the list of supported ASP.NET Core 2.1 packages: https://dotnet.microsoft.com/en-us/platform/support/policy/aspnet/2.1-packages

Lowered referenced package versions to 2.1 for the netstandard2.0 build.

Fixes #993 