### PR TITLE
XmlSerializer: Remove empty <xsd:import /> tag in generated WSDL

### DIFF
--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -297,9 +297,6 @@ namespace SoapCore.Meta
 			writer.WriteAttributeString("elementFormDefault", "qualified");
 			writer.WriteAttributeString("targetNamespace", TargetNameSpace);
 
-			writer.WriteStartElement("import", Namespaces.XMLNS_XSD);
-			writer.WriteEndElement();
-
 			foreach (var operation in _service.Operations)
 			{
 				bool hasWrittenOutParameters = false;


### PR DESCRIPTION
Fixes #1022