### PR TITLE
Add option to generate soapAction without contract name

### DIFF
--- a/src/SoapCore.Tests/OperationDescription/OperationDescriptionTests.cs
+++ b/src/SoapCore.Tests/OperationDescription/OperationDescriptionTests.cs
@@ -11,14 +11,14 @@ namespace SoapCore.Tests
 		[Fact]
 		public void TestProperUnrappingOfGenericResponses()
 		{
-			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract));
-			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContract), new ServiceContractAttribute());
+			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract), false);
+			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContract), new ServiceContractAttribute(), false);
 
 			System.Reflection.MethodInfo method = typeof(IServiceWithMessageContract).GetMethod(nameof(IServiceWithMessageContract.GetMyClass));
 
 			OperationContractAttribute contractAttribute = new OperationContractAttribute();
 
-			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute);
+			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute, false);
 
 			Assert.True(operationDescription.IsMessageContractResponse);
 		}
@@ -26,14 +26,14 @@ namespace SoapCore.Tests
 		[Fact]
 		public void TestSupportXmlRootForParameterName()
 		{
-			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract));
-			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContract), new ServiceContractAttribute());
+			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract), false);
+			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContract), new ServiceContractAttribute(), false);
 
 			System.Reflection.MethodInfo method = typeof(IServiceWithMessageContract).GetMethod(nameof(IServiceWithMessageContract.GetClassWithXmlRoot));
 
 			OperationContractAttribute contractAttribute = new OperationContractAttribute();
 
-			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute);
+			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute, false);
 
 			Assert.Equal("test", operationDescription.AllParameters.FirstOrDefault()?.Name);
 		}
@@ -41,14 +41,14 @@ namespace SoapCore.Tests
 		[Fact]
 		public void TestSupportXmlRootForParameterNameWithEmptyStringAsRootElementNameUsesParameterInfoToExtractAName()
 		{
-			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContractAndEmptyXmlRoot));
-			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContractAndEmptyXmlRoot), new ServiceContractAttribute());
+			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContractAndEmptyXmlRoot), false);
+			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContractAndEmptyXmlRoot), new ServiceContractAttribute(), false);
 
 			System.Reflection.MethodInfo method = typeof(IServiceWithMessageContractAndEmptyXmlRoot).GetMethod(nameof(IServiceWithMessageContractAndEmptyXmlRoot.GetClassWithEmptyXmlRoot));
 
 			OperationContractAttribute contractAttribute = new OperationContractAttribute();
 
-			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute);
+			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute, false);
 
 			Assert.Equal("classWithXmlRoot", operationDescription.AllParameters.FirstOrDefault()?.Name);
 		}
@@ -56,14 +56,14 @@ namespace SoapCore.Tests
 		[Fact]
 		public void TestProperUnrappingOfNonGenericResponses()
 		{
-			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract));
-			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContract), new ServiceContractAttribute());
+			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract), false);
+			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContract), new ServiceContractAttribute(), false);
 
 			System.Reflection.MethodInfo method = typeof(IServiceWithMessageContract).GetMethod(nameof(IServiceWithMessageContract.GetMyOtherClass));
 
 			OperationContractAttribute contractAttribute = new OperationContractAttribute();
 
-			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute);
+			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute, false);
 
 			Assert.True(operationDescription.IsMessageContractResponse);
 		}
@@ -71,14 +71,14 @@ namespace SoapCore.Tests
 		[Fact]
 		public void TestProperUnrappingOfNonMessageContractResponses()
 		{
-			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract));
-			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContract), new ServiceContractAttribute());
+			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract), false);
+			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContract), new ServiceContractAttribute(), false);
 
 			System.Reflection.MethodInfo method = typeof(IServiceWithMessageContract).GetMethod(nameof(IServiceWithMessageContract.GetMyStringClass));
 
 			OperationContractAttribute contractAttribute = new OperationContractAttribute();
 
-			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute);
+			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute, false);
 
 			Assert.False(operationDescription.IsMessageContractResponse);
 		}
@@ -86,14 +86,14 @@ namespace SoapCore.Tests
 		[Fact]
 		public void TestProperUnwrappingOfSoapFaults()
 		{
-			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract));
-			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContract), new ServiceContractAttribute());
+			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract), false);
+			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContract), new ServiceContractAttribute(), false);
 
 			System.Reflection.MethodInfo method = typeof(IServiceWithMessageContract).GetMethod(nameof(IServiceWithMessageContract.ThrowTypedFault));
 
 			OperationContractAttribute contractAttribute = new OperationContractAttribute();
 
-			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute);
+			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute, false);
 
 			var faultInfo = Assert.Single(operationDescription.Faults);
 			Assert.Equal("TypedSoapFault", faultInfo.Name);
@@ -106,17 +106,36 @@ namespace SoapCore.Tests
 		[Fact]
 		public void TestProperNamingOfAsyncMethods()
 		{
-			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract));
-			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContract), new ServiceContractAttribute());
+			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract), false);
+			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContract), new ServiceContractAttribute(), false);
 
 			System.Reflection.MethodInfo method = typeof(IServiceWithMessageContract).GetMethod(nameof(IServiceWithMessageContract.GetMyAsyncClassAsync));
 
 			OperationContractAttribute contractAttribute = new OperationContractAttribute();
 
-			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute);
+			ServiceModel.OperationDescription operationDescription = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute, false);
 
 			Assert.True(operationDescription.IsMessageContractResponse);
 			Assert.Equal("GetMyAsyncClass", operationDescription.Name);
+		}
+
+		[Fact]
+		public void TestGeneratedSoapActionName()
+		{
+			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithMessageContract), true);
+			ContractDescription contractDescription = new ContractDescription(serviceDescription, typeof(IServiceWithMessageContract), new ServiceContractAttribute(), true);
+
+			System.Reflection.MethodInfo method = typeof(IServiceWithMessageContract).GetMethod(nameof(IServiceWithMessageContract.GetMyOtherClass));
+
+			OperationContractAttribute contractAttribute = new OperationContractAttribute();
+
+			ServiceModel.OperationDescription operationDescription1 = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute, true);
+
+			Assert.Equal("http://tempuri.org/GetMyOtherClass", operationDescription1.SoapAction);
+
+			ServiceModel.OperationDescription operationDescription2 = new ServiceModel.OperationDescription(contractDescription, method, contractAttribute, false);
+
+			Assert.Equal("http://tempuri.org/IServiceWithMessageContract/GetMyOtherClass", operationDescription2.SoapAction);
 		}
 	}
 }

--- a/src/SoapCore.Tests/ServiceDescription/ServiceContractTests.cs
+++ b/src/SoapCore.Tests/ServiceDescription/ServiceContractTests.cs
@@ -11,7 +11,7 @@ namespace SoapCore.Tests
 		[Fact]
 		public void TestFallbackOfServiceNameToTypeName()
 		{
-			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithoutName));
+			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithoutName), false);
 
 			Assert.Equal("IServiceWithoutName", serviceDescription.ServiceName);
 		}
@@ -19,7 +19,7 @@ namespace SoapCore.Tests
 		[Fact]
 		public void TestExplicitlySetServiceName()
 		{
-			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithName));
+			ServiceDescription serviceDescription = new ServiceDescription(typeof(IServiceWithName), false);
 
 			Assert.Equal("MyServiceWithName", serviceDescription.ServiceName);
 		}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -1156,7 +1156,7 @@ namespace SoapCore.Tests.Wsdl
 
 		private async Task<string> GetWsdlFromMetaBodyWriter<T>(SoapSerializer serializer, string bindingName = null, string portName = null, bool useMicrosoftGuid = false)
 		{
-			var service = new ServiceDescription(typeof(T));
+			var service = new ServiceDescription(typeof(T), false);
 			var baseUrl = "http://tempuri.org/";
 			var xmlNamespaceManager = Namespaces.CreateDefaultXmlNamespaceManager(useMicrosoftGuid);
 			var defaultBindingName = !string.IsNullOrWhiteSpace(bindingName) ? bindingName : "BasicHttpBinding";

--- a/src/SoapCore/ServiceModel/ContractDescription.cs
+++ b/src/SoapCore/ServiceModel/ContractDescription.cs
@@ -7,7 +7,7 @@ namespace SoapCore.ServiceModel
 {
 	public class ContractDescription
 	{
-		public ContractDescription(ServiceDescription service, Type contractType, ServiceContractAttribute attribute)
+		public ContractDescription(ServiceDescription service, Type contractType, ServiceContractAttribute attribute, bool generateSoapActionWithoutContractName)
 		{
 			Service = service;
 			ContractType = contractType;
@@ -20,7 +20,7 @@ namespace SoapCore.ServiceModel
 			{
 				foreach (var operationContract in operationMethodInfo.GetCustomAttributes<OperationContractAttribute>())
 				{
-					operations.Add(new OperationDescription(this, operationMethodInfo, operationContract));
+					operations.Add(new OperationDescription(this, operationMethodInfo, operationContract, generateSoapActionWithoutContractName));
 				}
 			}
 

--- a/src/SoapCore/ServiceModel/OperationDescription.cs
+++ b/src/SoapCore/ServiceModel/OperationDescription.cs
@@ -12,11 +12,24 @@ namespace SoapCore.ServiceModel
 {
 	public class OperationDescription
 	{
-		public OperationDescription(ContractDescription contract, MethodInfo operationMethod, OperationContractAttribute contractAttribute)
+		public OperationDescription(ContractDescription contract, MethodInfo operationMethod, OperationContractAttribute contractAttribute, bool generateSoapActionWithoutContractName)
 		{
 			Contract = contract;
 			Name = contractAttribute.Name ?? GetNameByAction(contractAttribute.Action) ?? GetNameByMethod(operationMethod);
-			SoapAction = contractAttribute.Action ?? $"{contract.Namespace.TrimEnd('/')}/{contract.Name}/{Name}";
+
+			if (contractAttribute.Action != null)
+			{
+				SoapAction = contractAttribute.Action;
+			}
+			else if (generateSoapActionWithoutContractName)
+			{
+				SoapAction = $"{contract.Namespace.TrimEnd('/')}/{Name}";
+			}
+			else
+			{
+				SoapAction = $"{contract.Namespace.TrimEnd('/')}/{contract.Name}/{Name}";
+			}
+
 			IsOneWay = contractAttribute.IsOneWay;
 			DispatchMethod = operationMethod;
 

--- a/src/SoapCore/ServiceModel/ServiceDescription.cs
+++ b/src/SoapCore/ServiceModel/ServiceDescription.cs
@@ -8,7 +8,7 @@ namespace SoapCore.ServiceModel
 {
 	public class ServiceDescription
 	{
-		public ServiceDescription(Type serviceType)
+		public ServiceDescription(Type serviceType, bool generateSoapActionWithoutContractName)
 		{
 			ServiceType = serviceType;
 			ServiceKnownTypes = serviceType.GetCustomAttributes<ServiceKnownTypeAttribute>(inherit: false);
@@ -21,7 +21,7 @@ namespace SoapCore.ServiceModel
 			{
 				foreach (var serviceContract in contractType.GetTypeInfo().GetCustomAttributes<ServiceContractAttribute>())
 				{
-					var contractDescription = new ContractDescription(this, contractType, serviceContract);
+					var contractDescription = new ContractDescription(this, contractType, serviceContract, generateSoapActionWithoutContractName);
 
 					contracts.Add(contractDescription);
 

--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -136,5 +136,12 @@ namespace SoapCore
 		/// Sets additional namespace declaration attributes in envelope
 		/// </summary>
 		public Dictionary<string, string> AdditionalEnvelopeXmlnsAttributes { get; set; }
+
+		/// <summary>
+		/// By default, the soapAction that is generated if not explicitely specified is
+		/// {namespace}/{contractName}/{methodName}. If set to true, the service name will
+		/// be omitted, so that the soapAction will be {namespace}/{methodName}.
+		/// </summary>
+		public bool GenerateSoapActionWithoutContractName { get; set; } = false;
 	}
 }

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -65,7 +65,7 @@ namespace SoapCore
 
 			_serializerHelper = new SerializerHelper(options.SoapSerializer);
 			_pathComparisonStrategy = options.CaseInsensitivePath ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-			_service = new ServiceDescription(options.ServiceType);
+			_service = new ServiceDescription(options.ServiceType, options.GenerateSoapActionWithoutContractName);
 
 			if (options.EncoderOptions is null)
 			{

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -70,6 +70,8 @@ namespace SoapCore
 		public WsdlFileOptions WsdlFileOptions { get; set; }
 		public Dictionary<string, string> AdditionalEnvelopeXmlnsAttributes { get; set; }
 
+		public bool GenerateSoapActionWithoutContractName { get; set; } = false;
+
 		[Obsolete]
 		public static SoapOptions FromSoapCoreOptions<T>(SoapCoreOptions opt)
 		{
@@ -99,7 +101,8 @@ namespace SoapCore
 				WsdlFileOptions = opt.WsdlFileOptions,
 				AdditionalEnvelopeXmlnsAttributes = opt.AdditionalEnvelopeXmlnsAttributes,
 				CheckXmlCharacters = opt.CheckXmlCharacters,
-				UseMicrosoftGuid = opt.UseMicrosoftGuid
+				UseMicrosoftGuid = opt.UseMicrosoftGuid,
+				GenerateSoapActionWithoutContractName = opt.GenerateSoapActionWithoutContractName,
 			};
 
 #pragma warning disable CS0612 // Type or member is obsolete


### PR DESCRIPTION
By default, the soapAction that is generated if it is not specified in the `[OperationContract(Action = "...")]` attribute, follows the format `{namespace}/{contractName}/{methodName}`.

This seems to be different than the default soapAction that is generated in ASMX web services in .NET Framework. The new option makes it possible to omit the contractName and instead generate soapActions with the format `{namespace}/{methodName}`. The default for this new option is false. This means that the behavior for existing users of SoapCore does not change.

However I had to change the interface ISoapMessageProcessor to make AuthorizeOperationMessageProcessor work. The method ProcessMessage will now have an additional SoapOptions parameter. If users implement their own ISoapMessageProcessor, they have to add this parameter if they update the NuGet package. Is this acceptable?