### PR TITLE
Fix conflicting variable name in AddSoapMessageProcessor() example

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ services.AddSoapMessageProcessor(async (message, httpcontext, next) =>
 
 	//now you can inspect and modify the content at will.
 	//if you want to pass on the original message, use bufferedMessage.CreateMessage(); otherwise use one of the overloads of Message.CreateMessage() to create a new message
-	var message = bufferedMessage.CreateMessage();
+	var originalMessage = bufferedMessage.CreateMessage();
 
 	//pass the modified message on to the rest of the pipe.
 	var responseMessage = await next(message);


### PR DESCRIPTION
If you copy and paste the `AddSoapMessageProcessor()` example, the declaration of a `message` variable within the method conflicts with the `message` parameter. I have renamed the second instance to `originalMessage`.