### PR TITLE
fix(wsdl-asmx): handle nullable enums

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/IEnumService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IEnumService.cs
@@ -1,0 +1,24 @@
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services;
+
+[ServiceContract]
+public interface IEnumService
+{
+	[OperationContract]
+	TypeWithEnums Method(TypeWithEnums argument);
+}
+
+public class EnumService : IEnumService
+{
+	public TypeWithEnums Method(TypeWithEnums argument)
+	{
+		return new TypeWithEnums();
+	}
+}
+
+public class TypeWithEnums
+{
+	public NulEnum Enum { get; set; }
+	public NulEnum? NullEnum { get; set; }
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -926,6 +926,24 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[TestMethod]
+		public void CheckEnumServiceWsdl()
+		{
+			StartService(typeof(EnumService));
+			var wsdl = GetWsdlFromAsmx();
+			StopServer();
+			Assert.IsNotNull(wsdl);
+
+			var root = XElement.Parse(wsdl);
+			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+
+			var normalEnum = root.XPathSelectElement("//xsd:complexType[@name='TypeWithEnums']/xsd:sequence/xsd:element[@name='Enum' and @type='tns:NulEnum' and not(@nillable)]", nm);
+			Assert.IsNotNull(normalEnum);
+
+			var nullableEnum = root.XPathSelectElement("//xsd:complexType[@name='TypeWithEnums']/xsd:sequence/xsd:element[@name='NullEnum' and @type='tns:NulEnum' and @nillable='true']", nm);
+			Assert.IsNotNull(nullableEnum);
+		}
+
+		[TestMethod]
 		public void CheckFieldMembers()
 		{
 			StartService(typeof(OperationContractFieldMembersService));

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -1029,6 +1029,7 @@ namespace SoapCore.Meta
 				else if (underlyingType?.IsEnum == true)
 				{
 					xsTypename = new XmlQualifiedName(underlyingType.GetSerializedTypeName(), _xmlNamespaceManager.LookupNamespace("tns"));
+					writer.WriteAttributeString("nillable", "true");
 					_enumToBuild.Enqueue(underlyingType);
 				}
 				else


### PR DESCRIPTION
When the underlying type for nullable is an enum, we should add nillable attribute