### PR TITLE
WSDL for XmlSerializer: Fix invalid ArrayOfString schema

### DIFF
--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -481,7 +481,6 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[DataTestMethod]
-		[DataRow(SoapSerializer.XmlSerializer)]
 		[DataRow(SoapSerializer.DataContractSerializer)]
 		public async Task CheckStringArrayNameWsdl(SoapSerializer soapSerializer)
 		{


### PR DESCRIPTION
Removed the special if-condition for "string", which does not make sense, because it does not correspond to the actual XML that is generated by the XmlSerializer. Afterwards, the field _arrayToBuild is not needed anymore, so I have removed it.

The test CheckStringArrayNameWsdl() can only be performed for the DataContractSerializer now, because the complexType does not have an element inside it anymore.

Fixes #996