### PR TITLE
Fix SOAP 1.1 fault serialization

### DIFF
--- a/src/SoapCore.Tests/CustomMessageFault.cs
+++ b/src/SoapCore.Tests/CustomMessageFault.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace SoapCore.Tests
+{
+	internal class CustomMessageFault : MessageFault
+	{
+		private readonly string _reason;
+		private readonly string _actor;
+
+		public CustomMessageFault(string reason, string actor)
+		{
+			_reason = reason;
+			_actor = actor;
+		}
+
+		public override FaultCode Code => new FaultCode("Client");
+
+		public override bool HasDetail => false;
+
+		public override FaultReason Reason => new FaultReason(_reason);
+
+		public override string Actor => _actor;
+
+		protected override void OnWriteDetailContents(XmlDictionaryWriter writer)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}

--- a/src/SoapCore.Tests/ITestService.cs
+++ b/src/SoapCore.Tests/ITestService.cs
@@ -64,6 +64,9 @@ namespace SoapCore.Tests
 		void ThrowDetailedFault(string detailMessage);
 
 		[OperationContract]
+		void ThrowMessageFaultWithActor(string actor);
+
+		[OperationContract]
 		[ServiceFilter(typeof(ActionFilter.TestActionFilter))]
 		ComplexModelInput ComplexParamWithActionFilter(ComplexModelInput test);
 

--- a/src/SoapCore.Tests/IntegrationTests.cs
+++ b/src/SoapCore.Tests/IntegrationTests.cs
@@ -321,6 +321,20 @@ namespace SoapCore.Tests
 		}
 
 		[TestMethod]
+		public void ThrowsMessageFaultWithActor()
+		{
+			var client = CreateClient();
+			var e = Assert.ThrowsException<FaultException>(() =>
+			{
+				client.ThrowMessageFaultWithActor("actor");
+			});
+
+			var messageFault = e.CreateMessageFault();
+			Assert.IsNotNull(messageFault);
+			Assert.AreEqual("actor", messageFault.Actor);
+		}
+
+		[TestMethod]
 		public void EmptyBody()
 		{
 			var client = CreateClientASMX();

--- a/src/SoapCore.Tests/TestService.cs
+++ b/src/SoapCore.Tests/TestService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ServiceModel;
+using System.ServiceModel.Channels;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -61,6 +62,12 @@ namespace SoapCore.Tests
 		public void ThrowDetailedFault(string detailMessage)
 		{
 			throw new FaultException<FaultDetail>(new FaultDetail { ExceptionProperty = detailMessage }, new FaultReason("test"), new FaultCode("test"), "test");
+		}
+
+		public void ThrowMessageFaultWithActor(string actor)
+		{
+			var messageFault = new CustomMessageFault("reason", actor);
+			throw new FaultException(messageFault, "action");
 		}
 
 		public string Overload(double d)
@@ -139,19 +146,19 @@ namespace SoapCore.Tests
 			switch (input)
 			{
 				case ComplexInheritanceModelInputB _:
-					{
-						return new ComplexInheritanceModelInputB();
-					}
+				{
+					return new ComplexInheritanceModelInputB();
+				}
 
 				case ComplexInheritanceModelInputA _:
-					{
-						return new ComplexInheritanceModelInputA();
-					}
+				{
+					return new ComplexInheritanceModelInputA();
+				}
 
 				default:
-					{
-						throw new NotImplementedException();
-					}
+				{
+					throw new NotImplementedException();
+				}
 			}
 		}
 

--- a/src/SoapCore/FaultBodyWriter.cs
+++ b/src/SoapCore/FaultBodyWriter.cs
@@ -107,6 +107,7 @@ namespace SoapCore
 				</s:Body>
 			</s:Envelope>
 			*/
+			var actor = default(string);
 			if (_exception is FaultException)
 			{
 				var faultException = (FaultException)_exception;
@@ -126,11 +127,7 @@ namespace SoapCore
 					writer.WriteElementString("faultcode", "s:Client");
 				}
 
-				var actor = faultException.CreateMessageFault()?.Actor;
-				if (!string.IsNullOrWhiteSpace(actor))
-                {
-                    writer.WriteElementString ("faultactor", actor);
-                }
+				actor = faultException.CreateMessageFault()?.Actor;
 			}
 			else
 			{
@@ -138,6 +135,11 @@ namespace SoapCore
 			}
 
 			writer.WriteElementString("faultstring", faultString);
+
+			if (!string.IsNullOrWhiteSpace(actor))
+			{
+				writer.WriteElementString("faultactor", actor);
+			}
 
 			if (faultDetail != null)
 			{


### PR DESCRIPTION
The SOAP Fault element (in SOAP 1.1) requires that `faultactor` is inserted after `faultstring`, otherwise the SOAP message is invalid (https://schemas.xmlsoap.org/soap/envelope/).

This patch:
- Moves `faultactor` subelement after `faultstring`
- Adds a test to verify that the `Actor` property of the `MessageFault` contained in the catched `FaultException` is correctly populated.