### PR TITLE
Fix bug ArrayOfString maxOccurs="1" bug

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/ComplexType.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ComplexType.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace SoapCore.Tests.Wsdl.Services
@@ -12,5 +13,9 @@ namespace SoapCore.Tests.Wsdl.Services
 		public byte[] ByteArrayProperty { get; set; }
 
 		public Guid MyGuid { get; set; }
+
+		public List<string> StringList { get; set; }
+
+		public List<int> IntList { get; set; }
 	}
 }

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -752,6 +752,37 @@ namespace SoapCore.Tests.Wsdl
 
 		[DataTestMethod]
 		[DataRow(SoapSerializer.XmlSerializer)]
+		public async Task CheckArrayOfStringSerialization(SoapSerializer soapSerializer)
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<ComplexTypeAndOutParameterService>(soapSerializer, useMicrosoftGuid: true);
+			Trace.TraceInformation(wsdl);
+			Assert.IsNotNull(wsdl);
+
+			var root = XElement.Parse(wsdl);
+
+			// verify that ArrayOfString type has maxOccurs="unbounded" attribute
+			var arrayOfString = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value == "ArrayOfString");
+			Assert.IsNotNull(arrayOfString);
+			var stringSequence = GetElements(arrayOfString, _xmlSchema + "sequence").SingleOrDefault();
+			Assert.IsNotNull(stringSequence);
+			var stringElement = GetElements(stringSequence, _xmlSchema + "element").SingleOrDefault();
+			Assert.IsNotNull(stringElement);
+			Assert.IsTrue(stringElement.Attribute("minOccurs").Value == "0");
+			Assert.IsTrue(stringElement.Attribute("maxOccurs").Value == "unbounded");
+
+			// verify that ArrayOfInt type has maxOccurs="unbounded" attribute
+			var arrayOfInt = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value == "ArrayOfInt");
+			Assert.IsNotNull(arrayOfInt);
+			var intSequence = GetElements(arrayOfInt, _xmlSchema + "sequence").SingleOrDefault();
+			Assert.IsNotNull(intSequence);
+			var intElement = GetElements(intSequence, _xmlSchema + "element").SingleOrDefault();
+			Assert.IsNotNull(intElement);
+			Assert.IsTrue(intElement.Attribute("minOccurs").Value == "0");
+			Assert.IsTrue(intElement.Attribute("maxOccurs").Value == "unbounded");
+		}
+
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
 		[DataRow(SoapSerializer.DataContractSerializer)]
 		public async Task CheckUnqualifiedMembersService(SoapSerializer soapSerializer)
 		{

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -972,7 +972,7 @@ namespace SoapCore.Meta
 			{
 				elementNameFromAttribute = elementItem.ElementName;
 				toBuild.ChildElementName = elementNameFromAttribute;
-				createListWithoutProxyType = toBuild.Type.IsEnumerableType();
+				createListWithoutProxyType = toBuild.Type.IsEnumerableType() && toBuild.Type.Name != "String" && toBuild.Type.Name != "Byte[]";
 			}
 
 			var attributeItem = member.GetCustomAttribute<XmlAttributeAttribute>();
@@ -1133,7 +1133,7 @@ namespace SoapCore.Meta
 				{
 					// skip occurence
 				}
-				else if (isArray && type.Name != "String" && type.Name != "Byte[]")
+				else if (isArray)
 				{
 					writer.WriteAttributeString("minOccurs", "0");
 					writer.WriteAttributeString("maxOccurs", "unbounded");


### PR DESCRIPTION
This is a regression of #960.
In commit 5026da3f41660ab732b6aa5491a17d0aef33c17e, the AddSchemaType() method was changed to contain a special case for string and byte[]. However this breaks the situation where the inner type of a list is string. In that case, maxOccurs must be set to "unbounded" for the string element. So this commit reverts that change and instead fixes the original issue at another place.

Fixes #988