### PR TITLE
XmlSerializer WSDL: Use uppercase letter for ArrayOf<Type> type

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/ArrayService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ArrayService.cs
@@ -37,5 +37,14 @@ namespace SoapCore.Tests.Wsdl.Services
 		public long[] LongArray { get; set; }
 		public long[][] LongArrayArray { get; set; }
 		public List<List<string>> StringListList { get; set; }
+		public List<innerClass> InnerClassList { get; set; }
+	}
+
+// Class starts with lower-case letter on purpose for a test
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+	public class innerClass
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+	{
+		public string Name { get; set; }
 	}
 }

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -869,6 +869,10 @@ namespace SoapCore.Tests.Wsdl
 			var stringListList = root.XPathSelectElement("//xsd:complexType[@name='ArrayRequest']/xsd:sequence/xsd:element[@name='StringListList' and @type='tns:ArrayOfArrayOfString' and @nillable='true']", nm);
 			Assert.IsNotNull(stringListList);
 
+			// verify that ArrayOfInnerClass uses upper-case "i", even though the class starts with a lower-case letter.
+			var innerClassList = root.XPathSelectElement("//xsd:complexType[@name='ArrayRequest']/xsd:sequence/xsd:element[@name='InnerClassList' and @type='tns:ArrayOfInnerClass' and @nillable='true']", nm);
+			Assert.IsNotNull(innerClassList);
+
 			var nullableEnumerable = root.XPathSelectElement("//xsd:complexType[@name='EnumerableResponse']/xsd:sequence/xsd:element[@name='LongNullableEnumerable' and @type='tns:ArrayOfNullableLong' and @nillable='true']", nm);
 			Assert.IsNotNull(nullableEnumerable);
 

--- a/src/SoapCore/Meta/BodyWriterExtensions.cs
+++ b/src/SoapCore/Meta/BodyWriterExtensions.cs
@@ -235,7 +235,7 @@ namespace SoapCore.Meta
 
 		private static string GetArrayTypeName(string typeName, bool isNullable)
 		{
-			return "ArrayOf" + (isNullable ? "Nullable" : null) + (ClrTypeResolver.ResolveOrDefault(typeName).FirstCharToUpperOrDefault() ?? typeName);
+			return "ArrayOf" + (isNullable ? "Nullable" : null) + (ClrTypeResolver.ResolveOrDefault(typeName) ?? typeName).FirstCharToUpperOrDefault();
 		}
 
 		private static XmlSerializerNamespaces Convert(this XmlNamespaceManager xmlNamespaceManager)


### PR DESCRIPTION
The first letter of the class name is now converted to upper-case.

Added a test that verifies the correct behavior.

Fixes #1008