### PR TITLE
feat(wsdl-meta): support bool-specified pattern

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/ISpecifiedBoolService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ISpecifiedBoolService.cs
@@ -1,0 +1,27 @@
+using System.ServiceModel;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Wsdl.Services;
+
+[ServiceContract]
+public interface ISpecifiedBoolService
+{
+	[OperationContract]
+	TypeWithSpecifiedEnum Method(TypeWithSpecifiedEnum argument);
+}
+
+public class SpecifiedBoolService : ISpecifiedBoolService
+{
+	public TypeWithSpecifiedEnum Method(TypeWithSpecifiedEnum argument)
+	{
+		return new TypeWithSpecifiedEnum();
+	}
+}
+
+public class TypeWithSpecifiedEnum
+{
+	[XmlIgnore]
+	public bool EnumSpecified { get; set; }
+	public NulEnum Enum { get; set; }
+	public NulEnum NormalEnum { get; set; }
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -944,6 +944,24 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[TestMethod]
+		public void CheckEnumSpecifiedBoolWsdl()
+		{
+			StartService(typeof(SpecifiedBoolService));
+			var wsdl = GetWsdlFromAsmx();
+			StopServer();
+			Assert.IsNotNull(wsdl);
+
+			var root = XElement.Parse(wsdl);
+			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+
+			var enumWithSpecifiedBool = root.XPathSelectElement("//xsd:complexType[@name='TypeWithSpecifiedEnum']/xsd:sequence/xsd:element[@name='Enum' and @type='tns:NulEnum' and not(@nillable) and @minOccurs='0' and @maxOccurs='1']", nm);
+			Assert.IsNotNull(enumWithSpecifiedBool);
+
+			var normalEnum = root.XPathSelectElement("//xsd:complexType[@name='TypeWithSpecifiedEnum']/xsd:sequence/xsd:element[@name='NormalEnum' and @type='tns:NulEnum' and not(@nillable) and @minOccurs='1' and @maxOccurs='1']", nm);
+			Assert.IsNotNull(normalEnum);
+		}
+
+		[TestMethod]
 		public void CheckFieldMembers()
 		{
 			StartService(typeof(OperationContractFieldMembersService));

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -936,7 +936,10 @@ namespace SoapCore.Meta
 					}
 				}
 
-				AddSchemaType(writer, toBuild, elementNameFromAttribute ?? member.Name ?? parentTypeToBuild.ChildElementName, isArray: createListWithoutProxyType, isListWithoutWrapper: createListWithoutProxyType, isUnqualified: isUnqualified, defaultValue: defaultValue);
+				var hasSpecifiedBoolean = member.DeclaringType.GetProperties()
+					.Any(p => p.Name == $"{member.Name}Specified" && p.PropertyType == typeof(bool) && p.GetCustomAttribute<XmlIgnoreAttribute>() != null);
+
+				AddSchemaType(writer, toBuild, elementNameFromAttribute ?? member.Name ?? parentTypeToBuild.ChildElementName, isArray: createListWithoutProxyType, isListWithoutWrapper: createListWithoutProxyType, isUnqualified: isUnqualified, defaultValue: defaultValue, hasSpecifiedBoolean: hasSpecifiedBoolean);
 			}
 		}
 
@@ -956,7 +959,7 @@ namespace SoapCore.Meta
 			AddSchemaType(writer, new TypeToBuild(type), name, isArray, @namespace, isAttribute, isUnqualified: isUnqualified);
 		}
 
-		private void AddSchemaType(XmlDictionaryWriter writer, TypeToBuild toBuild, string name, bool isArray = false, string @namespace = null, bool isAttribute = false, bool isListWithoutWrapper = false, bool isUnqualified = false, string defaultValue = null, bool isOptionalAttribute = false)
+		private void AddSchemaType(XmlDictionaryWriter writer, TypeToBuild toBuild, string name, bool isArray = false, string @namespace = null, bool isAttribute = false, bool isListWithoutWrapper = false, bool isUnqualified = false, string defaultValue = null, bool isOptionalAttribute = false, bool hasSpecifiedBoolean = false)
 		{
 			var type = toBuild.Type;
 
@@ -1056,7 +1059,7 @@ namespace SoapCore.Meta
 				}
 				else
 				{
-					writer.WriteAttributeString("minOccurs", type.IsValueType && defaultValue == null ? "1" : "0");
+					writer.WriteAttributeString("minOccurs", type.IsValueType && defaultValue == null && !hasSpecifiedBoolean ? "1" : "0");
 					writer.WriteAttributeString("maxOccurs", "1");
 					if (defaultValue != null)
 					{


### PR DESCRIPTION
Adds a support for a common pattern in System.Web.WebServices where you could have boolean property that influenced the maxOccurs.
I couldnt find any MS article but this pattern is/as wildly used for XmlSerializer:
https://stackoverflow.com/a/7563231