### PR TITLE
Fix WSDL for list of anonymous type

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/ComplexTypeAnonymous.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ComplexTypeAnonymous.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[XmlType(AnonymousType = true)]
+	public class ComplexTypeAnonymous
+	{
+		public int IntProperty { get; set; }
+		[XmlElement(ElementName = "stringprop")]
+		public string StringProperty { get; set; }
+		[XmlElement(ElementName = "mybytes")]
+		public byte[] ByteArrayProperty { get; set; }
+
+		public Guid MyGuid { get; set; }
+
+		public List<string> StringList { get; set; }
+
+		public List<int> IntList { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/IComplexAnonymousListService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IComplexAnonymousListService.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface IComplexAnonymousListService
+	{
+		[OperationContract]
+		List<ComplexTypeAnonymous> Test();
+	}
+
+	public class ComplexAnonymousListService : IComplexAnonymousListService
+	{
+		public List<ComplexTypeAnonymous> Test() => throw new NotImplementedException();
+	}
+}

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -1240,6 +1240,11 @@ namespace SoapCore.Meta
 				}
 				else if (toBuild.IsAnonumous)
 				{
+					if (string.IsNullOrEmpty(name))
+					{
+						name = typeName;
+					}
+
 					writer.WriteAttributeString("name", name);
 					WriteQualification(writer, isUnqualified);
 					AddSchemaComplexType(writer, newTypeToBuild);


### PR DESCRIPTION
If your operation contract returns a list of an anonymous type, currently that type gets generated without a name, which results in an invalid WSDL.
An example how it looks like without this fix:
```XML
<xsd:complexType name="ArrayOfComplexTypeAnonymous">
  <xsd:sequence>
    <xsd:element minOccurs="0" maxOccurs="unbounded" nillable="true" name="">
```
I basically copied the code from the case where the type is not anonymous: If no name is given, take the type's name.