### PR TITLE
support for X-Forwarded-Host header

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ To use it, add a setting like this to appsettings
 ```json
 "FileWSDL": {
   "UrlOverride": "",
+  "SchemeOverride": "",
   "VirtualPath": "",
   "WebServiceWSDLMapping": {
     "Service.asmx": {
@@ -93,6 +94,7 @@ To use it, add a setting like this to appsettings
 ```
 
 * UrlOverride - can be used to override the URL in the service description. This can be useful if you are behind a firewall.
+* SchemeOverride - can be used to override the HTTP Scheme in the service description. This can be useful if you are behind a firewall and the firewall sets the X-Forwarded-Host header, but the internal HTTP scheme is not the same as the external.
 * VirualPath - can be used if you like to add a path between the base URL and service. 
 * WebServiceWSDLMapping
   * UrlOverride - can be used to override the URL for a specific WSDL mapping. This can be useful if you want to host different services under different folder.

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -20,6 +21,7 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using SoapCore.DocumentationWriter;
 using SoapCore.Extensibility;
@@ -984,16 +986,7 @@ namespace SoapCore
 
 			meta.WSDLFolder = mapping.WSDLFolder;
 			meta.XsdFolder = mapping.SchemaFolder;
-
-			if (options.UrlOverride != string.Empty)
-			{
-				meta.ServerUrl = options.UrlOverride;
-			}
-			else
-			{
-				meta.ServerUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host + "/";
-			}
-
+			meta.ServerUrl = options.GetServerUrl(httpContext);
 			return meta;
 		}
 
@@ -1072,16 +1065,9 @@ namespace SoapCore
 				meta.CurrentWebService = mapping.UrlOverride;
 			}
 
-			meta.XsdFolder = mapping.SchemaFolder;
 			meta.WSDLFolder = mapping.WSDLFolder;
-			if (options.UrlOverride != string.Empty)
-			{
-				meta.ServerUrl = options.UrlOverride;
-			}
-			else
-			{
-				meta.ServerUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host + "/";
-			}
+			meta.XsdFolder = mapping.SchemaFolder;
+			meta.ServerUrl = options.GetServerUrl(httpContext);
 
 			string wsdlfile = mapping.WsdlFile;
 

--- a/src/SoapCore/WSDLFileOptions.cs
+++ b/src/SoapCore/WSDLFileOptions.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
 
@@ -7,8 +8,27 @@ namespace SoapCore
 	{
 		public virtual Dictionary<string, WebServiceWSDLMapping> WebServiceWSDLMapping { get; set; } = new Dictionary<string, WebServiceWSDLMapping>();
 		public string UrlOverride { get; set; }
+		public string SchemeOverride { get; set; }
 		public string VirtualPath { get; set; }
 		public string AppPath { get; set; }
+
+		public virtual string GetServerUrl(HttpContext httpContext)
+		{
+			if (!string.IsNullOrEmpty(UrlOverride))
+			{
+				return UrlOverride;
+			}
+
+			string scheme = string.IsNullOrEmpty(SchemeOverride) ? httpContext.Request.Scheme : SchemeOverride;
+			string host = httpContext.Request.Host.ToString();
+			var forwardedHost = httpContext.Request.Headers["X-Forwarded-Host"];
+			if (forwardedHost.Count != 0)
+			{
+				host = forwardedHost[0];
+			}
+
+			return scheme + "://" + host + "/";
+		}
 	}
 
 	public class WsdlFileOptionsCaseInsensitive : WsdlFileOptions


### PR DESCRIPTION
The X-Forwarded-Host is a de-facto standard header which is set by the reverse proxies.
This PR adds support for this header. It also adds supoprt to override the url during the wsql/xsd query (with inheriting from the WsdlFileOptions class) and allows to override the http scheme.

For example it is useful in the following configuration:

The service is accessible from the internet in the following url:
https://external.hostname.com/ServiceName

But it is only a proxy, calls the internal service:
http://internal.hostname.com/ServiceName

And we also have development and test urls:
https://test.hostname.com/ServiceName
http://internaltest.hostname.com/ServiceName

The proxy sets the X-Forwarded-Host header (external.hostname.com or test.hostname.com), and SoapCore overrides the http scheme to "http".

In this way the address in the wsdl will be correct even if it is called from the internet or from the internal url directly.
