### PR TITLE
Allows for large files to be processed

### DIFF
--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -3,11 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.IO.Pipelines;
-using System.Linq;
 using System.Net.Http.Headers;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
@@ -15,6 +13,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace SoapCore.MessageEncoder
 {
@@ -137,9 +136,18 @@ namespace SoapCore.MessageEncoder
 				throw new ArgumentNullException(nameof(stream));
 			}
 
-			var ms = new MemoryStream();
-			await stream.CopyToAsync(ms);
-			ms.Seek(0, SeekOrigin.Begin);
+			Stream ms;
+			if (stream is FileBufferingReadStream)
+			{
+				ms = stream;
+			}
+			else
+			{
+				ms = new MemoryStream();
+				await stream.CopyToAsync(ms);
+				ms.Seek(0, SeekOrigin.Begin);
+			}
+
 			XmlReader reader;
 
 			var readEncoding = SoapMessageEncoderDefaults.ContentTypeToEncoding(contentType);

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -246,9 +246,15 @@ namespace SoapCore
 					}
 				}
 			}
+
 #if !NETCOREAPP3_0_OR_GREATER
 			return await messageEncoder.ReadMessageAsync(httpContext.Request.Body, messageEncoder.MaxSoapHeaderSize, httpContext.Request.ContentType);
 #else
+			if (httpContext.Request.Body is FileBufferingReadStream)
+			{
+				return await messageEncoder.ReadMessageAsync(httpContext.Request.Body, messageEncoder.MaxSoapHeaderSize, httpContext.Request.ContentType);
+			}
+
 			return await messageEncoder.ReadMessageAsync(httpContext.Request.BodyReader, messageEncoder.MaxSoapHeaderSize, httpContext.Request.ContentType);
 #endif
 		}


### PR DESCRIPTION
Checks if the body of the request is a `FileBufferingReadStream` and, if so, uses that instead of using a `MemoryStream`. A `FileBufferingReadStream` is used when `Request.EnableBuffering()` is called. It caches to disk if the stream is large. By using this instead of a `MemoryStream`, an `OutOfMemoryException` can be avoided when processing a very large request.