### PR TITLE
Installing vulnerable nuget packages into project explicitly

### DIFF
--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -60,10 +60,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.38" />
+		<PackageReference Include="System.Drawing.Common" Version="4.7.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.1" />
 		<PackageReference Include="System.ServiceModel.Http" Version="4.8.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Some nuget packages have some not safe transitive dependencies

![image](https://github.com/DigDes/SoapCore/assets/12097421/10dc7d51-71c0-472f-aa7f-f01ae5c733a7)

Newer versions of those nuget packages have been installed into project