### PR TITLE
Add XmlIncludeAttribute support when generating wsdl.

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/IXmlIncludeService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IXmlIncludeService.cs
@@ -1,0 +1,40 @@
+using System;
+using System.ServiceModel;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	internal interface IXmlIncludeService
+	{
+		[XmlInclude(typeof(XmlIncludeService.Dog))]
+		[XmlInclude(typeof(XmlIncludeService.Cat))]
+		[OperationContract]
+		XmlIncludeService.Animal Test(XmlIncludeService.Animal value);
+	}
+
+	public class XmlIncludeService : IXmlIncludeService
+	{
+		public Animal Test(Animal value)
+		{
+			return value;
+		}
+
+		[Serializable]
+		[XmlInclude(typeof(Dog))]
+		[XmlInclude(typeof(Cat))]
+		public class Animal
+		{
+		}
+
+		[Serializable]
+		public class Dog : Animal
+		{
+		}
+
+		[Serializable]
+		public class Cat : Animal
+		{
+		}
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -183,6 +183,27 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[TestMethod]
+		public void CheckXmlIncludeTypesASMX()
+		{
+			StartService(typeof(XmlIncludeService));
+			var wsdl = GetWsdlFromAsmx();
+			StopServer();
+
+			var root = XElement.Parse(wsdl);
+			var dogElement = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value.Equals("Dog") == true);
+			Assert.IsNotNull(dogElement);
+
+			var catElement = GetElements(root, _xmlSchema + "complexType").SingleOrDefault(a => a.Attribute("name")?.Value.Equals("Cat") == true);
+			Assert.IsNotNull(dogElement);
+
+			var animalElement = GetElements(dogElement, _xmlSchema + "extension").SingleOrDefault(a => a.Attribute("base")?.Value.Equals("tns:Animal") == true);
+			Assert.IsNotNull(animalElement);
+
+			animalElement = GetElements(catElement, _xmlSchema + "extension").SingleOrDefault(a => a.Attribute("base")?.Value.Equals("tns:Animal") == true);
+			Assert.IsNotNull(animalElement);
+		}
+
+		[TestMethod]
 		public void CheckEmptyMembersServiceASMX()
 		{
 			//This did not work without fixing the MetaBodyWriter

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -307,6 +307,12 @@ namespace SoapCore.Meta
 			{
 				bool hasWrittenOutParameters = false;
 
+				Type[] additionalTypesForOperation = GetKnownTypesFromMethod(operation.DispatchMethod);
+				foreach (Type additionalTypeForOperation in additionalTypesForOperation)
+				{
+					_complexTypeToBuild.Enqueue(new TypeToBuild(additionalTypeForOperation));
+				}
+
 				// input parameters of operation
 				writer.WriteStartElement("element", Namespaces.XMLNS_XSD);
 				writer.WriteAttributeString("name", GetOuterInputElementName(operation));
@@ -533,6 +539,22 @@ namespace SoapCore.Meta
 			}
 
 			writer.WriteEndElement(); // wsdl:types
+		}
+
+		private Type[] GetKnownTypesFromMethod(MethodInfo methodInfo)
+		{
+			List<Type> includeTypes = new();
+
+			if (methodInfo != null)
+			{
+				object[] customAttributes = methodInfo.GetCustomAttributes(typeof(XmlIncludeAttribute), true);
+				foreach (XmlIncludeAttribute attribute in customAttributes)
+				{
+					includeTypes.Add(attribute.Type);
+				}
+			}
+
+			return includeTypes.ToArray();
 		}
 
 		private void AddMessage(XmlDictionaryWriter writer)

--- a/src/SoapCore/ServiceBodyWriter.cs
+++ b/src/SoapCore/ServiceBodyWriter.cs
@@ -189,8 +189,6 @@ namespace SoapCore
 					}
 					else
 					{
-						var serializer = CachedXmlSerializer.GetXmlSerializer(resultType, xmlName, xmlNs);
-
 						if (_result is Stream)
 						{
 							writer.WriteStartElement(_resultName, _serviceNamespace);
@@ -222,6 +220,7 @@ namespace SoapCore
 							}
 							else
 							{
+								var serializer = CachedXmlSerializer.GetXmlSerializer(resultType, xmlName, xmlNs);
 								//https://github.com/DigDes/SoapCore/issues/719
 								serializer.Serialize(writer, _result);
 							}


### PR DESCRIPTION
Added XmlIncludeAttribute support when generating wsdl, so that all types specified in the attribute in the method declaration are present in the wsdl.