### PR TITLE
Call BeforeSendReply even when the service throws an exception

### DIFF
--- a/src/SoapCore.Tests/MessageInspectors/InspectorStyle.cs
+++ b/src/SoapCore.Tests/MessageInspectors/InspectorStyle.cs
@@ -3,6 +3,7 @@ namespace SoapCore.Tests.MessageInspectors
 	public enum InspectorStyle
 	{
 		MessageInspector,
-		MessageInspector2
+		MessageInspector2,
+		MessageInspector2NoException,
 	}
 }

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector2/MessageInspector2Mock.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector2/MessageInspector2Mock.cs
@@ -34,7 +34,7 @@ namespace SoapCore.Tests.MessageInspectors.MessageInspector2
 			BeforeSendReplyCalled = true;
 		}
 
-		private void ValidateMessage(ref Message message)
+		protected virtual void ValidateMessage(ref Message message)
 		{
 			throw new FaultException(new FaultReason("Message is invalid."), new FaultCode("Sender"), null);
 		}

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector2/MessageInspector2MockNoException.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector2/MessageInspector2MockNoException.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SoapCore.Tests.MessageInspectors.MessageInspector2
+{
+	public class MessageInspector2MockNoException : MessageInspector2Mock
+	{
+		protected override void ValidateMessage(ref Message message)
+		{
+		}
+	}
+}

--- a/src/SoapCore.Tests/MessageInspectors/MessageInspector2/MessageInspector2NoExceptionTests.cs
+++ b/src/SoapCore.Tests/MessageInspectors/MessageInspector2/MessageInspector2NoExceptionTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SoapCore.Tests.MessageInspectors.MessageInspector2
+{
+	[TestClass]
+	public class MessageInspector2NoExceptionTests
+	{
+		[ClassInitialize]
+		public static void StartServer(TestContext testContext)
+		{
+			Task.Run(() =>
+			{
+				var host = new WebHostBuilder()
+					.UseKestrel()
+					.UseUrls("http://localhost:7052")
+					.UseStartup<Startup>()
+					.UseSetting("InspectorStyle", InspectorStyle.MessageInspector2NoException.ToString())
+					.Build();
+
+				host.Run();
+			}).Wait(1000);
+		}
+
+		[TestInitialize]
+		public void Reset()
+		{
+			MessageInspector2Mock.Reset();
+		}
+
+		public ITestService CreateClient()
+		{
+			var binding = new BasicHttpBinding();
+			var endpoint = new EndpointAddress(new Uri(string.Format("http://{0}:7052/Service.svc", "localhost")));
+			var channelFactory = new ChannelFactory<ITestService>(binding, endpoint);
+			var serviceClient = channelFactory.CreateChannel();
+			return serviceClient;
+		}
+
+		[TestMethod]
+		public void AfterReceivedRequestCalled()
+		{
+			Assert.IsFalse(MessageInspector2Mock.AfterReceivedRequestCalled);
+			var client = CreateClient();
+			var result = client.Ping("Hello World");
+			Assert.IsTrue(MessageInspector2Mock.AfterReceivedRequestCalled);
+		}
+
+		[TestMethod]
+		public void BeforeSendReplyCalled()
+		{
+			Assert.IsFalse(MessageInspector2Mock.BeforeSendReplyCalled);
+			var client = CreateClient();
+			var result = client.Ping("Hello World");
+			Assert.IsTrue(MessageInspector2Mock.BeforeSendReplyCalled);
+		}
+
+		[TestMethod]
+		public void BeforeSendReplyCalledEvenIfServiceThrowsException()
+		{
+			Assert.IsFalse(MessageInspector2Mock.BeforeSendReplyCalled);
+			var client = CreateClient();
+			Assert.ThrowsException<FaultException>(client.ThrowException);
+			Assert.IsTrue(MessageInspector2Mock.BeforeSendReplyCalled);
+		}
+	}
+}

--- a/src/SoapCore.Tests/MessageInspectors/Startup.cs
+++ b/src/SoapCore.Tests/MessageInspectors/Startup.cs
@@ -36,6 +36,9 @@ namespace SoapCore.Tests.MessageInspectors
 				case InspectorStyle.MessageInspector2:
 					services.AddSoapMessageInspector(new MessageInspector2Mock());
 					break;
+				case InspectorStyle.MessageInspector2NoException:
+					services.AddSoapMessageInspector(new MessageInspector2MockNoException());
+					break;
 			}
 
 			services.AddMvc();


### PR DESCRIPTION
Add an exception handler in ProcessMessage to call BeforeSendReply even if the service throws an exception.