### PR TITLE
Add option IndentWsdl to control if the generated WSDL should be indented

### DIFF
--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -1120,13 +1120,13 @@ namespace SoapCore.Tests.Wsdl
 			var bodyWriter = serializer == SoapSerializer.DataContractSerializer
 				? new MetaWCFBodyWriter(service, baseUrl, defaultBindingName, false, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }) as BodyWriter
 				: new MetaBodyWriter(service, baseUrl, xmlNamespaceManager, defaultBindingName, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }, useMicrosoftGuid) as BodyWriter;
-			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, Encoding.UTF8, false, XmlDictionaryReaderQuotas.Max, false, true, false, null, bindingName, portName);
+			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, Encoding.UTF8, false, XmlDictionaryReaderQuotas.Max, false, false, null, bindingName, portName);
 			var responseMessage = Message.CreateMessage(encoder.MessageVersion, null, bodyWriter);
 			responseMessage = new MetaMessage(responseMessage, service, xmlNamespaceManager, defaultBindingName, false);
 
 			using (var memoryStream = new MemoryStream())
 			{
-				await encoder.WriteMessageAsync(responseMessage, memoryStream);
+				await encoder.WriteMessageAsync(responseMessage, memoryStream, true);
 				memoryStream.Position = 0;
 
 				using (var streamReader = new StreamReader(memoryStream))

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -28,12 +28,10 @@ namespace SoapCore.MessageEncoder
 		private readonly bool _overwriteResponseContentType;
 		private readonly bool _optimizeWriteForUtf8;
 		private readonly bool _omitXmlDeclaration;
-		private readonly bool _indentXml;
 		private readonly bool _checkXmlCharacters;
 
-		public SoapMessageEncoder(MessageVersion version, Encoding writeEncoding, bool overwriteResponseContentType, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool indentXml, bool checkXmlCharacters, XmlNamespaceManager xmlNamespaceOverrides, string bindingName, string portName, int maxSoapHeaderSize = SoapMessageEncoderDefaults.MaxSoapHeaderSizeDefault)
+		public SoapMessageEncoder(MessageVersion version, Encoding writeEncoding, bool overwriteResponseContentType, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool checkXmlCharacters, XmlNamespaceManager xmlNamespaceOverrides, string bindingName, string portName, int maxSoapHeaderSize = SoapMessageEncoderDefaults.MaxSoapHeaderSizeDefault)
 		{
-			_indentXml = indentXml;
 			_omitXmlDeclaration = omitXmlDeclaration;
 			_checkXmlCharacters = checkXmlCharacters;
 			BindingName = bindingName;
@@ -164,7 +162,7 @@ namespace SoapCore.MessageEncoder
 			return Task.FromResult(message);
 		}
 
-		public virtual async Task WriteMessageAsync(Message message, HttpContext httpContext, PipeWriter pipeWriter)
+		public virtual async Task WriteMessageAsync(Message message, HttpContext httpContext, PipeWriter pipeWriter, bool indentXml)
 		{
 			if (message == null)
 			{
@@ -189,7 +187,7 @@ namespace SoapCore.MessageEncoder
 				using (var xmlTextWriter = XmlWriter.Create(stringWriter, new XmlWriterSettings
 				{
 					OmitXmlDeclaration = _optimizeWriteForUtf8 && _omitXmlDeclaration, //can only omit if utf-8
-					Indent = _indentXml,
+					Indent = indentXml,
 					Encoding = _writeEncoding,
 					CloseOutput = true,
 					CheckCharacters = _checkXmlCharacters
@@ -217,7 +215,7 @@ namespace SoapCore.MessageEncoder
 			}
 		}
 
-		public virtual Task WriteMessageAsync(Message message, Stream stream)
+		public virtual Task WriteMessageAsync(Message message, Stream stream, bool indentXml)
 		{
 			if (message == null)
 			{
@@ -234,7 +232,7 @@ namespace SoapCore.MessageEncoder
 			using var xmlTextWriter = XmlWriter.Create(stream, new XmlWriterSettings
 			{
 				OmitXmlDeclaration = _optimizeWriteForUtf8 && _omitXmlDeclaration, //can only omit if utf-8,
-				Indent = _indentXml,
+				Indent = indentXml,
 				Encoding = _writeEncoding,
 				CloseOutput = false,
 				CheckCharacters = _checkXmlCharacters

--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -8,6 +8,8 @@ namespace SoapCore
 {
 	public class SoapCoreOptions
 	{
+		private bool? _indentWsdl = null;
+
 		/// <summary>
 		/// Gets or sets the Path of the Service
 		/// </summary>
@@ -104,6 +106,12 @@ namespace SoapCore
 		/// <para>Defaults to true</para>
 		/// </summary>
 		public bool IndentXml { get; set; } = true;
+
+		/// <summary>
+		/// Gets or sets a value indicating whether to indent the generated WSDL.
+		/// <para>Defaults to the value of <see cref="IndentXml"/></para>
+		/// </summary>
+		public bool IndentWsdl { get => _indentWsdl ?? IndentXml; set => _indentWsdl = value; }
 
 		/// <summary>
 		/// Gets or sets a value indicating whether to check to make sure that the XmlOutput doesn't contain invalid characters

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -77,7 +77,7 @@ namespace SoapCore
 			for (var i = 0; i < options.EncoderOptions.Length; i++)
 			{
 				var encoderOptions = options.EncoderOptions[i];
-				_messageEncoders[i] = new SoapMessageEncoder(encoderOptions.MessageVersion, encoderOptions.WriteEncoding, encoderOptions.OverwriteResponseContentType, encoderOptions.ReaderQuotas, options.OmitXmlDeclaration, options.IndentXml, options.CheckXmlCharacters, encoderOptions.XmlNamespaceOverrides, encoderOptions.BindingName, encoderOptions.PortName, encoderOptions.MaxSoapHeaderSize);
+				_messageEncoders[i] = new SoapMessageEncoder(encoderOptions.MessageVersion, encoderOptions.WriteEncoding, encoderOptions.OverwriteResponseContentType, encoderOptions.ReaderQuotas, options.OmitXmlDeclaration, options.CheckXmlCharacters, encoderOptions.XmlNamespaceOverrides, encoderOptions.BindingName, encoderOptions.PortName, encoderOptions.MaxSoapHeaderSize);
 			}
 		}
 
@@ -171,14 +171,14 @@ namespace SoapCore
 		}
 
 #if !NETCOREAPP3_0_OR_GREATER
-		private static Task WriteMessageAsync(SoapMessageEncoder messageEncoder, Message responseMessage, HttpContext httpContext)
+		private static Task WriteMessageAsync(SoapMessageEncoder messageEncoder, Message responseMessage, HttpContext httpContext, bool indentXml)
 		{
-			return messageEncoder.WriteMessageAsync(responseMessage, httpContext.Response.Body);
+			return messageEncoder.WriteMessageAsync(responseMessage, httpContext.Response.Body, indentXml);
 		}
 #else
-		private static Task WriteMessageAsync(SoapMessageEncoder messageEncoder, Message responseMessage, HttpContext httpContext)
+		private static Task WriteMessageAsync(SoapMessageEncoder messageEncoder, Message responseMessage, HttpContext httpContext, bool indentXml)
 		{
-			return messageEncoder.WriteMessageAsync(responseMessage, httpContext, httpContext.Response.BodyWriter);
+			return messageEncoder.WriteMessageAsync(responseMessage, httpContext, httpContext.Response.BodyWriter, indentXml);
 		}
 #endif
 
@@ -257,7 +257,7 @@ namespace SoapCore
 				httpContext.Response.ContentType = "text/html;charset=UTF-8";
 
 				using var ms = new MemoryStream();
-				await messageEncoder.WriteMessageAsync(responseMessage, ms);
+				await messageEncoder.WriteMessageAsync(responseMessage, ms, _options.IndentWsdl);
 				ms.Position = 0;
 				using var sr = new StreamReader(ms);
 				var wsdl = await sr.ReadToEndAsync();
@@ -272,7 +272,7 @@ namespace SoapCore
 			//we should use text/xml in wsdl page for browser compability.
 			httpContext.Response.ContentType = "text/xml;charset=UTF-8"; // _messageEncoders[0].ContentType;
 
-			await WriteMessageAsync(messageEncoder, responseMessage, httpContext);
+			await WriteMessageAsync(messageEncoder, responseMessage, httpContext, _options.IndentWsdl);
 		}
 
 		private async Task ProcessOperation(HttpContext httpContext, IServiceProvider serviceProvider)
@@ -324,7 +324,7 @@ namespace SoapCore
 
 			if (responseMessage != null)
 			{
-				await WriteMessageAsync(messageEncoder, responseMessage, httpContext);
+				await WriteMessageAsync(messageEncoder, responseMessage, httpContext, _options.IndentXml);
 			}
 		}
 

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -56,6 +56,8 @@ namespace SoapCore
 
 		public bool IndentXml { get; set; } = true;
 
+		public bool IndentWsdl { get; set; } = true;
+
 		public bool UseMicrosoftGuid { get; set; } = false;
 
 		/// <summary>
@@ -92,6 +94,7 @@ namespace SoapCore
 				OmitXmlDeclaration = opt.OmitXmlDeclaration,
 				StandAloneAttribute = opt.StandAloneAttribute,
 				IndentXml = opt.IndentXml,
+				IndentWsdl = opt.IndentWsdl,
 				XmlNamespacePrefixOverrides = opt.XmlNamespacePrefixOverrides,
 				WsdlFileOptions = opt.WsdlFileOptions,
 				AdditionalEnvelopeXmlnsAttributes = opt.AdditionalEnvelopeXmlnsAttributes,


### PR DESCRIPTION
Currently the option `IndentXml` can be used to control if the generated XML is indented or not. This applies to both: the SOAP response XML and the generated WSDL.

It would be nice to control both of these independently. For example, the XML for the SOAP responses should not be indented, but the XML for the WSDL should be indented.

I propose to add a new configuration option `IndentWsdl`. If this option is explicitly set, it will control if the generated WSDL is indented or not. If it is not set, it will default to the setting of `IndentXml`, so existing users should not notice a difference in behavior.