### PR TITLE
HTTP scheme override in the generated WSDL

### DIFF
--- a/src/SoapCore.Tests/Wsdl/IStartupConfiguration.cs
+++ b/src/SoapCore.Tests/Wsdl/IStartupConfiguration.cs
@@ -7,15 +7,20 @@ namespace SoapCore.Tests.Wsdl
 	public interface IStartupConfiguration
 	{
 		Type ServiceType { get; }
+
+		string SchemeOverride { get; }
 	}
 
 	public class StartupConfiguration : IStartupConfiguration
 	{
-		public StartupConfiguration(Type serviceType)
+		public StartupConfiguration(Type serviceType, string schemeOverride)
 		{
 			ServiceType = serviceType;
+			SchemeOverride = schemeOverride;
 		}
 
 		public Type ServiceType { get; }
+
+		public string SchemeOverride { get; }
 	}
 }

--- a/src/SoapCore.Tests/Wsdl/Startup.cs
+++ b/src/SoapCore.Tests/Wsdl/Startup.cs
@@ -15,9 +15,12 @@ namespace SoapCore.Tests.Wsdl
 	{
 		private readonly Type _serviceType;
 
+		private readonly string _schemeOverride;
+
 		public Startup(IStartupConfiguration configuration)
 		{
 			_serviceType = configuration.ServiceType;
+			_schemeOverride = configuration.SchemeOverride;
 		}
 
 		public void ConfigureServices(IServiceCollection services)
@@ -31,7 +34,19 @@ namespace SoapCore.Tests.Wsdl
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
 			app.UseSoapEndpoint(_serviceType, "/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
-			app.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
+			if (string.IsNullOrEmpty(_schemeOverride))
+			{
+				app.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
+			}
+			else
+			{
+				app.UseSoapEndpoint(_serviceType, soapCoreOptions =>
+				{
+					soapCoreOptions.Path = "/Service.asmx";
+					soapCoreOptions.SoapSerializer = SoapSerializer.XmlSerializer;
+					soapCoreOptions.SchemeOverride = _schemeOverride;
+				});
+			}
 
 			app.UseMvc();
 		}
@@ -43,7 +58,20 @@ namespace SoapCore.Tests.Wsdl
 			app.UseEndpoints(x =>
 			{
 				x.UseSoapEndpoint(_serviceType, "/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
-				x.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
+
+				if (string.IsNullOrEmpty(_schemeOverride))
+				{
+					x.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
+				}
+				else
+				{
+					x.UseSoapEndpoint(_serviceType, soapCoreOptions =>
+					{
+						soapCoreOptions.Path = "/Service.asmx";
+						soapCoreOptions.SoapSerializer = SoapSerializer.XmlSerializer;
+						soapCoreOptions.SchemeOverride = _schemeOverride;
+					});
+				}
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/Wsdl/Startup.cs
+++ b/src/SoapCore.Tests/Wsdl/Startup.cs
@@ -33,20 +33,8 @@ namespace SoapCore.Tests.Wsdl
 #if !NETCOREAPP3_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 		{
-			app.UseSoapEndpoint(_serviceType, "/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
-			if (string.IsNullOrEmpty(_schemeOverride))
-			{
-				app.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
-			}
-			else
-			{
-				app.UseSoapEndpoint(_serviceType, soapCoreOptions =>
-				{
-					soapCoreOptions.Path = "/Service.asmx";
-					soapCoreOptions.SoapSerializer = SoapSerializer.XmlSerializer;
-					soapCoreOptions.SchemeOverride = _schemeOverride;
-				});
-			}
+			app.UseSoapEndpoint(_serviceType, "/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer, schemeOverride: _schemeOverride);
+			app.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer, schemeOverride: _schemeOverride);
 
 			app.UseMvc();
 		}
@@ -57,21 +45,8 @@ namespace SoapCore.Tests.Wsdl
 
 			app.UseEndpoints(x =>
 			{
-				x.UseSoapEndpoint(_serviceType, "/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
-
-				if (string.IsNullOrEmpty(_schemeOverride))
-				{
-					x.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer);
-				}
-				else
-				{
-					x.UseSoapEndpoint(_serviceType, soapCoreOptions =>
-					{
-						soapCoreOptions.Path = "/Service.asmx";
-						soapCoreOptions.SoapSerializer = SoapSerializer.XmlSerializer;
-						soapCoreOptions.SchemeOverride = _schemeOverride;
-					});
-				}
+				x.UseSoapEndpoint(_serviceType, "/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer, schemeOverride: _schemeOverride);
+				x.UseSoapEndpoint(_serviceType, "/Service.asmx", new SoapEncoderOptions(), SoapSerializer.XmlSerializer, schemeOverride: _schemeOverride);
 			});
 		}
 #endif

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -1361,6 +1361,21 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(arrayElementType);
 		}
 
+		[TestMethod]
+		public void CheckSchemeOverride()
+		{
+			StartService(typeof(TestService), schemeOverride: "https");
+			var wsdl = GetWsdlFromAsmx();
+			StopServer();
+			Assert.IsNotNull(wsdl);
+
+			var root = XElement.Parse(wsdl);
+			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+
+			var addressElement = GetElements(root, _soapSchema + "address").SingleOrDefault(a => a.Attribute("location")?.Value.StartsWith("https") == true);
+			Assert.IsNotNull(addressElement);
+		}
+
 		[TestCleanup]
 		public void StopServer()
 		{
@@ -1429,12 +1444,12 @@ namespace SoapCore.Tests.Wsdl
 			}
 		}
 
-		private void StartService(Type serviceType)
+		private void StartService(Type serviceType, string schemeOverride = null)
 		{
 			_host = new WebHostBuilder()
 				.UseKestrel()
 				.UseUrls("http://127.0.0.1:0")
-				.ConfigureServices(services => services.AddSingleton<IStartupConfiguration>(new StartupConfiguration(serviceType)))
+				.ConfigureServices(services => services.AddSingleton<IStartupConfiguration>(new StartupConfiguration(serviceType, schemeOverride)))
 				.UseStartup<Startup>()
 				.Build();
 

--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -132,7 +132,6 @@ namespace SoapCore
 
 		public WsdlFileOptions WsdlFileOptions { get; set; }
 
-
 		/// <summary>
 		/// Get or sets a value indicating the use of custom serializer, use for if multiple custom serializer used to services
 		/// </summary>
@@ -156,6 +155,13 @@ namespace SoapCore
 		/// Default is true.
 		/// </summary>
 		public bool NormalizeNewLines { get; set; } = true;
+
+		/// <summary>
+		/// Can be used to override the HTTP Scheme in the generated service description. This can be useful
+		/// if you are behind a firewall and the firewall sets the X-Forwarded-Host header, but the
+		/// internal HTTP scheme is not the same as the external.
+		/// </summary>
+		public string SchemeOverride { get; set; }
 
 		public void UseCustomSerializer<TCustomSerializer>()
 			where TCustomSerializer : class, IXmlSerializationHandler

--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -18,23 +18,23 @@ namespace SoapCore
 {
 	public static class SoapEndpointExtensions
 	{
-		public static IApplicationBuilder UseSoapEndpoint<T>(this IApplicationBuilder builder, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IApplicationBuilder UseSoapEndpoint<T>(this IApplicationBuilder builder, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
 		{
-			return builder.UseSoapEndpoint<CustomMessage>(typeof(T), path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
+			return builder.UseSoapEndpoint<CustomMessage>(typeof(T), path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration, schemeOverride);
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint<T, T_MESSAGE>(this IApplicationBuilder builder, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IApplicationBuilder UseSoapEndpoint<T, T_MESSAGE>(this IApplicationBuilder builder, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
 			where T_MESSAGE : CustomMessage, new()
 		{
-			return builder.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
+			return builder.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration, schemeOverride);
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IApplicationBuilder UseSoapEndpoint(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
 		{
-			return builder.UseSoapEndpoint<CustomMessage>(type, path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
+			return builder.UseSoapEndpoint<CustomMessage>(type, path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration, schemeOverride);
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint<T_MESSAGE>(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IApplicationBuilder UseSoapEndpoint<T_MESSAGE>(this IApplicationBuilder builder, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
 			where T_MESSAGE : CustomMessage, new()
 		{
 			return builder.UseSoapEndpoint<T_MESSAGE>(type, options =>
@@ -47,6 +47,7 @@ namespace SoapCore
 				options.IndentXml = indentXml;
 				options.OmitXmlDeclaration = omitXmlDeclaration;
 				options.WsdlFileOptions = wsdlFileOptions;
+				options.SchemeOverride = schemeOverride;
 			});
 		}
 
@@ -76,12 +77,12 @@ namespace SoapCore
 			return builder.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, binding, serializer, caseInsensitivePath, soapModelBounder, null, indentXml, omitXmlDeclaration);
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint<T>(this IApplicationBuilder builder, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IApplicationBuilder UseSoapEndpoint<T>(this IApplicationBuilder builder, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
 		{
-			return builder.UseSoapEndpoint<T, CustomMessage>(path, encoders, serializer, caseInsensitivePath, soapModelBounder, indentXml, omitXmlDeclaration);
+			return builder.UseSoapEndpoint<T, CustomMessage>(path, encoders, serializer, caseInsensitivePath, soapModelBounder, indentXml, omitXmlDeclaration, schemeOverride);
 		}
 
-		public static IApplicationBuilder UseSoapEndpoint<T, T_MESSAGE>(this IApplicationBuilder builder, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IApplicationBuilder UseSoapEndpoint<T, T_MESSAGE>(this IApplicationBuilder builder, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
 			where T_MESSAGE : CustomMessage, new()
 		{
 			return builder.UseSoapEndpoint<T_MESSAGE>(typeof(T), options =>
@@ -93,6 +94,7 @@ namespace SoapCore
 				options.SoapModelBounder = soapModelBounder;
 				options.IndentXml = indentXml;
 				options.OmitXmlDeclaration = omitXmlDeclaration;
+				options.SchemeOverride = schemeOverride;
 			});
 		}
 
@@ -172,23 +174,23 @@ namespace SoapCore
 		}
 
 #if NETCOREAPP3_0_OR_GREATER
-		public static IEndpointConventionBuilder UseSoapEndpoint<T>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IEndpointConventionBuilder UseSoapEndpoint<T>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
 		{
-			return routes.UseSoapEndpoint<T, CustomMessage>(path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
+			return routes.UseSoapEndpoint<T, CustomMessage>(path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration, schemeOverride);
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
 			where T_MESSAGE : CustomMessage, new()
 		{
-			return routes.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
+			return routes.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration, schemeOverride);
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IEndpointConventionBuilder UseSoapEndpoint(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
 		{
-			return routes.UseSoapEndpoint<CustomMessage>(type, path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
+			return routes.UseSoapEndpoint<CustomMessage>(type, path, encoder, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration, schemeOverride);
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint<T_MESSAGE>(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IEndpointConventionBuilder UseSoapEndpoint<T_MESSAGE>(this IEndpointRouteBuilder routes, Type type, string path, SoapEncoderOptions encoder, SoapSerializer serializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
 			where T_MESSAGE : CustomMessage, new()
 		{
 			return routes.UseSoapEndpoint<T_MESSAGE>(type, options =>
@@ -201,6 +203,7 @@ namespace SoapCore
 				options.WsdlFileOptions = wsdlFileOptions;
 				options.IndentXml = indentXml;
 				options.OmitXmlDeclaration = omitXmlDeclaration;
+				options.SchemeOverride = schemeOverride;
 			});
 		}
 
@@ -241,18 +244,18 @@ namespace SoapCore
 			return routes.UseSoapEndpoint<T_MESSAGE>(typeof(T), path, binding, serializer, caseInsensitivePath, soapModelBounder, null, indentXml, omitXmlDeclaration);
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint<T>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IEndpointConventionBuilder UseSoapEndpoint<T>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
 		{
-			return routes.UseSoapEndpoint<T, CustomMessage>(path, encoders, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration);
+			return routes.UseSoapEndpoint<T, CustomMessage>(path, encoders, serializer, caseInsensitivePath, soapModelBounder, wsdlFileOptions, indentXml, omitXmlDeclaration, schemeOverride);
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
 			where T_MESSAGE : CustomMessage, new()
 		{
-			return routes.UseSoapEndpoint<T, T_MESSAGE>(path, encoders, serializer, caseInsensitivePath, soapModelBounder, null, indentXml, omitXmlDeclaration);
+			return routes.UseSoapEndpoint<T, T_MESSAGE>(path, encoders, serializer, caseInsensitivePath, soapModelBounder, null, indentXml, omitXmlDeclaration, schemeOverride);
 		}
 
-		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true)
+		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
 		where T_MESSAGE : CustomMessage, new()
 		{
 			return routes.UseSoapEndpoint<T, T_MESSAGE>(opt =>
@@ -265,6 +268,7 @@ namespace SoapCore
 				opt.WsdlFileOptions = wsdlFileOptions;
 				opt.IndentXml = indentXml;
 				opt.OmitXmlDeclaration = omitXmlDeclaration;
+				opt.SchemeOverride = schemeOverride;
 			});
 		}
 
@@ -454,7 +458,6 @@ namespace SoapCore
 			serviceCollection.Add(new ServiceDescriptor(typeof(ISoapMessageProcessor), typeof(TProcessor), lifetime));
 			return serviceCollection;
 		}
-
 
 		public static IServiceCollection AddCustomSoapMessageSerializer(this IServiceCollection serviceCollection, IXmlSerializationHandler messageSerializer)
 		{

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -1,18 +1,3 @@
-using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
-using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
-using SoapCore.DocumentationWriter;
-using SoapCore.Extensibility;
-using SoapCore.MessageEncoder;
-using SoapCore.Meta;
-using SoapCore.Serializer;
-using SoapCore.ServiceModel;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -28,6 +13,22 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Threading.Tasks;
 using System.Xml;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using SoapCore.DocumentationWriter;
+using SoapCore.Extensibility;
+using SoapCore.MessageEncoder;
+using SoapCore.Meta;
+using SoapCore.Serializer;
+using SoapCore.ServiceModel;
 
 namespace SoapCore
 {
@@ -261,7 +262,8 @@ namespace SoapCore
 
 		private async Task ProcessMeta(HttpContext httpContext, bool showDocumentation)
 		{
-			var baseUrl = httpContext.Request.Scheme + "://" + httpContext.Request.Host + httpContext.Request.PathBase + httpContext.Request.Path;
+			var scheme = string.IsNullOrEmpty(_options.SchemeOverride) ? httpContext.Request.Scheme : _options.SchemeOverride;
+			var baseUrl = scheme + "://" + httpContext.Request.Host + httpContext.Request.PathBase + httpContext.Request.Path;
 			var xmlNamespaceManager = GetXmlNamespaceManager(null);
 			var bindingName = !string.IsNullOrWhiteSpace(_options.EncoderOptions[0].BindingName) ? _options.EncoderOptions[0].BindingName : "BasicHttpBinding_" + _service.GeneralContract.Name;
 			var bodyWriter = _options.SoapSerializer == SoapSerializer.XmlSerializer
@@ -292,6 +294,7 @@ namespace SoapCore
 				{
 					httpContext.Response.ContentLength = documentation.Length;
 				}
+
 				await httpContext.Response.WriteAsync(documentation);
 
 				return;
@@ -463,7 +466,6 @@ namespace SoapCore
 			XmlWriter writer = XmlWriter.Create(ms, new XmlWriterSettings
 			{
 				Encoding = DefaultEncodings.UTF8,
-
 			});
 			XmlDictionaryWriter dictionaryWriter = XmlDictionaryWriter.CreateDictionaryWriter(writer);
 

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.ServiceModel.Channels;
 using System.Xml;
-using SoapCore.ServiceModel;
 using SoapCore.Extensibility;
 using SoapCore.Meta;
+using SoapCore.ServiceModel;
 
 namespace SoapCore
 {
@@ -78,6 +78,8 @@ namespace SoapCore
 		public bool NormalizeNewLines { get; set; } = true;
 		public IWsdlOperationNameGenerator WsdlOperationNameGenerator { get; set; } = new DefaultWsdlOperationNameGenerator();
 
+		public string SchemeOverride { get; set; }
+
 		[Obsolete]
 		public static SoapOptions FromSoapCoreOptions<T>(SoapCoreOptions opt)
 		{
@@ -111,6 +113,7 @@ namespace SoapCore
 				UseMicrosoftGuid = opt.UseMicrosoftGuid,
 				GenerateSoapActionWithoutContractName = opt.GenerateSoapActionWithoutContractName,
 				NormalizeNewLines = opt.NormalizeNewLines,
+				SchemeOverride = opt.SchemeOverride,
 			};
 
 #pragma warning disable CS0612 // Type or member is obsolete


### PR DESCRIPTION
Add an option to override the HTTP scheme in the `soap:address` element of the generated WSDL.