### PR TITLE
removed unnessecary buffered copy

### DIFF
--- a/src/SoapCore/DocumentationWriter/SoapMethods.cs
+++ b/src/SoapCore/DocumentationWriter/SoapMethods.cs
@@ -49,6 +49,15 @@ namespace SoapCore.DocumentationWriter
 			return (SoapDefinition)xs.Deserialize(sr);
 		}
 
+		public static SoapDefinition DeserializeFromStream(Stream xml)
+		{
+			XmlSerializer xs = new XmlSerializer(typeof(SoapDefinition));
+
+			xs.UnknownElement += _unknownElementHandler;
+
+			return (SoapDefinition)xs.Deserialize(xml);
+		}
+
 		public string GenerateDocumentation()
 		{
 #if NETCOREAPP3_1_OR_GREATER

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -139,35 +139,33 @@ namespace SoapCore.MessageEncoder
 
 			Message message;
 
-			using (var ms = new MemoryStream())
+			var ms = new MemoryStream();
+			await stream.CopyToAsync(ms);
+			ms.Seek(0, SeekOrigin.Begin);
+			XmlReader reader;
+
+			var readEncoding = SoapMessageEncoderDefaults.ContentTypeToEncoding(contentType);
+
+			if (readEncoding == null)
 			{
-				await stream.CopyToAsync(ms);
-				ms.Seek(0, SeekOrigin.Begin);
-				XmlReader reader;
-
-				var readEncoding = SoapMessageEncoderDefaults.ContentTypeToEncoding(contentType);
-
-				if (readEncoding == null)
-				{
-					// Fallback to default or writeEncoding
-					readEncoding = _writeEncoding;
-				}
-
-				var supportXmlDictionaryReader = SoapMessageEncoderDefaults.TryValidateEncoding(readEncoding, out _);
-
-				if (supportXmlDictionaryReader)
-				{
-					reader = XmlDictionaryReader.CreateTextReader(ms, readEncoding, ReaderQuotas, dictionaryReader => { });
-				}
-				else
-				{
-					var streamReaderWithEncoding = new StreamReader(ms, readEncoding);
-					var xmlReaderSettings = new XmlReaderSettings() { IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit, CloseInput = true };
-					reader = XmlReader.Create(streamReaderWithEncoding, xmlReaderSettings);
-				}
-
-				message = Message.CreateMessage(reader, maxSizeOfHeaders, MessageVersion).CreateBufferedCopy(int.MaxValue).CreateMessage();
+				// Fallback to default or writeEncoding
+				readEncoding = _writeEncoding;
 			}
+
+			var supportXmlDictionaryReader = SoapMessageEncoderDefaults.TryValidateEncoding(readEncoding, out _);
+
+			if (supportXmlDictionaryReader)
+			{
+				reader = XmlDictionaryReader.CreateTextReader(ms, readEncoding, ReaderQuotas, dictionaryReader => { });
+			}
+			else
+			{
+				var streamReaderWithEncoding = new StreamReader(ms, readEncoding);
+				var xmlReaderSettings = new XmlReaderSettings() { IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit, CloseInput = true };
+				reader = XmlReader.Create(streamReaderWithEncoding, xmlReaderSettings);
+			}
+
+			message = Message.CreateMessage(reader, maxSizeOfHeaders, MessageVersion);
 
 			return message;
 		}

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -161,7 +161,7 @@ namespace SoapCore.MessageEncoder
 			else
 			{
 				var streamReaderWithEncoding = new StreamReader(ms, readEncoding);
-				var xmlReaderSettings = new XmlReaderSettings() { IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit, CloseInput = true };
+				var xmlReaderSettings = new XmlReaderSettings() { XmlResolver = null, IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit, CloseInput = true };
 				reader = XmlReader.Create(streamReaderWithEncoding, xmlReaderSettings);
 			}
 

--- a/src/SoapCore/Meta/BodyWriterExtensions.cs
+++ b/src/SoapCore/Meta/BodyWriterExtensions.cs
@@ -40,11 +40,8 @@ namespace SoapCore.Meta
 
 				memoryStream.Position = 0;
 
-				var streamReader = new StreamReader(memoryStream);
-				var result = streamReader.ReadToEnd();
-
 				var doc = new XmlDocument();
-				doc.LoadXml(result);
+				doc.Load(memoryStream);
 				doc.DocumentElement.WriteContentTo(writer);
 
 				return true;
@@ -130,11 +127,8 @@ namespace SoapCore.Meta
 				schema.Write(memoryStream);
 				memoryStream.Position = 0;
 
-				var streamReader = new StreamReader(memoryStream);
-				var result = streamReader.ReadToEnd();
-
 				var doc = new XmlDocument();
-				doc.LoadXml(result);
+				doc.Load(memoryStream);
 				doc.DocumentElement.WriteContentTo(writer);
 
 				return true;

--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<Description>SOAP protocol middleware for ASP.NET Core</Description>
-		<Version>1.1.0.45</Version>
+		<Version>1.1.0.46</Version>
 		<Authors>Digital Design</Authors>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 		<PackageId>SoapCore</PackageId>

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -264,10 +264,7 @@ namespace SoapCore
 				using var ms = new MemoryStream();
 				await messageEncoder.WriteMessageAsync(responseMessage, httpContext, ms, _options.IndentWsdl);
 				ms.Position = 0;
-				using var sr = new StreamReader(ms);
-				var wsdl = await sr.ReadToEndAsync();
-
-				var documentation = SoapDefinition.DeserializeFromString(wsdl).GenerateDocumentation();
+				var documentation = SoapDefinition.DeserializeFromStream(ms).GenerateDocumentation();
 
 				await httpContext.Response.WriteAsync(documentation);
 
@@ -438,7 +435,7 @@ namespace SoapCore
 
 			bodyWriter.WriteBodyContents(dictionaryWriter);
 			dictionaryWriter.Flush();
-			await context.Response.WriteAsync(DefaultEncodings.UTF8.GetString(ms.ToArray()));
+			await ms.CopyToAsync(context.Response.Body);
 		}
 
 		private Func<Message, Task<Message>> MakeProcessorPipe(ISoapMessageProcessor[] soapMessageProcessors, HttpContext httpContext, Func<Message, Task<Message>> processMessageFunc)


### PR DESCRIPTION
* added method to deserialize SoapDefinition from stream 
* removed unnessecary StreamReader usage

@zgabi made me aware that MemoryStream does not need to be disposed.
That made me realize that we could avoid a BufferedCopy of message in ReadMessageAsync.

Then I found some other perf fixes that could be done around memorystream usage in the lib.

@akshaybheda all that hoop jumping and this code is back to basically your first commit in ReadMessageAsync. 😆 