### PR TITLE
Reduce and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Support ref\out params, exceptions. Works with legacy SOAP\WCF-clients.
 
 The following frameworks are supported:
 
-- .NET 5.0-7.0 (using ASP.NET Core 5.0-7.0)
+- .NET 8.0 (using ASP.NET Core 8.0)
 - .NET Core 3.1 (using ASP.NET Core 3.1)
 - .NET Standard 2.0-2.1 (using ASP.NET Core 2.1)
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<!-- https://github.com/dotnet/reproducible-builds -->
-		<PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All"/>
+		<PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All"/>
 	</ItemGroup>
 
 </Project>

--- a/src/SoapCore.Benchmark/Program.cs
+++ b/src/SoapCore.Benchmark/Program.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 namespace SoapCore.Benchmark
 {
 	[MemoryDiagnoser]
-	[SimpleJob(targetCount: 5)]
+	[SimpleJob(iterationCount: 5)]
 	public class EchoBench
 	{
 		// 0 measures overhead of creating host

--- a/src/SoapCore.Benchmark/SoapCore.Benchmark.csproj
+++ b/src/SoapCore.Benchmark/SoapCore.Benchmark.csproj
@@ -10,10 +10,10 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.32" />
 	</ItemGroup>
 	<ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.13" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SoapCore.Benchmark/SoapCore.Benchmark.csproj
+++ b/src/SoapCore.Benchmark/SoapCore.Benchmark.csproj
@@ -17,7 +17,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SoapCore.Tests/NativeAuthenticationAndAuthorization/NativeAuthenticationAndAuthorizationTests.cs
+++ b/src/SoapCore.Tests/NativeAuthenticationAndAuthorization/NativeAuthenticationAndAuthorizationTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.ServiceModel;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.IdentityModel.Tokens;
@@ -89,6 +91,7 @@ namespace SoapCore.Tests.NativeAuthenticationAndAuthorization
 		[TestMethod]
 		public void CheckNoAuthenticationProvidedAndAuthenticationRequired()
 		{
+			UseEnglishUICulture();
 			var inputModel = new ComplexModelInput
 			{
 				StringProperty = "string property test value",
@@ -132,6 +135,7 @@ namespace SoapCore.Tests.NativeAuthenticationAndAuthorization
 		[TestMethod]
 		public void CheckNoAuthenticationProvidedAndRoleAuthorizationRequired()
 		{
+			UseEnglishUICulture();
 			var inputModel = new ComplexModelInput
 			{
 				StringProperty = "string property test value",
@@ -154,6 +158,7 @@ namespace SoapCore.Tests.NativeAuthenticationAndAuthorization
 		[TestMethod]
 		public void CheckWrongRoleProvidedAndRoleAuthorizationRequired()
 		{
+			UseEnglishUICulture();
 			var inputModel = new ComplexModelInput
 			{
 				StringProperty = "string property test value",
@@ -202,6 +207,7 @@ namespace SoapCore.Tests.NativeAuthenticationAndAuthorization
 		[TestMethod]
 		public void CheckNoAuthenticationProvidedAndPolicyAuthorizationRequired()
 		{
+			UseEnglishUICulture();
 			var inputModel = new ComplexModelInput
 			{
 				StringProperty = "string property test value",
@@ -224,6 +230,7 @@ namespace SoapCore.Tests.NativeAuthenticationAndAuthorization
 		[TestMethod]
 		public void CheckWrongClaimsProvidedAndPolicyAuthorizationRequired()
 		{
+			UseEnglishUICulture();
 			var inputModel = new ComplexModelInput
 			{
 				StringProperty = "string property test value",
@@ -373,6 +380,11 @@ namespace SoapCore.Tests.NativeAuthenticationAndAuthorization
 			var result = client.JwtAuthenticationAndAuthorizationComplexGenericActionResult(inputModel);
 			Assert.IsNotNull(result);
 			Assert.AreEqual(result.StringProperty, "Number is even.");
+		}
+
+		private static void UseEnglishUICulture()
+		{
+			Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
 		}
 
 		private string GenerateToken(List<Claim> claims)

--- a/src/SoapCore.Tests/SoapCore.Tests.csproj
+++ b/src/SoapCore.Tests/SoapCore.Tests.csproj
@@ -17,28 +17,28 @@
 		<AdditionalFiles Include="stylecop.json" />
 	</ItemGroup>
 	<ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.13" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.13" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="DeepEqual.SuperJMN" Version="2.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Moq" Version="4.20.70" />
-		<PackageReference Include="Shouldly" Version="4.2.1" />
-		<PackageReference Include="xunit" Version="2.6.6" />
-		<PackageReference Include="xunit.runner.console" Version="2.6.6">
+		<PackageReference Include="Moq" Version="4.20.72" />
+		<PackageReference Include="Shouldly" Version="4.3.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.console" Version="2.9.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/SoapCore.Tests/SoapCore.Tests.csproj
+++ b/src/SoapCore.Tests/SoapCore.Tests.csproj
@@ -24,7 +24,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="DeepEqual.SuperJMN" Version="2.0.0" />
-		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
 		<PackageReference Include="MSTest.TestFramework" Version="3.1.1" />

--- a/src/SoapCore/DocumentationWriter/SoapMethods.cs
+++ b/src/SoapCore/DocumentationWriter/SoapMethods.cs
@@ -1,9 +1,6 @@
-#if !NETCOREAPP3_1_OR_GREATER
-using Newtonsoft.Json;
-#endif
 using System.IO;
 using System.Linq;
-using System.Text;
+using System.Text.Json;
 using System.Xml;
 using System.Xml.Serialization;
 
@@ -60,11 +57,7 @@ namespace SoapCore.DocumentationWriter
 
 		public string GenerateDocumentation()
 		{
-#if NETCOREAPP3_1_OR_GREATER
-			var json = System.Text.Json.JsonSerializer.Serialize(this);
-#else
-			var json = JsonConvert.SerializeObject(this);
-#endif
+			var json = JsonSerializer.Serialize(this);
 
 			var html = $@"<!DOCTYPE html>
 <html lang=""en"">

--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -60,7 +60,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Drawing.Common" Version="8.0.2" />
 		<PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -29,7 +29,6 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'netstandard2.1'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.38" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
@@ -39,6 +38,7 @@
 		<PackageReference Include="System.ServiceModel.Http" Version="4.8.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.1.3" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.38" />
+		<PackageReference Include="System.Text.Json" Version="9.0.2" />
 	</ItemGroup>
 	<ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -29,27 +29,21 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'netstandard2.1'">
-		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.38" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-		<PackageReference Include="System.IO.Pipelines" Version="4.7.0" />
-		<PackageReference Include="System.CodeDom" Version="4.7.0" />
-		<PackageReference Include="System.ServiceModel.Http" Version="4.8.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.1.3" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.38" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
+		<PackageReference Include="System.CodeDom" Version="9.0.2" />
+		<PackageReference Include="System.ServiceModel.Http" Version="8.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="9.0.2" />
 		<PackageReference Include="System.Text.Json" Version="9.0.2" />
 	</ItemGroup>
 	<ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 		<PackageReference Include="System.CodeDom" Version="4.7.0" />
-		<PackageReference Include="System.ServiceModel.Http" Version="4.8.1" />
+		<PackageReference Include="System.ServiceModel.Http" Version="4.10.3" />
 	</ItemGroup>
 	<ItemGroup Condition="$(TargetFramework) == 'net8.0'">
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="8.0.2" />
-		<PackageReference Include="System.CodeDom" Version="8.0.0" />
-		<PackageReference Include="System.ServiceModel.Http" Version="8.0.0" />
+		<PackageReference Include="System.CodeDom" Version="9.0.2" />
+		<PackageReference Include="System.ServiceModel.Http" Version="8.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -60,12 +54,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
With the last update of SoapCore 1.2.0 some dependencies were added that are not really necessary and were removed in previous versions (e.g. `System.Drawing.Common`).

- I have reduced the dependencies to the essentials and updated them.
- I have also replaced the dependency on `Newtonsoft.Json` with `System.Text.Json`.
- The tests failed for me due to the localization, because the tests are dependent on the text. I have therefore set the `CurrentUICulture ` for the relevant tests.
- In the readme it was listed that .NET 5.0 to 7.0 is supported, which is currently only the case with netstandard2.1. I have therefore updated this to .NET 8.0.