### PR TITLE
XmlSerializer WSDL: XmlAttribute: Set use="required" attribute

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/AttributeType.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/AttributeType.cs
@@ -1,0 +1,21 @@
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	public class AttributeType
+	{
+		[XmlAttribute]
+		public string StringProperty { get; set; }
+
+		[XmlAttribute]
+		public int IntProperty { get; set; }
+
+		[XmlAttribute]
+		public int OptionalIntProperty { get; set; }
+
+		public bool ShouldSerializeOptionalIntProperty()
+		{
+			return OptionalIntProperty != 0;
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/IAttributeService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IAttributeService.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface IAttributeService
+	{
+		[OperationContract]
+		AttributeType Method();
+	}
+
+	public class AttributeService : IAttributeService
+	{
+		public AttributeType Method()
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/src/SoapCore/Meta/BodyWriterExtensions.cs
+++ b/src/SoapCore/Meta/BodyWriterExtensions.cs
@@ -164,6 +164,17 @@ namespace SoapCore.Meta
 					attr.AttributeType == typeof(XmlIgnoreAttribute));
 		}
 
+		/// <summary>
+		/// Checks if the parent has a ShouldSerialize*() method defined for a specific member.
+		/// </summary>
+		/// <param name="member">The member to check</param>
+		/// <param name="parent">Parent of the member</param>
+		/// <returns>True if a ShouldSerialize*() method exists</returns>
+		public static bool HasShouldSerializeMethod(this MemberInfo member, TypeToBuild parent)
+		{
+			return parent.Type.GetMethod($"ShouldSerialize{member.Name}", Array.Empty<Type>()) != null;
+		}
+
 		public static bool IsEnumerableType(this Type collectionType)
 		{
 			if (collectionType.IsArray)

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -944,7 +944,9 @@ namespace SoapCore.Meta
 					name = member.Name;
 				}
 
-				AddSchemaType(writer, toBuild, name, isAttribute: true, isUnqualified: isUnqualified);
+				bool isOptional = member.HasShouldSerializeMethod(parentTypeToBuild);
+
+				AddSchemaType(writer, toBuild, name, isAttribute: true, isUnqualified: isUnqualified, isOptionalAttribute: isOptional);
 			}
 			else if (messageBodyMemberAttribute != null)
 			{
@@ -992,7 +994,7 @@ namespace SoapCore.Meta
 			AddSchemaType(writer, new TypeToBuild(type), name, isArray, @namespace, isAttribute, isUnqualified: isUnqualified);
 		}
 
-		private void AddSchemaType(XmlDictionaryWriter writer, TypeToBuild toBuild, string name, bool isArray = false, string @namespace = null, bool isAttribute = false, bool isListWithoutWrapper = false, bool isUnqualified = false, string defaultValue = null)
+		private void AddSchemaType(XmlDictionaryWriter writer, TypeToBuild toBuild, string name, bool isArray = false, string @namespace = null, bool isAttribute = false, bool isListWithoutWrapper = false, bool isUnqualified = false, string defaultValue = null, bool isOptionalAttribute = false)
 		{
 			var type = toBuild.Type;
 
@@ -1121,6 +1123,11 @@ namespace SoapCore.Meta
 				else
 				{
 					writer.WriteAttributeString("type", $"{_xmlNamespaceManager.LookupPrefix(xsTypename.Namespace)}:{xsTypename.Name}");
+				}
+
+				if (isAttribute && typeInfo.IsValueType && !isOptionalAttribute)
+				{
+					writer.WriteAttributeString("use", "required");
 				}
 			}
 			else


### PR DESCRIPTION
If a member has been annotated with the [XmlAttribute] attribute, and it is a value type, such as int, it will get the use="required" attribute. However if it has a ShouldSerialize*() method, then it is considered optional and the use="required" attribute is not added.

Added a new test to verify this behavior.

Fixes #1006