### PR TITLE
XmlSerializer WSDL: Improve enum order

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/EnumWithCustomNames.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/EnumWithCustomNames.cs
@@ -5,11 +5,11 @@ namespace SoapCore.Tests.Wsdl.Services
 	public enum EnumWithCustomNames
 	{
 		[XmlEnum("F")]
-		FirstEnumMember,
+		FirstEnumMember = -2,
 
 		[XmlEnum("S")]
-		SecondEnumMember,
+		SecondEnumMember = 1,
 
-		ThirdEnumMember
+		ThirdEnumMember = 0
 	}
 }

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -617,11 +617,12 @@ namespace SoapCore.Tests.Wsdl
 			Assert.AreEqual(3, testEnumerationElements.Count);
 
 			//checking custom names specified per XmlEnumAttribute are used
-			Assert.IsNotNull(testEnumerationElements.SingleOrDefault(e => e.FirstAttribute?.Value == "F"));
-			Assert.IsNotNull(testEnumerationElements.SingleOrDefault(e => e.FirstAttribute?.Value == "S"));
+			// also verify that the order of the enum values is correct as specified in the source
+			Assert.IsTrue(testEnumerationElements[0].FirstAttribute?.Value == "F");
+			Assert.IsTrue(testEnumerationElements[1].FirstAttribute?.Value == "S");
 
 			//checking default name specified by enum member
-			Assert.IsNotNull(testEnumerationElements.SingleOrDefault(e => e.FirstAttribute?.Value == "ThirdEnumMember"));
+			Assert.IsTrue(testEnumerationElements[2].FirstAttribute?.Value == "ThirdEnumMember");
 		}
 
 		[DataTestMethod]

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -470,7 +470,10 @@ namespace SoapCore.Meta
 					writer.WriteStartElement("restriction", Namespaces.XMLNS_XSD);
 					writer.WriteAttributeString("base", $"{_xmlNamespaceManager.LookupPrefix(Namespaces.XMLNS_XSD)}:string");
 
-					var membersWithCustomNames = from n in Enum.GetNames(toBuild)
+					// enum values are ordered by the order in which they are specified in the source code.
+					var orderedNames = toBuild.GetFields().Where(fi => fi.IsStatic).OrderBy(fi => fi.MetadataToken).Select(fi => fi.Name);
+
+					var membersWithCustomNames = from n in orderedNames
 												 join m in toBuild.GetMembers() on n equals m.Name
 												 let ca = m.CustomAttributes.FirstOrDefault(ca => ca.AttributeType == typeof(XmlEnumAttribute))
 												 select new


### PR DESCRIPTION
The enum values are now specified in the order in which they are declared in the source code. This is the same behavior as the WSDL that is generated by a .NET Framework ASMX Web Service.

Improved the enum test so that it also checks the order of the elements.

Fixes #1011