### PR TITLE
Add Option to not normalize newlines

### DIFF
--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -1163,7 +1163,7 @@ namespace SoapCore.Tests.Wsdl
 			var bodyWriter = serializer == SoapSerializer.DataContractSerializer
 				? new MetaWCFBodyWriter(service, baseUrl, defaultBindingName, false, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }) as BodyWriter
 				: new MetaBodyWriter(service, baseUrl, xmlNamespaceManager, defaultBindingName, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }, useMicrosoftGuid) as BodyWriter;
-			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, Encoding.UTF8, false, XmlDictionaryReaderQuotas.Max, false, false, null, bindingName, portName);
+			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, Encoding.UTF8, false, XmlDictionaryReaderQuotas.Max, false, false, null, bindingName, portName, true);
 			var responseMessage = Message.CreateMessage(encoder.MessageVersion, null, bodyWriter);
 			responseMessage = new MetaMessage(responseMessage, service, xmlNamespaceManager, defaultBindingName, false);
 

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -29,8 +29,9 @@ namespace SoapCore.MessageEncoder
 		private readonly bool _optimizeWriteForUtf8;
 		private readonly bool _omitXmlDeclaration;
 		private readonly bool _checkXmlCharacters;
+		private readonly bool _normalizeNewLines;
 
-		public SoapMessageEncoder(MessageVersion version, Encoding writeEncoding, bool overwriteResponseContentType, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool checkXmlCharacters, XmlNamespaceManager xmlNamespaceOverrides, string bindingName, string portName, int maxSoapHeaderSize = SoapMessageEncoderDefaults.MaxSoapHeaderSizeDefault)
+		public SoapMessageEncoder(MessageVersion version, Encoding writeEncoding, bool overwriteResponseContentType, XmlDictionaryReaderQuotas quotas, bool omitXmlDeclaration, bool checkXmlCharacters, XmlNamespaceManager xmlNamespaceOverrides, string bindingName, string portName, bool normalizeNewLines, int maxSoapHeaderSize = SoapMessageEncoderDefaults.MaxSoapHeaderSizeDefault)
 		{
 			_omitXmlDeclaration = omitXmlDeclaration;
 			_checkXmlCharacters = checkXmlCharacters;
@@ -41,6 +42,8 @@ namespace SoapCore.MessageEncoder
 			_optimizeWriteForUtf8 = IsUtf8Encoding(writeEncoding);
 
 			_overwriteResponseContentType = overwriteResponseContentType;
+
+			_normalizeNewLines = normalizeNewLines;
 
 			MessageVersion = version ?? throw new ArgumentNullException(nameof(version));
 
@@ -188,7 +191,8 @@ namespace SoapCore.MessageEncoder
 				Indent = indentXml,
 				Encoding = _writeEncoding,
 				CloseOutput = false,
-				CheckCharacters = _checkXmlCharacters
+				CheckCharacters = _checkXmlCharacters,
+				NewLineHandling = _normalizeNewLines ? NewLineHandling.Replace : NewLineHandling.None,
 			}))
 			{
 				using var xmlWriter = XmlDictionaryWriter.CreateDictionaryWriter(xmlTextWriter);
@@ -231,7 +235,8 @@ namespace SoapCore.MessageEncoder
 				Indent = indentXml,
 				Encoding = _writeEncoding,
 				CloseOutput = false,
-				CheckCharacters = _checkXmlCharacters
+				CheckCharacters = _checkXmlCharacters,
+				NewLineHandling = _normalizeNewLines ? NewLineHandling.Replace : NewLineHandling.None,
 			}))
 			{
 				using var xmlWriter = XmlDictionaryWriter.CreateDictionaryWriter(xmlTextWriter);

--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -143,5 +143,12 @@ namespace SoapCore
 		/// be omitted, so that the soapAction will be {namespace}/{methodName}.
 		/// </summary>
 		public bool GenerateSoapActionWithoutContractName { get; set; } = false;
+
+		/// <summary>
+		/// Gets or sets a value indicating whether newlines in the SOAP XML responses
+		/// should be normalized to the system's default newline character (CRLF on Windows).
+		/// Default is true.
+		/// </summary>
+		public bool NormalizeNewLines { get; set; } = true;
 	}
 }

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -77,7 +77,7 @@ namespace SoapCore
 			for (var i = 0; i < options.EncoderOptions.Length; i++)
 			{
 				var encoderOptions = options.EncoderOptions[i];
-				_messageEncoders[i] = new SoapMessageEncoder(encoderOptions.MessageVersion, encoderOptions.WriteEncoding, encoderOptions.OverwriteResponseContentType, encoderOptions.ReaderQuotas, options.OmitXmlDeclaration, options.CheckXmlCharacters, encoderOptions.XmlNamespaceOverrides, encoderOptions.BindingName, encoderOptions.PortName, encoderOptions.MaxSoapHeaderSize);
+				_messageEncoders[i] = new SoapMessageEncoder(encoderOptions.MessageVersion, encoderOptions.WriteEncoding, encoderOptions.OverwriteResponseContentType, encoderOptions.ReaderQuotas, options.OmitXmlDeclaration, options.CheckXmlCharacters, encoderOptions.XmlNamespaceOverrides, encoderOptions.BindingName, encoderOptions.PortName, options.NormalizeNewLines, encoderOptions.MaxSoapHeaderSize);
 			}
 		}
 

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -72,6 +72,8 @@ namespace SoapCore
 
 		public bool GenerateSoapActionWithoutContractName { get; set; } = false;
 
+		public bool NormalizeNewLines { get; set; } = true;
+
 		[Obsolete]
 		public static SoapOptions FromSoapCoreOptions<T>(SoapCoreOptions opt)
 		{
@@ -103,6 +105,7 @@ namespace SoapCore
 				CheckXmlCharacters = opt.CheckXmlCharacters,
 				UseMicrosoftGuid = opt.UseMicrosoftGuid,
 				GenerateSoapActionWithoutContractName = opt.GenerateSoapActionWithoutContractName,
+				NormalizeNewLines = opt.NormalizeNewLines,
 			};
 
 #pragma warning disable CS0612 // Type or member is obsolete


### PR DESCRIPTION
The XmlWriter that is used by SoapCore to write the SOAP XML responses for all requests will by default normalize newlines in the generated XML responses.

This means that for a string that contains LF (`'\n'`) newlines, these newlines will automatically be converted to CRLF (`"\r\n"`).

This is different from the behavior of the old ASMX Web Services, which will not normalize the newlines.

I have added a new option that controls whether the newlines should be normalized or not. The default behavior is "true", so the commit will not change the behavior for existing users of SoapCore.