### PR TITLE
xml (xsd, wsdl) Attribute access simplified + unnecessary usings removed from MemoryStreams

### DIFF
--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -1167,16 +1167,14 @@ namespace SoapCore.Tests.Wsdl
 			var responseMessage = Message.CreateMessage(encoder.MessageVersion, null, bodyWriter);
 			responseMessage = new MetaMessage(responseMessage, service, xmlNamespaceManager, defaultBindingName, false);
 
-			using (var memoryStream = new MemoryStream())
-			{
-				await encoder.WriteMessageAsync(responseMessage, null, memoryStream, true);
-				memoryStream.Position = 0;
+			var memoryStream = new MemoryStream();
+			await encoder.WriteMessageAsync(responseMessage, null, memoryStream, true);
+			memoryStream.Position = 0;
 
-				using (var streamReader = new StreamReader(memoryStream))
-				{
-					var result = streamReader.ReadToEnd();
-					return result;
-				}
+			using (var streamReader = new StreamReader(memoryStream))
+			{
+				var result = streamReader.ReadToEnd();
+				return result;
 			}
 		}
 

--- a/src/SoapCore/FaultBodyWriter.cs
+++ b/src/SoapCore/FaultBodyWriter.cs
@@ -158,15 +158,13 @@ namespace SoapCore
 				return null;
 			}
 
-			using (var ms = new MemoryStream())
-			{
-				var serializer = new DataContractSerializer(detailObject.GetType());
-				serializer.WriteObject(ms, detailObject);
-				ms.Position = 0;
-				var doc = new XmlDocument();
-				doc.Load(ms);
-				return doc.DocumentElement;
-			}
+			var ms = new MemoryStream();
+			var serializer = new DataContractSerializer(detailObject.GetType());
+			serializer.WriteObject(ms, detailObject);
+			ms.Position = 0;
+			var doc = new XmlDocument();
+			doc.Load(ms);
+			return doc.DocumentElement;
 		}
 
 		/// <summary>

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -137,37 +137,33 @@ namespace SoapCore.MessageEncoder
 				throw new ArgumentNullException(nameof(stream));
 			}
 
-			Message message;
+			var ms = new MemoryStream();
+			await stream.CopyToAsync(ms);
+			ms.Seek(0, SeekOrigin.Begin);
+			XmlReader reader;
 
-			using (var ms = new MemoryStream())
+			var readEncoding = SoapMessageEncoderDefaults.ContentTypeToEncoding(contentType);
+
+			if (readEncoding == null)
 			{
-				await stream.CopyToAsync(ms);
-				ms.Seek(0, SeekOrigin.Begin);
-				XmlReader reader;
-
-				var readEncoding = SoapMessageEncoderDefaults.ContentTypeToEncoding(contentType);
-
-				if (readEncoding == null)
-				{
-					// Fallback to default or writeEncoding
-					readEncoding = _writeEncoding;
-				}
-
-				var supportXmlDictionaryReader = SoapMessageEncoderDefaults.TryValidateEncoding(readEncoding, out _);
-
-				if (supportXmlDictionaryReader)
-				{
-					reader = XmlDictionaryReader.CreateTextReader(ms, readEncoding, ReaderQuotas, dictionaryReader => { });
-				}
-				else
-				{
-					var streamReaderWithEncoding = new StreamReader(ms, readEncoding);
-					var xmlReaderSettings = new XmlReaderSettings() { IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit, CloseInput = true };
-					reader = XmlReader.Create(streamReaderWithEncoding, xmlReaderSettings);
-				}
-
-				message = Message.CreateMessage(reader, maxSizeOfHeaders, MessageVersion).CreateBufferedCopy(int.MaxValue).CreateMessage();
+				// Fallback to default or writeEncoding
+				readEncoding = _writeEncoding;
 			}
+
+			var supportXmlDictionaryReader = SoapMessageEncoderDefaults.TryValidateEncoding(readEncoding, out _);
+
+			if (supportXmlDictionaryReader)
+			{
+				reader = XmlDictionaryReader.CreateTextReader(ms, readEncoding, ReaderQuotas, dictionaryReader => { });
+			}
+			else
+			{
+				var streamReaderWithEncoding = new StreamReader(ms, readEncoding);
+				var xmlReaderSettings = new XmlReaderSettings() { IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit, CloseInput = true };
+				reader = XmlReader.Create(streamReaderWithEncoding, xmlReaderSettings);
+			}
+
+			var message = Message.CreateMessage(reader, maxSizeOfHeaders, MessageVersion).CreateBufferedCopy(int.MaxValue).CreateMessage();
 
 			return message;
 		}
@@ -191,7 +187,7 @@ namespace SoapCore.MessageEncoder
 
 			ThrowIfMismatchedMessageVersion(message);
 
-			using var memoryStream = new MemoryStream();
+			var memoryStream = new MemoryStream();
 			using (var xmlTextWriter = XmlWriter.Create(memoryStream, new XmlWriterSettings
 			{
 				OmitXmlDeclaration = _optimizeWriteForUtf8 && _omitXmlDeclaration, //can only omit if utf-8
@@ -235,7 +231,7 @@ namespace SoapCore.MessageEncoder
 
 			ThrowIfMismatchedMessageVersion(message);
 
-			using var memoryStream = new MemoryStream();
+			var memoryStream = new MemoryStream();
 			using (var xmlTextWriter = XmlWriter.Create(memoryStream, new XmlWriterSettings
 			{
 				OmitXmlDeclaration = _optimizeWriteForUtf8 && _omitXmlDeclaration, //can only omit if utf-8,

--- a/src/SoapCore/Meta/BodyWriterExtensions.cs
+++ b/src/SoapCore/Meta/BodyWriterExtensions.cs
@@ -32,7 +32,7 @@ namespace SoapCore.Meta
 				exporter.ExportTypeMapping(xmlTypeMapping);
 				schemas.Compile(null, true);
 
-				using var memoryStream = new MemoryStream();
+				var memoryStream = new MemoryStream();
 				foreach (XmlSchema schema in schemas)
 				{
 					schema.Write(memoryStream);
@@ -126,7 +126,7 @@ namespace SoapCore.Meta
 					schema.Items.Add(element);
 				}
 
-				using var memoryStream = new MemoryStream();
+				var memoryStream = new MemoryStream();
 				schema.Write(memoryStream);
 				memoryStream.Position = 0;
 

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -261,7 +261,7 @@ namespace SoapCore
 			{
 				httpContext.Response.ContentType = "text/html;charset=UTF-8";
 
-				using var ms = new MemoryStream();
+				var ms = new MemoryStream();
 				await messageEncoder.WriteMessageAsync(responseMessage, httpContext, ms, _options.IndentWsdl);
 				ms.Position = 0;
 				using var sr = new StreamReader(ms);
@@ -432,7 +432,7 @@ namespace SoapCore
 
 			context.Response.ContentType = "text/xml";
 
-			using var ms = new MemoryStream();
+			var ms = new MemoryStream();
 			XmlWriter writer = XmlWriter.Create(ms, new XmlWriterSettings() { Encoding = DefaultEncodings.UTF8 });
 			XmlDictionaryWriter dictionaryWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
 


### PR DESCRIPTION
The xml attribute was accessed several times in MetaFromFile class. It is faster to get it only once and use that object. The code is also shorter.

MemoryStream using blocks and using declarations removed since they are unnecessary.
Check the .NET documentation:
https://learn.microsoft.com/en-us/dotnet/api/system.io.memorystream?view=net-8.0

> This type implements the [IDisposable](https://learn.microsoft.com/en-us/dotnet/api/system.idisposable?view=net-8.0) interface, but does not actually have any resources to dispose. This means that disposing it by directly calling [Dispose()](https://learn.microsoft.com/en-us/dotnet/api/system.idisposable.dispose?view=net-8.0#system-idisposable-dispose) or by using a language construct such as using (in C#) or Using (in Visual Basic) is not necessary.

This is the same for all previous .NET versions.