### PR TITLE
feat(wsdl-meta): add support for XmlArray attribute

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/IXmlArrayAttributeService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IXmlArrayAttributeService.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Wsdl.Services;
+
+[ServiceContract]
+public interface IXmlArrayAttributeService
+{
+	[OperationContract]
+	TypeWithXmlArrayAttribute Method(TypeWithXmlArrayAttribute argument);
+}
+
+public class XmlArrayAttributeService : IXmlArrayAttributeService
+{
+	public TypeWithXmlArrayAttribute Method(TypeWithXmlArrayAttribute argument)
+	{
+		return new TypeWithXmlArrayAttribute();
+	}
+}
+
+public class TypeWithXmlArrayAttribute
+{
+	[XmlArray("AvlRoomTypeItems")]
+	public List<AvlRoomTypeItem> AvlRoomTypeList { get; set; }
+}
+
+public class AvlRoomTypeItem
+{
+	public string RoomTypeCode { get; set; }
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -1027,6 +1027,27 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(propAnonAttribute);
 		}
 
+		[TestMethod]
+		public void CheckXmlArrayAttributeTypeServiceWsdl()
+		{
+			StartService(typeof(XmlArrayAttributeService));
+			var wsdl = GetWsdlFromAsmx();
+			StopServer();
+			Assert.IsNotNull(wsdl);
+
+			var root = XElement.Parse(wsdl);
+			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+
+			var typeWithXmlArrayAttribute = root.XPathSelectElement("//xsd:complexType[@name='TypeWithXmlArrayAttribute']/xsd:sequence/xsd:element[@name='AvlRoomTypeItems' and @type='tns:ArrayOfAvlRoomTypeItem' and @nillable='true' and @minOccurs='0' and @maxOccurs='1']", nm);
+			Assert.IsNotNull(typeWithXmlArrayAttribute);
+
+			var array = root.XPathSelectElement("//xsd:complexType[@name='ArrayOfAvlRoomTypeItem']/xsd:sequence/xsd:element[@name='AvlRoomTypeItem' and @type='tns:AvlRoomTypeItem' and @nillable='true' and @minOccurs='0' and @maxOccurs='unbounded']", nm);
+			Assert.IsNotNull(array);
+
+			var arrayItem = root.XPathSelectElement("//xsd:complexType[@name='AvlRoomTypeItem']/xsd:sequence/xsd:element[@name='RoomTypeCode' and @type='xsd:string' and not(@nillable) and @minOccurs='0' and @maxOccurs='1']", nm);
+			Assert.IsNotNull(arrayItem);
+		}
+
 		[DataTestMethod]
 		public async Task CheckXmlAnnotatedChoiceReturnServiceWsdl()
 		{

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -886,14 +886,27 @@ namespace SoapCore.Meta
 				toBuild.ChildElementName = arrayItem.ElementName;
 			}
 
-			var elementItem = member.GetCustomAttribute<XmlElementAttribute>();
-			bool isUnqualified = elementItem?.Form == XmlSchemaForm.Unqualified;
+			bool isUnqualified = false;
 			string elementNameFromAttribute = null;
-			if (elementItem != null && !string.IsNullOrWhiteSpace(elementItem.ElementName))
+			var elementItem = member.GetCustomAttribute<XmlElementAttribute>();
+			var arrayAttribute = member.GetCustomAttribute<XmlArrayAttribute>();
+			if (elementItem != null)
 			{
-				elementNameFromAttribute = elementItem.ElementName;
-				toBuild.ChildElementName = elementNameFromAttribute;
-				createListWithoutProxyType = toBuild.Type.IsEnumerableType() && toBuild.Type.Name != "String" && toBuild.Type.Name != "Byte[]";
+				isUnqualified = elementItem.Form == XmlSchemaForm.Unqualified;
+				if (!string.IsNullOrWhiteSpace(elementItem.ElementName))
+				{
+					elementNameFromAttribute = elementItem.ElementName;
+					toBuild.ChildElementName = elementNameFromAttribute;
+					createListWithoutProxyType = toBuild.Type.IsEnumerableType() && toBuild.Type.Name != "String" && toBuild.Type.Name != "Byte[]";
+				}
+			}
+			else if (arrayAttribute != null)
+			{
+				isUnqualified = arrayAttribute.Form == XmlSchemaForm.Unqualified;
+				if (!string.IsNullOrWhiteSpace(arrayAttribute.ElementName))
+				{
+					elementNameFromAttribute = arrayAttribute.ElementName;
+				}
 			}
 
 			var attributeItem = member.GetCustomAttribute<XmlAttributeAttribute>();


### PR DESCRIPTION
XmlElement was supported but array might use XmlArray attribute to specify name.