### PR TITLE
added bad request status code for Ill formed xml requests: XML Except…

### DIFF
--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -323,6 +323,10 @@ namespace SoapCore
 				{
 					status = StatusCodes.Status403Forbidden;
 				}
+				else if (ex is XmlException)
+				{
+					status = StatusCodes.Status400BadRequest;
+				}
 
 				responseMessage = CreateErrorResponseMessage(ex, status, serviceProvider, requestMessage, messageEncoder, httpContext);
 			}


### PR DESCRIPTION
Currently if there is an incorrect character at the end of the request body after > tag. It throws internal server error where it should be bad request