### PR TITLE
feat(meta-wsdl): add support for soap:header

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/IServiceWithSoapHeaders.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IServiceWithSoapHeaders.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Serialization;
+using SoapCore.ServiceModel;
+#pragma warning disable SA1401 // Fields should be private
+
+namespace SoapCore.Tests.Wsdl.Services;
+[ServiceContract]
+public interface IServiceWithSoapHeaders
+{
+	[OperationContract]
+	[AuthenticationContextSoapHeader]
+	public void Method();
+}
+
+public class ServiceWithSoapHeaders : IServiceWithSoapHeaders
+{
+	public void Method()
+	{
+	}
+}
+
+public sealed class AuthenticationContextSoapHeader : SoapHeaderAttribute
+{
+	[XmlAnyAttribute]
+	public XmlAttribute[] XAttributes;
+
+	public string OperatorCode { get; set; }
+	public string Password { get; set; }
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -808,6 +808,32 @@ namespace SoapCore.Tests.Wsdl
 
 		[DataTestMethod]
 		[DataRow(SoapSerializer.XmlSerializer)]
+		public async Task CheckSoapHeaderTypes(SoapSerializer soapSerializer)
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<ServiceWithSoapHeaders>(soapSerializer);
+			Trace.TraceInformation(wsdl);
+
+			var root = XElement.Parse(wsdl);
+			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+
+			var headerComplexType = root.XPathSelectElements("//xsd:complexType[@name='AuthenticationContextSoapHeader']", nm);
+			Assert.IsNotNull(headerComplexType);
+
+			var headerComplexTypePassword = root.XPathSelectElements("//xsd:complexType[@name='AuthenticationContextSoapHeader']/xsd:sequence/xsd:element[@name='OperatorCode' and @type='xsd:string' and not(@nillable) and @minOccurs=0 and @maxOccurs=1]", nm);
+			Assert.IsNotNull(headerComplexTypePassword);
+
+			var headerComplexTypeOperatorCode = root.XPathSelectElements("//xsd:complexType[@name='AuthenticationContextSoapHeader']/xsd:sequence/xsd:element[@name='Password' and @type='xsd:string' and not(@nillable) and @minOccurs=0 and @maxOccurs=1]", nm);
+			Assert.IsNotNull(headerComplexTypeOperatorCode);
+
+			var anyAttribute = root.XPathSelectElement("//xsd:complexType[@name='AuthenticationContextSoapHeader']/xsd:anyAttribute", nm);
+			Assert.IsNotNull(anyAttribute);
+
+			var headerElementOnOperation = root.XPathSelectElement("//wsdl:operation[@name='Method']/wsdl:input/soap:header[@message='tns:MethodAuthenticationContextSoapHeader' and @part='AuthenticationContextSoapHeader' and @use='literal']", nm);
+			Assert.IsNotNull(headerElementOnOperation);
+		}
+
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
 		[DataRow(SoapSerializer.DataContractSerializer)]
 		public async Task CheckUnqualifiedMembersService(SoapSerializer soapSerializer)
 		{

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -299,6 +299,8 @@ namespace SoapCore.Meta
 			writer.WriteAttributeString("elementFormDefault", "qualified");
 			writer.WriteAttributeString("targetNamespace", TargetNameSpace);
 
+			HashSet<Type> headerTypesWritten = new();
+
 			foreach (var operation in _service.Operations)
 			{
 				bool hasWrittenOutParameters = false;
@@ -441,6 +443,22 @@ namespace SoapCore.Meta
 					writer.WriteAttributeString("nillable", "true");
 					writer.WriteAttributeString("type", "tns:" + faultTypeToBuild.TypeName);
 					writer.WriteEndElement(); // element
+				}
+
+				if (operation.HeaderType != null && !headerTypesWritten.Contains(operation.HeaderType))
+				{
+					var headerTypeToBuild = new TypeToBuild(operation.HeaderType);
+
+					//enqueue the complex type itself
+					_complexTypeToBuild.Enqueue(headerTypeToBuild);
+
+					//write element pendant for the header type
+					writer.WriteStartElement("element", Namespaces.XMLNS_XSD);
+					writer.WriteAttributeString("name", headerTypeToBuild.TypeName);
+					writer.WriteAttributeString("type", "tns:" + headerTypeToBuild.TypeName);
+					writer.WriteEndElement(); // element
+
+					headerTypesWritten.Add(operation.HeaderType);
 				}
 			}
 
@@ -595,6 +613,18 @@ namespace SoapCore.Meta
 					writer.WriteEndElement(); // wsdl:message
 				}
 
+				if (operation.HeaderType is not null)
+				{
+					var name = operation.HeaderType.Name;
+					writer.WriteStartElement("wsdl", "message", Namespaces.WSDL_NS);
+					writer.WriteAttributeString("name", $"{operation.Name}{name}");
+					writer.WriteStartElement("wsdl", "part", Namespaces.WSDL_NS);
+					writer.WriteAttributeString("name", name);
+					writer.WriteAttributeString("element", "tns:" + name);
+					writer.WriteEndElement(); // wsdl:part
+					writer.WriteEndElement(); // wsdl:message
+				}
+
 				AddMessageFaults(writer, operation);
 			}
 		}
@@ -688,7 +718,18 @@ namespace SoapCore.Meta
 					writer.WriteStartElement(soap, "body", soapNamespace);
 					writer.WriteAttributeString("use", "literal");
 					writer.WriteEndElement(); // soap:body
+
+					if (operation.HeaderType != null)
+					{
+						writer.WriteStartElement(soap, "header", soapNamespace);
+						writer.WriteAttributeString("message", $"tns:{operation.Name}{operation.HeaderType.Name}");
+						writer.WriteAttributeString("part", operation.HeaderType.Name);
+						writer.WriteAttributeString("use", "literal");
+						writer.WriteEndElement();
+					}
+
 					writer.WriteEndElement(); // wsdl:input
+
 
 					if (!operation.IsOneWay)
 					{
@@ -752,7 +793,9 @@ namespace SoapCore.Meta
 
 			var baseType = type.GetTypeInfo().BaseType;
 
-			return !isArrayType && !type.IsEnum && !type.IsPrimitive && !type.IsValueType && baseType != null && !baseType.Name.Equals("Object");
+			return !isArrayType && !type.IsEnum && !type.IsPrimitive && !type.IsValueType && baseType != null
+			       && !baseType.Name.Equals("Object")
+			       && type.BaseType?.BaseType?.FullName?.Equals("System.Attribute") != true;
 		}
 
 		private void AddSchemaComplexType(XmlDictionaryWriter writer, TypeToBuild toBuild)
@@ -803,9 +846,10 @@ namespace SoapCore.Meta
 					if (!isWrappedBodyType)
 					{
 						var propertyOrFieldMembers = toBuildBodyType.GetPropertyOrFieldMembers()
-							.Where(mi => !mi.IsIgnored() && mi.DeclaringType == toBuildType).ToList();
+							.Where(mi => !mi.IsIgnored() && mi.DeclaringType == toBuildType)
+							.ToList();
 
-						var elements = propertyOrFieldMembers.Where(t => !t.IsAttribute()).ToList();
+						var elements = propertyOrFieldMembers.Where(t => !t.IsAttribute() && t.GetCustomAttribute<XmlAnyAttributeAttribute>() == null).ToList();
 						if (elements.Any())
 						{
 							writer.WriteStartElement("sequence", Namespaces.XMLNS_XSD);
@@ -817,10 +861,17 @@ namespace SoapCore.Meta
 							writer.WriteEndElement(); // sequence
 						}
 
-						var attributes = propertyOrFieldMembers.Where(t => t.IsAttribute());
+						var attributes = propertyOrFieldMembers.Where(t => t.IsAttribute() && t.GetCustomAttribute<XmlAnyAttributeAttribute>() == null);
 						foreach (var attribute in attributes)
 						{
 							AddSchemaTypePropertyOrField(writer, attribute, toBuild);
+						}
+
+						var anyAttribute = propertyOrFieldMembers.FirstOrDefault(t => t.GetCustomAttribute<XmlAnyAttributeAttribute>() != null);
+						if (anyAttribute != null)
+						{
+							writer.WriteStartElement("anyAttribute", Namespaces.XMLNS_XSD);
+							writer.WriteEndElement();
 						}
 					}
 					else

--- a/src/SoapCore/ServiceModel/OperationDescription.cs
+++ b/src/SoapCore/ServiceModel/OperationDescription.cs
@@ -82,6 +82,9 @@ namespace SoapCore.ServiceModel
 				.ToArray();
 
 			ServiceKnownTypes = operationMethod.GetCustomAttributes<ServiceKnownTypeAttribute>(inherit: false);
+
+			var soapHeader = operationMethod.GetCustomAttributes<SoapHeaderAttribute>(inherit: false);
+			HeaderType = soapHeader.FirstOrDefault()?.GetType();
 		}
 
 		public ContractDescription Contract { get; private set; }
@@ -103,6 +106,7 @@ namespace SoapCore.ServiceModel
 		public IEnumerable<ServiceKnownTypeAttribute> ServiceKnownTypes { get; private set; }
 		public IEnumerable<ReturnChoice> ReturnChoices { get; private set; }
 		public bool ReturnsChoice => ReturnChoices != null;
+		public Type HeaderType { get; set; }
 
 		public IEnumerable<ServiceKnownTypeAttribute> GetServiceKnownTypesHierarchy()
 		{

--- a/src/SoapCore/ServiceModel/SoapHeader.cs
+++ b/src/SoapCore/ServiceModel/SoapHeader.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace SoapCore.ServiceModel;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class SoapHeaderAttribute : Attribute
+{
+}


### PR DESCRIPTION
This implements the soap:header for MetaWritter.
https://learn.microsoft.com/pl-pl/dotnet/api/system.web.services.protocols.soapheader?view=netframework-4.8.1
I created new SoapHeader attribute that mimics the the SoapHeader from net framework.
Users can derive from it and decorate methods on the service.

@andersjonsson what is the recommended way to get the header and inject it into the service?
In my soap service I simply extended the IServiceOperationTuner so it also has ```Message```.
Then I could do that to deserialize my header and inject it:
```csharp
public class SoapHeaderOperationTuner : IServiceOperationTuner
{
    public void Tune(HttpContext httpContext, object serviceInstance, SoapCore.ServiceModel.OperationDescription operation, Message message)
    {
        if (operation.HeaderType is null)
            return;

        var service = (serviceInstance as MyService)!;

        var headerName = operation.HeaderType.Name;
        var contractNamespace = operation.Contract.Namespace;

        var headerIndex = message.Headers.FindHeader(headerName, contractNamespace);
        if (headerIndex < 0) 
            return;

        var header = message.Headers[headerIndex].ToString();
        if (string.IsNullOrEmpty(header))
            return;

        var xml = new XmlDocument();
        xml.LoadXml(header);
        if(xml.DocumentElement == null)
            return;

        using var nodeReader = new XmlNodeReader(xml.DocumentElement);
        var serializer = CachedXmlSerializer.GetXmlSerializer(operation.HeaderType, headerName, contractNamespace);

        var deserializedHeader = serializer.Deserialize(nodeReader);
        if (deserializedHeader is AuthenticationContext authHeader)
            service.AuthenticationContextHeader = authHeader;
    }
}
```