### PR TITLE
Implement custom message class

### DIFF
--- a/src/SoapCore.Benchmark/Program.cs
+++ b/src/SoapCore.Benchmark/Program.cs
@@ -12,6 +12,7 @@ using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Diagnosers;
 using Microsoft.Extensions.Logging;
 using BenchmarkDotNet.Jobs;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace SoapCore.Benchmark
 {
@@ -81,9 +82,26 @@ namespace SoapCore.Benchmark
 	}
 	class Program
 	{
-		static void Main()
+		static async Task Main()
 		{
 			BenchmarkRunner.Run<EchoBench>();
+
+			//var eb = new EchoBench();
+			//eb.Setup();
+			//eb.LoopNum = 100_000;
+
+			//Console.WriteLine("Klicka");
+			//Console.ReadKey();
+			
+
+			//Console.WriteLine("Running...");
+
+			//await eb.Echo();
+			
+
+			//Console.WriteLine("Klicka igen");
+			//Console.ReadKey();
+			//eb.Cleanup();
 		}
 	}
 }

--- a/src/SoapCore.Benchmark/Program.cs
+++ b/src/SoapCore.Benchmark/Program.cs
@@ -18,7 +18,7 @@ namespace SoapCore.Benchmark
 {
 	[MemoryDiagnoser]
 	[SimpleJob(RuntimeMoniker.Net80, baseline: true, iterationCount: 20)]
-	[SimpleJob(RuntimeMoniker.NetCoreApp31, iterationCount: 20)]
+	//[SimpleJob(RuntimeMoniker.NetCoreApp31, iterationCount: 20)]
 	public class EchoBench
 	{
 		// 0 measures overhead of creating host

--- a/src/SoapCore.Benchmark/Program.cs
+++ b/src/SoapCore.Benchmark/Program.cs
@@ -11,11 +11,13 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Diagnosers;
 using Microsoft.Extensions.Logging;
+using BenchmarkDotNet.Jobs;
 
 namespace SoapCore.Benchmark
 {
 	[MemoryDiagnoser]
-	[SimpleJob(iterationCount: 5)]
+	[SimpleJob(RuntimeMoniker.Net80, baseline: true, iterationCount: 20)]
+	[SimpleJob(RuntimeMoniker.NetCoreApp31, iterationCount: 20)]
 	public class EchoBench
 	{
 		// 0 measures overhead of creating host

--- a/src/SoapCore.Tests/Serialization/MessageHeadersTests.cs
+++ b/src/SoapCore.Tests/Serialization/MessageHeadersTests.cs
@@ -35,7 +35,9 @@ namespace SoapCore.Tests.Serialization
 				Body2 = Guid.NewGuid().ToString()
 			};
 
-			_fixture.ServiceMock.Setup(x => x.GetWithBody(It.IsAny<MessageHeadersModelWithBody>())).Callback((MessageHeadersModelWithBody m) =>
+			_fixture.ServiceMock.Setup(x =>
+			x.GetWithBody(It.IsAny<MessageHeadersModelWithBody>()))
+				.Callback((MessageHeadersModelWithBody m) =>
 			{
 				m.ShouldDeepEqual(model);
 			}).Returns(new MessageHeadersModelWithBody()

--- a/src/SoapCore.Tests/SoapCore.Tests.csproj
+++ b/src/SoapCore.Tests/SoapCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net8.0;</TargetFrameworks>
 		<CodeAnalysisRuleSet>..\SoapCore.ruleset</CodeAnalysisRuleSet>
 		<IsPackable>false</IsPackable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/SoapCore.Tests/SoapCore.Tests.csproj
+++ b/src/SoapCore.Tests/SoapCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;netcoreapp3.1</TargetFrameworks>
 		<CodeAnalysisRuleSet>..\SoapCore.ruleset</CodeAnalysisRuleSet>
 		<IsPackable>false</IsPackable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -20,6 +20,22 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.13" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.13" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.32" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.32" />
+		<PackageReference Include="Microsoft.Identitymodel.JsonWebTokens" Version="8.6.0" />
+		<PackageReference Include="System.Identitymodel.Tokens.Jwt" Version="8.6.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+
 	</ItemGroup>
 
 	<ItemGroup>
@@ -38,10 +54,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-		</PackageReference>
+		<PackageReference Include="System.Formats.Asn1" Version="9.0.2"/>
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SoapCore/Extensibility/AuthorizeOperationMessageProcessor.cs
+++ b/src/SoapCore/Extensibility/AuthorizeOperationMessageProcessor.cs
@@ -45,7 +45,7 @@ namespace SoapCore.Extensibility
 			var soapAction = HeadersHelper.GetSoapAction(httpContext, ref requestMessage);
 			requestMessage.Headers.Action = soapAction.ToString();
 
-			if (soapAction.IsEmpty)
+			if (string.IsNullOrEmpty(soapAction))
 			{
 				throw new ArgumentException("Unable to handle request without a valid action parameter. Please supply a valid soap action.");
 			}
@@ -148,8 +148,10 @@ namespace SoapCore.Extensibility
 			}
 		}
 
-		private static bool TryGetOperation(ReadOnlySpan<char> methodName, Type serviceType, bool generateSoapActionWithoutContractName, out OperationDescription operation)
+		private static bool TryGetOperation(string methodNameStr, Type serviceType, bool generateSoapActionWithoutContractName, out OperationDescription operation)
 		{
+			ReadOnlySpan<char> methodName = methodNameStr.AsSpan();
+
 			var service = new ServiceDescription(serviceType, generateSoapActionWithoutContractName);
 			operation = null;
 			foreach (var o in service.Operations)

--- a/src/SoapCore/Extensibility/AuthorizeOperationMessageProcessor.cs
+++ b/src/SoapCore/Extensibility/AuthorizeOperationMessageProcessor.cs
@@ -152,12 +152,12 @@ namespace SoapCore.Extensibility
 		{
 			var service = new ServiceDescription(serviceType, generateSoapActionWithoutContractName);
 			operation = service.Operations.FirstOrDefault(o => o.SoapAction.Equals(methodName, StringComparison.Ordinal)
-							|| o.Name.Equals(HeadersHelper.GetTrimmedSoapAction(methodName), StringComparison.Ordinal)
-							|| methodName.Equals(HeadersHelper.GetTrimmedSoapAction(o.Name), StringComparison.Ordinal));
+							|| o.Name.AsSpan().Equals(HeadersHelper.GetTrimmedSoapAction(methodName.AsSpan()), StringComparison.Ordinal)
+							|| methodName.AsSpan().Equals(HeadersHelper.GetTrimmedSoapAction(o.Name.AsSpan()), StringComparison.Ordinal));
 
 			operation ??= service.Operations.FirstOrDefault(o =>
-							methodName.Equals(HeadersHelper.GetTrimmedClearedSoapAction(o.SoapAction), StringComparison.Ordinal)
-							|| methodName.Contains(HeadersHelper.GetTrimmedSoapAction(o.Name)));
+							methodName.AsSpan().Equals(HeadersHelper.GetTrimmedClearedSoapAction(o.SoapAction.AsSpan()), StringComparison.Ordinal)
+							|| methodName.AsSpan().IndexOf(HeadersHelper.GetTrimmedSoapAction(o.Name.AsSpan())) >= 0);
 
 			return operation != null;
 		}

--- a/src/SoapCore/Extensibility/AuthorizeOperationMessageProcessor.cs
+++ b/src/SoapCore/Extensibility/AuthorizeOperationMessageProcessor.cs
@@ -43,7 +43,6 @@ namespace SoapCore.Extensibility
 		public async Task<Message> ProcessMessage(Message requestMessage, HttpContext httpContext, Func<Message, Task<Message>> next)
 		{
 			var soapAction = HeadersHelper.GetSoapAction(httpContext, ref requestMessage);
-			requestMessage.Headers.Action = soapAction.ToString();
 
 			if (string.IsNullOrEmpty(soapAction))
 			{

--- a/src/SoapCore/HeadersHelper.cs
+++ b/src/SoapCore/HeadersHelper.cs
@@ -13,7 +13,6 @@ namespace SoapCore
 	{
 		private static readonly char[] ContentTypeSeparators = new[] { ';' };
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static ReadOnlySpan<char> GetSoapAction(HttpContext httpContext, ref Message message)
 		{
 			XmlDictionaryReader reader = null;

--- a/src/SoapCore/HeadersHelper.cs
+++ b/src/SoapCore/HeadersHelper.cs
@@ -15,16 +15,6 @@ namespace SoapCore
 
 		public static ReadOnlySpan<char> GetSoapAction(HttpContext httpContext, ref Message message)
 		{
-			XmlDictionaryReader reader = null;
-			if (!message.IsEmpty)
-			{
-				MessageBuffer mb = message.CreateBufferedCopy(int.MaxValue);
-				Message responseMsg = mb.CreateMessage();
-				message = mb.CreateMessage();
-
-				reader = responseMsg.GetReaderAtBodyContents();
-			}
-
 			var soapAction = httpContext.Request.Headers["SOAPAction"].FirstOrDefault().AsSpan();
 			if (soapAction.Length == 2 && soapAction[0] == '"' && soapAction[1] == '"')
 			{
@@ -167,9 +157,18 @@ namespace SoapCore
 					}
 				}
 
-				if (soapAction.IsEmpty && reader != null)
+				if (soapAction.IsEmpty)
 				{
-					soapAction = reader.LocalName.AsSpan();
+					XmlDictionaryReader reader = null;
+					if (!message.IsEmpty)
+					{
+						MessageBuffer mb = message.CreateBufferedCopy(int.MaxValue);
+						Message responseMsg = mb.CreateMessage();
+						message = mb.CreateMessage();
+
+						reader = responseMsg.GetReaderAtBodyContents();
+						soapAction = reader.LocalName.AsSpan();
+					}
 				}
 			}
 

--- a/src/SoapCore/HeadersHelper.cs
+++ b/src/SoapCore/HeadersHelper.cs
@@ -99,7 +99,7 @@ namespace SoapCore
 				}
 
 				if (soapAction != null &&
-				    (string.IsNullOrEmpty(GetTrimmedSoapAction(soapAction)) || string.IsNullOrEmpty(GetTrimmedClearedSoapAction(soapAction))))
+				    (GetTrimmedSoapAction(soapAction.AsSpan()).Length == 0 || GetTrimmedClearedSoapAction(soapAction.AsSpan()).Length == 0))
 				{
 					soapAction = string.Empty;
 				}
@@ -137,27 +137,27 @@ namespace SoapCore
 			return soapAction;
 		}
 
-		public static string GetTrimmedClearedSoapAction(string inSoapAction)
+		public static ReadOnlySpan<char> GetTrimmedClearedSoapAction(ReadOnlySpan<char> inSoapAction)
 		{
-			string trimmedAction = GetTrimmedSoapAction(inSoapAction);
+			ReadOnlySpan<char> trimmedAction = GetTrimmedSoapAction(inSoapAction);
 
-			if (trimmedAction.EndsWith("Request"))
+			if (trimmedAction.EndsWith("Request".AsSpan()))
 			{
-				int endIndex = trimmedAction.LastIndexOf('R');
-				string clearedAction = trimmedAction.Substring(0, endIndex);
+				var clearedAction = trimmedAction.Slice(0, trimmedAction.Length - 7);
 				return clearedAction;
 			}
 
 			return trimmedAction;
 		}
 
-		public static string GetTrimmedSoapAction(string inSoapAction)
+		public static ReadOnlySpan<char> GetTrimmedSoapAction(ReadOnlySpan<char> inSoapAction)
 		{
-			string soapAction = inSoapAction;
-			if (soapAction.Contains('/'))
+			ReadOnlySpan<char> soapAction = inSoapAction;
+			var lastIndexOfSlash = soapAction.LastIndexOf('/');
+			if (lastIndexOfSlash >= 0)
 			{
 				// soapAction may be a path. Therefore must take the action from the path provided.
-				soapAction = soapAction.Split('/').Last();
+				soapAction = soapAction.Slice(lastIndexOfSlash + 1);
 			}
 
 			return soapAction;

--- a/src/SoapCore/HeadersHelper.cs
+++ b/src/SoapCore/HeadersHelper.cs
@@ -13,7 +13,7 @@ namespace SoapCore
 	{
 		private static readonly char[] ContentTypeSeparators = new[] { ';' };
 
-		public static ReadOnlySpan<char> GetSoapAction(HttpContext httpContext, ref Message message)
+		public static string GetSoapAction(HttpContext httpContext, ref Message message)
 		{
 			var soapAction = httpContext.Request.Headers["SOAPAction"].FirstOrDefault().AsSpan();
 			if (soapAction.Length == 2 && soapAction[0] == '"' && soapAction[1] == '"')
@@ -178,7 +178,7 @@ namespace SoapCore
 				soapAction = soapAction.Trim('"');
 			}
 
-			return soapAction;
+			return soapAction.ToString();
 		}
 
 		public static ReadOnlySpan<char> GetTrimmedClearedSoapAction(ReadOnlySpan<char> inSoapAction)

--- a/src/SoapCore/MemberWithAttribute.cs
+++ b/src/SoapCore/MemberWithAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace SoapCore
+{
+
+	public class MemberWithAttribute<TAttribute>(MemberInfo member, TAttribute attribute)
+		where TAttribute : Attribute
+	{
+		public MemberInfo Member { get; private set; } = member;
+		public TAttribute Attribute { get; private set; } = attribute;
+	}
+}

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -118,7 +118,7 @@ namespace SoapCore.MessageEncoder
 			return false;
 		}
 
-		public async Task<Message> ReadMessageAsync(PipeReader pipeReader, int maxSizeOfHeaders, string contentType)
+		public Message ReadMessage(PipeReader pipeReader, int maxSizeOfHeaders, string contentType)
 		{
 			if (pipeReader == null)
 			{
@@ -126,10 +126,10 @@ namespace SoapCore.MessageEncoder
 			}
 
 			using var stream = pipeReader.AsStream(true);
-			return await ReadMessageAsync(stream, maxSizeOfHeaders, contentType);
+			return ReadMessage(stream, maxSizeOfHeaders, contentType);
 		}
 
-		public async Task<Message> ReadMessageAsync(Stream stream, int maxSizeOfHeaders, string contentType)
+		public Message ReadMessage(Stream stream, int maxSizeOfHeaders, string contentType)
 		{
 			if (stream == null)
 			{

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -152,7 +152,7 @@ namespace SoapCore.MessageEncoder
 			{
 				using (var xdReader = XmlDictionaryReader.CreateTextReader(stream, readEncoding, ReaderQuotas, dictionaryReader => { }))
 				{
-					message = ParsedMessage.FromXmlReaderAsync(xdReader, MessageVersion);
+					message = ParsedMessage.FromXmlReader(xdReader, MessageVersion);
 				}
 			}
 			else
@@ -162,7 +162,7 @@ namespace SoapCore.MessageEncoder
 				var xmlReaderSettings = new XmlReaderSettings() { XmlResolver = null, IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit, CloseInput = true };
 				using (var xReader = XmlReader.Create(streamReaderWithEncoding, xmlReaderSettings))
 				{
-					message = ParsedMessage.FromXmlReaderAsync(xReader, MessageVersion);
+					message = ParsedMessage.FromXmlReader(xReader, MessageVersion);
 				}
 			}
 

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -172,7 +172,8 @@ namespace SoapCore.MessageEncoder
 				reader = XmlReader.Create(streamReaderWithEncoding, xmlReaderSettings);
 			}
 
-			return Message.CreateMessage(reader, maxSizeOfHeaders, MessageVersion);
+			return await ParsedMessage.FromXmlReaderAsync(reader, MessageVersion);
+			//return Message.CreateMessage(reader, MaxSoapHeaderSize, MessageVersion);
 		}
 
 		public virtual async Task WriteMessageAsync(Message message, HttpContext httpContext, PipeWriter pipeWriter, bool indentXml)

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -173,7 +173,7 @@ namespace SoapCore.MessageEncoder
 			}
 
 			return await ParsedMessage.FromXmlReaderAsync(reader, MessageVersion);
-			//return Message.CreateMessage(reader, MaxSoapHeaderSize, MessageVersion);
+//			return Message.CreateMessage(reader, MaxSoapHeaderSize, MessageVersion);
 		}
 
 		public virtual async Task WriteMessageAsync(Message message, HttpContext httpContext, PipeWriter pipeWriter, bool indentXml)

--- a/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
+++ b/src/SoapCore/MessageEncoder/SoapMessageEncoder.cs
@@ -136,19 +136,7 @@ namespace SoapCore.MessageEncoder
 				throw new ArgumentNullException(nameof(stream));
 			}
 
-			Stream ms;
-			if (stream is FileBufferingReadStream)
-			{
-				ms = stream;
-			}
-			else
-			{
-				ms = new MemoryStream();
-				await stream.CopyToAsync(ms);
-				ms.Seek(0, SeekOrigin.Begin);
-			}
-
-			XmlReader reader;
+			Message message;
 
 			var readEncoding = SoapMessageEncoderDefaults.ContentTypeToEncoding(contentType);
 
@@ -162,18 +150,23 @@ namespace SoapCore.MessageEncoder
 
 			if (supportXmlDictionaryReader)
 			{
-				reader = XmlDictionaryReader.CreateTextReader(ms, readEncoding, ReaderQuotas, dictionaryReader => { });
+				using (var xdReader = XmlDictionaryReader.CreateTextReader(stream, readEncoding, ReaderQuotas, dictionaryReader => { }))
+				{
+					message = ParsedMessage.FromXmlReaderAsync(xdReader, MessageVersion);
+				}
 			}
 			else
 			{
-				var streamReaderWithEncoding = new StreamReader(ms, readEncoding);
+				var streamReaderWithEncoding = new StreamReader(stream, readEncoding);
 
 				var xmlReaderSettings = new XmlReaderSettings() { XmlResolver = null, IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit, CloseInput = true };
-				reader = XmlReader.Create(streamReaderWithEncoding, xmlReaderSettings);
+				using (var xReader = XmlReader.Create(streamReaderWithEncoding, xmlReaderSettings))
+				{
+					message = ParsedMessage.FromXmlReaderAsync(xReader, MessageVersion);
+				}
 			}
 
-			return await ParsedMessage.FromXmlReaderAsync(reader, MessageVersion);
-//			return Message.CreateMessage(reader, MaxSoapHeaderSize, MessageVersion);
+			return message;
 		}
 
 		public virtual async Task WriteMessageAsync(Message message, HttpContext httpContext, PipeWriter pipeWriter, bool indentXml)

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -20,8 +20,8 @@ namespace SoapCore.Meta
 	public class MetaBodyWriter : BodyWriter
 	{
 		private const string FaultSuffix = "Fault";
-		private static int _namespaceCounter = 1;
 
+		//private static int _namespaceCounter = 1;
 		private readonly ServiceDescription _service;
 		private readonly string _baseUrl;
 		private readonly XmlNamespaceManager _xmlNamespaceManager;
@@ -288,7 +288,7 @@ namespace SoapCore.Meta
 			writer.WriteAttributeString("elementFormDefault", "qualified");
 			writer.WriteAttributeString("targetNamespace", TargetNameSpace);
 
-			HashSet<Type> headerTypesWritten = new();
+			HashSet<Type> headerTypesWritten = new ();
 
 			foreach (var operation in _service.Operations)
 			{
@@ -546,7 +546,7 @@ namespace SoapCore.Meta
 
 		private Type[] GetKnownTypesFromMethod(MethodInfo methodInfo)
 		{
-			List<Type> includeTypes = new();
+			List<Type> includeTypes = new ();
 
 			if (methodInfo != null)
 			{
@@ -740,7 +740,6 @@ namespace SoapCore.Meta
 					}
 
 					writer.WriteEndElement(); // wsdl:input
-
 
 					if (!operation.IsOneWay)
 					{

--- a/src/SoapCore/ParsedMessage.cs
+++ b/src/SoapCore/ParsedMessage.cs
@@ -16,7 +16,7 @@ namespace SoapCore
 		private readonly MessageHeaders _headers;
 		private readonly MessageProperties _properties;
 		private readonly MessageVersion _version;
-		private readonly XDocument _envelope;
+		private readonly XDocument _body;
 		private readonly bool _isEmpty;
 
 		/// <summary>
@@ -53,13 +53,13 @@ namespace SoapCore
 			_headers = headers;
 			_properties = properties;
 			_version = version;
-			_envelope = body;
+			_body = body;
 			_isEmpty = isEmpty;
 		}
 
 		public XDocument GetBodyAsXDocument()
 		{
-			return _envelope;
+			return _body;
 		}
 
 		/// <summary>
@@ -129,7 +129,7 @@ namespace SoapCore
 			}
 
 			//return new XDocument(bodyNode.Elements().FirstOrDefault());
-			return (envelope, bodyNode.IsEmpty);
+			return (new XDocument(bodyNode), bodyNode.IsEmpty);
 		}
 
 		/// <summary>
@@ -168,7 +168,7 @@ namespace SoapCore
 
 		protected override XmlDictionaryReader OnGetReaderAtBodyContents()
 		{
-			var reader = new XDocumentXmlReader(_envelope);
+			var reader = new XDocumentXmlReader(_body);
 
 			//var reader = XmlReader.Create(new StringReader(_body.ToString()));
 			XNamespace soapNs = _version.Envelope.Namespace();
@@ -201,7 +201,7 @@ namespace SoapCore
 
 		public override string ToString()
 		{
-			return _envelope?.ToString() ?? "<Empty Body>";
+			return _body?.ToString() ?? "<Empty Body>";
 		}
 	}
 

--- a/src/SoapCore/ParsedMessage.cs
+++ b/src/SoapCore/ParsedMessage.cs
@@ -162,7 +162,8 @@ namespace SoapCore
 
 		protected override XmlDictionaryReader OnGetReaderAtBodyContents()
 		{
-			var reader = _body.CreateReader();
+			
+			var reader = XmlReader.Create(new StringReader(_body.ToString()));
 			reader.Read();
 			return XmlDictionaryReader.CreateDictionaryReader(reader);
 		}

--- a/src/SoapCore/ParsedMessage.cs
+++ b/src/SoapCore/ParsedMessage.cs
@@ -101,14 +101,14 @@ namespace SoapCore
 					string actor = element.Attribute(soapNs + "actor")?.Value ?? string.Empty;
 					bool relay = element.Attribute(soapNs + "relay")?.Value.ToLower() == "true";
 
-					var header = MessageHeader.CreateHeader(element.Name.LocalName, element.Name.NamespaceName, element.Value, mustUnderstand, actor, relay);
-
-					headers.Add(header);
-
-					if (header.Name.Equals("replyto", StringComparison.OrdinalIgnoreCase))
+					object value = element.Elements().FirstOrDefault();
+					if (value is null)
 					{
-						headers.ReplyTo = new System.ServiceModel.EndpointAddress(element.Value);
+						value = element.Value;
 					}
+
+					var header = MessageHeader.CreateHeader(element.Name.LocalName, element.Name.NamespaceName, value, mustUnderstand, actor, relay);
+					headers.Add(header);
 				}
 			}
 
@@ -162,8 +162,8 @@ namespace SoapCore
 
 		protected override XmlDictionaryReader OnGetReaderAtBodyContents()
 		{
-			
-			var reader = XmlReader.Create(new StringReader(_body.ToString()));
+			var reader = new XDocumentXmlReader(_body);
+			//var reader = XmlReader.Create(new StringReader(_body.ToString()));
 			reader.Read();
 			return XmlDictionaryReader.CreateDictionaryReader(reader);
 		}

--- a/src/SoapCore/ParsedMessage.cs
+++ b/src/SoapCore/ParsedMessage.cs
@@ -165,8 +165,8 @@ namespace SoapCore
 
 		protected override XmlDictionaryReader OnGetReaderAtBodyContents()
 		{
-			//var reader = new XDocumentXmlReader(_body);
-			var reader = XmlReader.Create(new StringReader(_body.ToString()));
+			var reader = new XDocumentXmlReader(_body);
+			//var reader = XmlReader.Create(new StringReader(_body.ToString()));
 			reader.Read();
 			return XmlDictionaryReader.CreateDictionaryReader(reader);
 		}

--- a/src/SoapCore/ParsedMessage.cs
+++ b/src/SoapCore/ParsedMessage.cs
@@ -33,7 +33,7 @@ namespace SoapCore
 
 		public override bool IsEmpty => _isEmpty;
 
-		public static ParsedMessage FromXmlReaderAsync(XmlReader reader, MessageVersion version)
+		public static ParsedMessage FromXmlReader(XmlReader reader, MessageVersion version)
 		{
 			if (reader == null)
 			{

--- a/src/SoapCore/ParsedMessage.cs
+++ b/src/SoapCore/ParsedMessage.cs
@@ -89,7 +89,10 @@ namespace SoapCore
 		{
 			var headers = new MessageHeaders(version);
 			var root = envelope.Root;
-			if (root == null) return headers;
+			if (root == null)
+			{
+				return headers;
+			}
 
 			XNamespace soapNs = version.Envelope.Namespace();
 			var headerNode = root.Element(soapNs + "Header");

--- a/src/SoapCore/ParsedMessage.cs
+++ b/src/SoapCore/ParsedMessage.cs
@@ -102,17 +102,7 @@ namespace SoapCore
 			{
 				foreach (var element in headerNode.Elements())
 				{
-					bool mustUnderstand = element.Attribute(soapNs + "mustUnderstand")?.Value == "1";
-					string actor = element.Attribute(soapNs + "actor")?.Value ?? string.Empty;
-					bool relay = element.Attribute(soapNs + "relay")?.Value.ToLower() == "true";
-
-					object value = element.Elements().FirstOrDefault();
-					if (value is null)
-					{
-						value = element.Value;
-					}
-
-					var header = MessageHeader.CreateHeader(element.Name.LocalName, element.Name.NamespaceName, value, mustUnderstand, actor, relay);
+					var header = new ParsedMessageHeader(element.Name.LocalName, element.Name.NamespaceName, element.Elements().ToArray(), element.Value, element.Attributes().ToArray());
 					headers.Add(header);
 				}
 			}

--- a/src/SoapCore/ParsedMessage.cs
+++ b/src/SoapCore/ParsedMessage.cs
@@ -16,7 +16,7 @@ namespace SoapCore
 		private readonly MessageHeaders _headers;
 		private readonly MessageProperties _properties;
 		private readonly MessageVersion _version;
-		private readonly XDocument _body;
+		private readonly XDocument _envelope;
 		private readonly bool _isEmpty;
 
 		/// <summary>
@@ -53,13 +53,13 @@ namespace SoapCore
 			_headers = headers;
 			_properties = properties;
 			_version = version;
-			_body = body;
+			_envelope = body;
 			_isEmpty = isEmpty;
 		}
 
 		public XDocument GetBodyAsXDocument()
 		{
-			return _body;
+			return _envelope;
 		}
 
 		/// <summary>
@@ -160,12 +160,15 @@ namespace SoapCore
 
 		protected override void OnWriteBodyContents(XmlDictionaryWriter writer)
 		{
-			_body.WriteTo(writer);
+			using (var reader = GetReaderAtBodyContents())
+			{
+				writer.WriteNode(reader, true);
+			}
 		}
 
 		protected override XmlDictionaryReader OnGetReaderAtBodyContents()
 		{
-			var reader = new XDocumentXmlReader(_body);
+			var reader = new XDocumentXmlReader(_envelope);
 			//var reader = XmlReader.Create(new StringReader(_body.ToString()));
 
 			XNamespace soapNs = _version.Envelope.Namespace();
@@ -196,7 +199,7 @@ namespace SoapCore
 
 		public override string ToString()
 		{
-			return _body?.ToString() ?? "<Empty Body>";
+			return _envelope?.ToString() ?? "<Empty Body>";
 		}
 	}
 

--- a/src/SoapCore/ParsedMessage.cs
+++ b/src/SoapCore/ParsedMessage.cs
@@ -169,8 +169,8 @@ namespace SoapCore
 		protected override XmlDictionaryReader OnGetReaderAtBodyContents()
 		{
 			var reader = new XDocumentXmlReader(_envelope);
-			//var reader = XmlReader.Create(new StringReader(_body.ToString()));
 
+			//var reader = XmlReader.Create(new StringReader(_body.ToString()));
 			XNamespace soapNs = _version.Envelope.Namespace();
 
 			while (reader.Read()) // Advance through the document
@@ -181,7 +181,9 @@ namespace SoapCore
 				}
 			}
 
-			while (reader.Read() && reader.NodeType != XmlNodeType.Element && reader.NodeType != XmlNodeType.EndElement) ;
+			while (reader.Read() && reader.NodeType != XmlNodeType.Element && reader.NodeType != XmlNodeType.EndElement)
+			{
+			}
 
 			return XmlDictionaryReader.CreateDictionaryReader(reader);
 		}

--- a/src/SoapCore/ParsedMessage.cs
+++ b/src/SoapCore/ParsedMessage.cs
@@ -19,23 +19,7 @@ namespace SoapCore
 		private readonly XDocument _body;
 		private readonly bool _isEmpty;
 
-		/// <summary>
-		/// Creates a ParsedMessage from an ASP.NET Core HttpRequest.
-		/// </summary>
-		public static async Task<ParsedMessage> FromHttpRequestAsync(HttpRequest httpRequest, MessageVersion version)
-		{
-			if (httpRequest == null) throw new ArgumentNullException(nameof(httpRequest));
-			if (version == null) throw new ArgumentNullException(nameof(version));
-
-			var envelope = await ReadHttpRequestBodyAsync(httpRequest);
-			var headers = ExtractSoapHeaders(envelope, version);
-			var properties = ExtractSoapProperties(httpRequest);
-			(var body, var isEmpty) = ExtractSoapBody(envelope, version);
-
-			return new ParsedMessage(headers, properties, version, body, isEmpty);
-		}
-
-		public static async Task<ParsedMessage> FromXmlReaderAsync(XmlReader reader, MessageVersion version)
+		public static ParsedMessage FromXmlReaderAsync(XmlReader reader, MessageVersion version)
 		{
 			if (reader == null) throw new ArgumentNullException(nameof(reader));
 			if (version == null) throw new ArgumentNullException(nameof(version));
@@ -60,28 +44,6 @@ namespace SoapCore
 		public XDocument GetBodyAsXDocument()
 		{
 			return _body;
-		}
-
-		/// <summary>
-		/// Reads the HttpRequest body and converts it to an XDocument.
-		/// </summary>
-		private static async Task<XDocument> ReadHttpRequestBodyAsync(HttpRequest httpRequest)
-		{
-			if (httpRequest.Body == null || httpRequest.ContentLength == 0)
-				return new XDocument();
-
-			httpRequest.EnableBuffering(); // Allows re-reading the stream
-			using (var reader = new StreamReader(httpRequest.Body, Encoding.UTF8, true, -1, true))
-			{
-				string bodyText = await reader.ReadToEndAsync();
-				httpRequest.Body.Position = 0; // Reset stream position for further use
-
-				using (var stringReader = new StringReader(bodyText))
-				using (var xmlReader = XmlReader.Create(stringReader))
-				{
-					return XDocument.Load(xmlReader);
-				}
-			}
 		}
 
 		/// <summary>

--- a/src/SoapCore/ParsedMessage.cs
+++ b/src/SoapCore/ParsedMessage.cs
@@ -1,0 +1,187 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.AspNetCore.Http;
+
+
+namespace SoapCore
+{
+	public class ParsedMessage : Message
+	{
+		private readonly MessageHeaders _headers;
+		private readonly MessageProperties _properties;
+		private readonly MessageVersion _version;
+		private readonly XDocument _body;
+
+		/// <summary>
+		/// Creates a ParsedMessage from an ASP.NET Core HttpRequest.
+		/// </summary>
+		public static async Task<ParsedMessage> FromHttpRequestAsync(HttpRequest httpRequest, MessageVersion version)
+		{
+			if (httpRequest == null) throw new ArgumentNullException(nameof(httpRequest));
+			if (version == null) throw new ArgumentNullException(nameof(version));
+
+			var envelope = await ReadHttpRequestBodyAsync(httpRequest);
+			var headers = ExtractSoapHeaders(envelope, version);
+			var properties = ExtractSoapProperties(httpRequest);
+			var body = ExtractSoapBody(envelope, version);
+
+			return new ParsedMessage(headers, properties, version, body);
+		}
+
+		public static async Task<ParsedMessage> FromXmlReaderAsync(XmlReader reader, MessageVersion version)
+		{
+			if (reader == null) throw new ArgumentNullException(nameof(reader));
+			if (version == null) throw new ArgumentNullException(nameof(version));
+
+			var envelope = XDocument.Load(reader);
+			var headers = ExtractSoapHeaders(envelope, version);
+			//var properties = ExtractSoapProperties(httpRequest);
+			var body = ExtractSoapBody(envelope, version);
+
+			return new ParsedMessage(headers, new MessageProperties(), version, body);
+		}
+
+		public ParsedMessage(MessageHeaders headers, MessageProperties properties, MessageVersion version, XDocument body)
+		{
+			_headers = headers;
+			_properties = properties;
+			_version = version;
+			_body = body;
+		}
+
+		public XDocument GetBodyAsXDocument()
+		{
+			return _body;
+		}
+
+		/// <summary>
+		/// Reads the HttpRequest body and converts it to an XDocument.
+		/// </summary>
+		private static async Task<XDocument> ReadHttpRequestBodyAsync(HttpRequest httpRequest)
+		{
+			if (httpRequest.Body == null || httpRequest.ContentLength == 0)
+				return new XDocument();
+
+			httpRequest.EnableBuffering(); // Allows re-reading the stream
+			using (var reader = new StreamReader(httpRequest.Body, Encoding.UTF8, true, -1, true))
+			{
+				string bodyText = await reader.ReadToEndAsync();
+				httpRequest.Body.Position = 0; // Reset stream position for further use
+
+				using (var stringReader = new StringReader(bodyText))
+				using (var xmlReader = XmlReader.Create(stringReader))
+				{
+					return XDocument.Load(xmlReader);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Extracts SOAP headers from the SOAP message body.
+		/// </summary>
+		private static MessageHeaders ExtractSoapHeaders(XDocument envelope, MessageVersion version)
+		{
+			var headers = new MessageHeaders(version);
+			var root = envelope.Root;
+			if (root == null) return headers;
+
+			XNamespace soapNs = version.Envelope.Namespace();
+			var headerNode = root.Element(soapNs + "Header");
+			if (headerNode != null)
+			{
+				foreach (var element in headerNode.Elements())
+				{
+					bool mustUnderstand = element.Attribute(soapNs + "mustUnderstand")?.Value == "1";
+					string actor = element.Attribute(soapNs + "actor")?.Value ?? string.Empty;
+					bool relay = element.Attribute(soapNs + "relay")?.Value.ToLower() == "true";
+
+					var header = MessageHeader.CreateHeader(element.Name.LocalName, element.Name.NamespaceName, element.Value, mustUnderstand, actor, relay);
+
+					headers.Add(header);
+
+					if (header.Name.Equals("replyto", StringComparison.OrdinalIgnoreCase))
+					{
+						headers.ReplyTo = new System.ServiceModel.EndpointAddress(element.Value);
+					}
+				}
+			}
+
+			return headers;
+		}
+
+		/// <summary>
+		/// Extracts only the SOAP Body content.
+		/// </summary>
+		private static XDocument ExtractSoapBody(XDocument envelope, MessageVersion version)
+		{
+			var root = envelope.Root;
+			if (root == null) return new XDocument();
+
+			XNamespace soapNs = version.Envelope.Namespace();
+			var bodyNode = root.Element(soapNs + "Body");
+			if (bodyNode == null) return new XDocument();
+
+			return new XDocument(bodyNode.Elements().FirstOrDefault());
+		}
+
+		/// <summary>
+		/// Extracts SOAP-specific properties.
+		/// </summary>
+		private static MessageProperties ExtractSoapProperties(HttpRequest httpRequest)
+		{
+			var properties = new MessageProperties
+			{
+				["HttpMethod"] = httpRequest.Method,
+				["RequestUri"] = httpRequest.Path + httpRequest.QueryString
+			};
+
+			if (httpRequest.ContentType != null)
+			{
+				properties["Content-Type"] = httpRequest.ContentType;
+			}
+
+			return properties;
+		}
+
+		public override MessageHeaders Headers => _headers;
+		public override MessageProperties Properties => _properties;
+		public override MessageVersion Version => _version;
+
+		public override bool IsEmpty => !_body.Elements().Any();
+
+		protected override void OnWriteBodyContents(XmlDictionaryWriter writer)
+		{
+			_body.WriteTo(writer);
+		}
+
+		protected override XmlDictionaryReader OnGetReaderAtBodyContents()
+		{
+			var reader = _body.CreateReader();
+			reader.Read();
+			return XmlDictionaryReader.CreateDictionaryReader(reader);
+		}
+
+		protected override void OnClose()
+		{
+			_properties.Dispose();
+			base.OnClose();
+		}
+
+		protected override MessageBuffer OnCreateBufferedCopy(int maxBufferSize)
+		{
+			return new ParsedMessageBuffer(this);
+		}
+
+		public override string ToString()
+		{
+			return _body?.ToString() ?? "<Empty Body>";
+		}
+	}
+
+}

--- a/src/SoapCore/ParsedMessage.cs
+++ b/src/SoapCore/ParsedMessage.cs
@@ -165,8 +165,8 @@ namespace SoapCore
 
 		protected override XmlDictionaryReader OnGetReaderAtBodyContents()
 		{
-			var reader = new XDocumentXmlReader(_body);
-			//var reader = XmlReader.Create(new StringReader(_body.ToString()));
+			//var reader = new XDocumentXmlReader(_body);
+			var reader = XmlReader.Create(new StringReader(_body.ToString()));
 			reader.Read();
 			return XmlDictionaryReader.CreateDictionaryReader(reader);
 		}

--- a/src/SoapCore/ParsedMessageBuffer.cs
+++ b/src/SoapCore/ParsedMessageBuffer.cs
@@ -11,7 +11,7 @@ namespace SoapCore
 
 		public ParsedMessageBuffer(ParsedMessage message)
 		{
-			_originalMessage = new ParsedMessage(message.Headers, message.Properties, message.Version, message.GetBodyAsXDocument());
+			_originalMessage = new ParsedMessage(message.Headers, message.Properties, message.Version, message.GetBodyAsXDocument(), message.IsEmpty);
 		}
 
 		public override int BufferSize => int.MaxValue;
@@ -22,7 +22,7 @@ namespace SoapCore
 
 		public override Message CreateMessage()
 		{
-			return new ParsedMessage(_originalMessage.Headers, _originalMessage.Properties, _originalMessage.Version, _originalMessage.GetBodyAsXDocument());
+			return new ParsedMessage(_originalMessage.Headers, _originalMessage.Properties, _originalMessage.Version, _originalMessage.GetBodyAsXDocument(), _originalMessage.IsEmpty);
 		}
 	}
 }

--- a/src/SoapCore/ParsedMessageBuffer.cs
+++ b/src/SoapCore/ParsedMessageBuffer.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel.Channels;
+using System.Text;
+
+namespace SoapCore
+{
+	public class ParsedMessageBuffer : MessageBuffer
+	{
+		private readonly ParsedMessage _originalMessage;
+
+		public ParsedMessageBuffer(ParsedMessage message)
+		{
+			_originalMessage = new ParsedMessage(message.Headers, message.Properties, message.Version, message.GetBodyAsXDocument());
+		}
+
+		public override int BufferSize => int.MaxValue;
+
+		public override void Close()
+		{
+		}
+
+		public override Message CreateMessage()
+		{
+			return new ParsedMessage(_originalMessage.Headers, _originalMessage.Properties, _originalMessage.Version, _originalMessage.GetBodyAsXDocument());
+		}
+	}
+}

--- a/src/SoapCore/ParsedMessageBuffer.cs
+++ b/src/SoapCore/ParsedMessageBuffer.cs
@@ -18,6 +18,7 @@ namespace SoapCore
 
 		public override void Close()
 		{
+			_originalMessage?.Close();
 		}
 
 		public override Message CreateMessage()

--- a/src/SoapCore/ParsedMessageHeader.cs
+++ b/src/SoapCore/ParsedMessageHeader.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.ServiceModel.Channels;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace SoapCore
+{
+	public class ParsedMessageHeader : MessageHeader
+	{
+		private readonly XElement[] _content;
+		private readonly XAttribute[] _attributes;
+		private readonly string _value;
+
+		public ParsedMessageHeader(string name, string ns, XElement[] content, string value, XAttribute[] attributes)
+		{
+			Name = name;
+			Namespace = ns;
+			_content = content;
+			_attributes = attributes;
+			_value = value;
+		}
+
+		public override string Name { get; }
+		public override string Namespace { get; }
+
+		protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
+		{
+			// Write custom attributes
+			foreach (var attr in _attributes)
+			{
+				writer.WriteAttributeString(attr.Name.LocalName, attr.Value);
+			}
+
+			if (_content != null && _content.Length > 0)
+			{
+				foreach (var content in _content)
+				{
+					// Write the XML content inside the header
+					content.WriteTo(writer);
+				}
+			}
+			else
+			{
+				writer.WriteString(_value);
+			}
+		}
+	}
+}

--- a/src/SoapCore/ReflectionExtensions.cs
+++ b/src/SoapCore/ReflectionExtensions.cs
@@ -139,10 +139,13 @@ namespace SoapCore
 			throw new NotImplementedException($"Unable to get value out of member with type {memberInfo.GetType()}");
 		}
 
-		internal static IEnumerable<MemberInfo> GetMembersWithAttribute<TAttribute>(this Type type)
-			where TAttribute : Attribute
+		internal static IEnumerable<MemberWithAttribute<TAttribute>> GetMembersWithAttribute<TAttribute>(this Type type)
+	where TAttribute : Attribute
 		{
-			return GetPropertyOrFieldMembers(type).Where(x => x.GetCustomAttribute<TAttribute>() != null);
+			return from p in GetPropertyOrFieldMembers(type)
+				   let attr = p.GetCustomAttribute<TAttribute>()
+				   where attr != null
+				   select new MemberWithAttribute<TAttribute>(p, attr);
 		}
 
 		internal static bool TryGetBaseTypeWithKnownTypes(this Type type, out Type result)

--- a/src/SoapCore/ServiceBodyWriter.cs
+++ b/src/SoapCore/ServiceBodyWriter.cs
@@ -150,11 +150,7 @@ namespace SoapCore
 
 					if (shouldInline)
 					{
-						var memberInformation = resultType.GetMembersWithAttribute<MessageBodyMemberAttribute>().Select(mi => new
-						{
-							Member = mi,
-							MessageBodyMemberAttribute = mi.GetCustomAttribute<MessageBodyMemberAttribute>()
-						}).OrderBy(x => x.MessageBodyMemberAttribute?.Order ?? 0);
+						var memberInformation = resultType.GetMembersWithAttribute<MessageBodyMemberAttribute>().OrderBy(x => x.Attribute?.Order ?? 0);
 
 						if (messageContractAttribute != null && messageContractAttribute.IsWrapped)
 						{
@@ -166,8 +162,8 @@ namespace SoapCore
 							var memberType = memberInfo.Member.GetPropertyOrFieldType();
 							var memberValue = memberInfo.Member.GetPropertyOrFieldValue(_result);
 
-							var memberName = memberInfo.MessageBodyMemberAttribute?.Name ?? memberInfo.Member.Name;
-							var memberNamespace = memberInfo.MessageBodyMemberAttribute?.Namespace ?? _serviceNamespace;
+							var memberName = memberInfo.Attribute?.Name ?? memberInfo.Member.Name;
+							var memberNamespace = memberInfo.Attribute?.Namespace ?? _serviceNamespace;
 
 							var serializer = CachedXmlSerializer.GetXmlSerializer(memberType, memberName, memberNamespace);
 

--- a/src/SoapCore/ServiceBodyWriter.cs
+++ b/src/SoapCore/ServiceBodyWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -57,7 +58,7 @@ namespace SoapCore
 		{
 			int blockSize = 256;
 			int bytesRead = 0;
-			byte[] block = new byte[blockSize];
+			byte[] block = ArrayPool<byte>.Shared.Rent(blockSize);
 			var stream = (Stream)value;
 			stream.Position = 0;
 
@@ -76,9 +77,11 @@ namespace SoapCore
 				if (blockSize < 65536 && bytesRead == blockSize)
 				{
 					blockSize = blockSize * 16;
-					block = new byte[blockSize];
+					ArrayPool<byte>.Shared.Return(block);
+					block = ArrayPool<byte>.Shared.Rent(blockSize);
 				}
 			}
+			ArrayPool<byte>.Shared.Return(block);
 		}
 
 		private void OnWriteXmlSerializerBodyContents(XmlDictionaryWriter writer)

--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -18,6 +18,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>$(NoWarn);1591</NoWarn>
 		<PackageIcon>logo.png</PackageIcon>
+		<EnablePreviewFeatures>true</EnablePreviewFeatures>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<Description>SOAP protocol middleware for ASP.NET Core</Description>
-		<Version>1.2.0.0</Version>
+		<Version>1.2.1.0</Version>
 		<Authors>Digital Design</Authors>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;netcoreapp3.1;</TargetFrameworks>
 		<PackageId>SoapCore</PackageId>

--- a/src/SoapCore/SoapCore.csproj
+++ b/src/SoapCore/SoapCore.csproj
@@ -18,7 +18,6 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>$(NoWarn);1591</NoWarn>
 		<PackageIcon>logo.png</PackageIcon>
-		<EnablePreviewFeatures>true</EnablePreviewFeatures>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -524,7 +524,6 @@ namespace SoapCore
 					resultOutDictionary[parameterInfo.Name] = arguments[parameterInfo.Index];
 				}
 
-
 				responseMessage = CreateResponseMessage(operation, responseObject, resultOutDictionary, actionString, requestMessage, messageEncoder);
 
 				httpContext.Response.ContentType = httpContext.Request.ContentType;
@@ -1016,7 +1015,7 @@ namespace SoapCore
 
 			foreach (string key in httpProperty.Headers.Keys)
 			{
-				httpContext.Response.Headers.Add(key, httpProperty.Headers.GetValues(key));
+				httpContext.Response.Headers.Append(key, httpProperty.Headers.GetValues(key));
 			}
 		}
 

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -218,20 +218,20 @@ namespace SoapCore
 					if (messageEncoder.IsContentTypeSupported(multipartSection.ContentType, true)
 						|| messageEncoder.IsContentTypeSupported(multipartSection.ContentType, false))
 					{
-						return await messageEncoder.ReadMessageAsync(multipartSection.Body, messageEncoder.MaxSoapHeaderSize, multipartSection.ContentType);
+						return messageEncoder.ReadMessage(multipartSection.Body, messageEncoder.MaxSoapHeaderSize, multipartSection.ContentType);
 					}
 				}
 			}
 
 #if !NETCOREAPP3_0_OR_GREATER
-			return await messageEncoder.ReadMessageAsync(httpContext.Request.Body, messageEncoder.MaxSoapHeaderSize, httpContext.Request.ContentType);
+			return messageEncoder.ReadMessage(httpContext.Request.Body, messageEncoder.MaxSoapHeaderSize, httpContext.Request.ContentType);
 #else
 			if (httpContext.Request.Body is FileBufferingReadStream)
 			{
-				return await messageEncoder.ReadMessageAsync(httpContext.Request.Body, messageEncoder.MaxSoapHeaderSize, httpContext.Request.ContentType);
+				return messageEncoder.ReadMessage(httpContext.Request.Body, messageEncoder.MaxSoapHeaderSize, httpContext.Request.ContentType);
 			}
 
-			return await messageEncoder.ReadMessageAsync(httpContext.Request.BodyReader, messageEncoder.MaxSoapHeaderSize, httpContext.Request.ContentType);
+			return messageEncoder.ReadMessage(httpContext.Request.BodyReader, messageEncoder.MaxSoapHeaderSize, httpContext.Request.ContentType);
 #endif
 		}
 
@@ -449,7 +449,7 @@ namespace SoapCore
 		{
 			Message responseMessage;
 			var soapAction = HeadersHelper.GetSoapAction(httpContext, ref requestMessage);
-			requestMessage.Headers.Action = soapAction.ToString();
+			requestMessage.Headers.Action = soapAction;
 
 			if (string.IsNullOrEmpty(soapAction))
 			{

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -322,7 +322,7 @@ namespace SoapCore
 
 		private async Task ProcessHttpOperation(HttpContext context, IServiceProvider serviceProvider, string methodName)
 		{
-			if (!TryGetOperation(methodName.AsSpan(), out var operation))
+			if (!TryGetOperation(methodName, out var operation))
 			{
 				context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
 				await context.Response.WriteAsync($"Service does not support \"/{methodName}\"");
@@ -451,7 +451,7 @@ namespace SoapCore
 			var soapAction = HeadersHelper.GetSoapAction(httpContext, ref requestMessage);
 			requestMessage.Headers.Action = soapAction.ToString();
 
-			if (soapAction.IsEmpty)
+			if (string.IsNullOrEmpty(soapAction))
 			{
 				throw new ArgumentException($"Unable to handle request without a valid action parameter. Please supply a valid soap action.");
 			}
@@ -554,9 +554,11 @@ namespace SoapCore
 			return responseMessage;
 		}
 
-		private bool TryGetOperation(ReadOnlySpan<char> methodName, out OperationDescription operation)
+		private bool TryGetOperation(string methodNameStr, out OperationDescription operation)
 		{
+			var methodName = methodNameStr.AsSpan();
 			operation = null;
+
 			foreach (var o in _service.Operations)
 			{
 				if (o.SoapAction.AsSpan().Equals(methodName, StringComparison.OrdinalIgnoreCase)

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -555,14 +555,14 @@ namespace SoapCore
 		private bool TryGetOperation(string methodName, out OperationDescription operation)
 		{
 			operation = _service.Operations.FirstOrDefault(o => o.SoapAction.Equals(methodName, StringComparison.OrdinalIgnoreCase)
-							|| o.Name.Equals(HeadersHelper.GetTrimmedSoapAction(methodName), StringComparison.OrdinalIgnoreCase)
-							|| methodName.Equals(HeadersHelper.GetTrimmedSoapAction(o.Name), StringComparison.OrdinalIgnoreCase));
+							|| o.Name.AsSpan().Equals(HeadersHelper.GetTrimmedSoapAction(methodName.AsSpan()), StringComparison.OrdinalIgnoreCase)
+							|| methodName.AsSpan().Equals(HeadersHelper.GetTrimmedSoapAction(o.Name.AsSpan()), StringComparison.OrdinalIgnoreCase));
 
 			if (operation == null)
 			{
 				operation = _service.Operations.FirstOrDefault(o =>
-							methodName.Equals(HeadersHelper.GetTrimmedClearedSoapAction(o.SoapAction), StringComparison.OrdinalIgnoreCase)
-							|| methodName.IndexOf(HeadersHelper.GetTrimmedSoapAction(o.Name), StringComparison.OrdinalIgnoreCase) >= 0);
+							methodName.AsSpan().Equals(HeadersHelper.GetTrimmedClearedSoapAction(o.SoapAction.AsSpan()), StringComparison.OrdinalIgnoreCase)
+							|| methodName.AsSpan().IndexOf(HeadersHelper.GetTrimmedSoapAction(o.Name.AsSpan()), StringComparison.OrdinalIgnoreCase) >= 0);
 			}
 
 			return operation != null;

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -630,8 +630,8 @@ namespace SoapCore
 				var messageHeaderMembers = responseObject.GetType().GetMembersWithAttribute<MessageHeaderAttribute>();
 				foreach (var messageHeaderMember in messageHeaderMembers)
 				{
-					var messageHeaderAttribute = messageHeaderMember.GetCustomAttribute<MessageHeaderAttribute>();
-					responseMessage.Headers.Add(MessageHeader.CreateHeader(messageHeaderAttribute.Name ?? messageHeaderMember.Name, messageHeaderAttribute.Namespace ?? operation.Contract.Namespace, messageHeaderMember.GetPropertyOrFieldValue(responseObject), messageHeaderAttribute.MustUnderstand));
+					var messageHeaderAttribute = messageHeaderMember.Attribute;
+					responseMessage.Headers.Add(MessageHeader.CreateHeader(messageHeaderAttribute.Name ?? messageHeaderMember.Member.Name, messageHeaderAttribute.Namespace ?? operation.Contract.Namespace, messageHeaderMember.Member.GetPropertyOrFieldValue(responseObject), messageHeaderAttribute.MustUnderstand));
 				}
 			}
 

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -876,12 +876,14 @@ namespace SoapCore
 				}
 			}
 
-			var messageBodyMembers = parameterType.GetPropertyOrFieldMembers()
-				.Where(x => x.GetCustomAttribute<MessageBodyMemberAttribute>() != null).Select(mi => new
-				{
-					Member = mi,
-					MessageBodyMemberAttribute = mi.GetCustomAttribute<MessageBodyMemberAttribute>()
-				}).OrderBy(x => x.MessageBodyMemberAttribute.Order);
+			var messageBodyMembers = (from p in parameterType.GetPropertyOrFieldMembers()
+									  let attr = p.GetCustomAttribute<MessageBodyMemberAttribute>()
+									  where attr != null
+									  select new
+									  {
+										  Member = p,
+										  MessageBodyMemberAttribute = attr
+									  }).OrderBy(x => x.MessageBodyMemberAttribute.Order);
 
 			if (messageContractAttribute.IsWrapped)
 			{

--- a/src/SoapCore/XDocumentXmlReader.cs
+++ b/src/SoapCore/XDocumentXmlReader.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace SoapCore
+{
+	public class XDocumentXmlReader : XmlReader
+	{
+		private readonly XDocument _document;
+		private readonly XmlReader _reader;
+
+		public XDocumentXmlReader(XDocument document)
+		{
+			_document = document ?? throw new ArgumentNullException(nameof(document));
+			_reader = document.CreateReader();
+		}
+
+		public override int ReadContentAsBase64(byte[] buffer, int index, int count)
+		{
+			string base64String = _reader.Value;
+			byte[] data = Convert.FromBase64String(base64String);
+			int bytesToCopy = Math.Min(count, data.Length) - index;
+			Array.Copy(data, 0, buffer, index, bytesToCopy);
+			return bytesToCopy;
+		}
+
+		public override int ReadContentAsBinHex(byte[] buffer, int index, int count)
+		{
+			string hexString = _reader.Value;
+#if NET8_0_OR_GREATER
+			byte[] data = Convert.FromHexString(hexString);
+#else
+			byte[] data = Enumerable.Range(0, hexString.Length)
+                      .Where(x => x % 2 == 0)
+                      .Select(x => Convert.ToByte(hexString.Substring(x, 2), 16))
+                      .ToArray();
+#endif
+			int bytesToCopy = Math.Min(count, data.Length) - index;
+			Array.Copy(data, 0, buffer, index, bytesToCopy);
+			return bytesToCopy;
+		}
+
+		public override bool Read() => _reader.Read();
+		public override string GetAttribute(int i) => _reader.GetAttribute(i);
+		public override string GetAttribute(string name) => _reader.GetAttribute(name);
+		public override string GetAttribute(string name, string namespaceURI) => _reader.GetAttribute(name, namespaceURI);
+		public override bool MoveToAttribute(string name) => _reader.MoveToAttribute(name);
+		public override bool MoveToAttribute(string name, string ns) => _reader.MoveToAttribute(name, ns);
+		public override bool MoveToFirstAttribute() => _reader.MoveToFirstAttribute();
+		public override bool MoveToNextAttribute() => _reader.MoveToNextAttribute();
+		public override bool MoveToElement() => _reader.MoveToElement();
+		public override void Close() => _reader.Close();
+		public override string LookupNamespace(string prefix) => _reader.LookupNamespace(prefix);
+		public override void ResolveEntity() => _reader.ResolveEntity();
+		public override bool ReadAttributeValue() => _reader.ReadAttributeValue();
+
+		public override XmlNodeType NodeType => _reader.NodeType;
+		public override string Name => _reader.Name;
+		public override string LocalName => _reader.LocalName;
+		public override string NamespaceURI => _reader.NamespaceURI;
+		public override string Prefix => _reader.Prefix;
+		public override bool HasValue => _reader.HasValue;
+		public override string Value => _reader.Value;
+		public override int Depth => _reader.Depth;
+		public override string BaseURI => _reader.BaseURI;
+		public override bool IsEmptyElement => _reader.IsEmptyElement;
+		public override int AttributeCount => _reader.AttributeCount;
+		public override bool EOF => _reader.EOF;
+		public override ReadState ReadState => _reader.ReadState;
+		public override XmlNameTable NameTable => _reader.NameTable;
+	}
+}

--- a/src/SoapCore/XDocumentXmlReader.cs
+++ b/src/SoapCore/XDocumentXmlReader.cs
@@ -22,9 +22,19 @@ namespace SoapCore
 		{
 			string base64String = _reader.Value;
 			byte[] data = Convert.FromBase64String(base64String);
-			int bytesToCopy = Math.Min(count, data.Length) - index;
+			int bytesToCopy = Math.Max(Math.Min(count, data.Length) - index, 0);
 			Array.Copy(data, 0, buffer, index, bytesToCopy);
 			return bytesToCopy;
+		}
+
+		public override int ReadElementContentAsBase64(byte[] buffer, int index, int count)
+		{
+			if (!Read() || _reader.NodeType != XmlNodeType.Text)
+			{
+				return 0;
+			}
+
+			return ReadContentAsBase64(buffer, index, count);
 		}
 
 		public override int ReadContentAsBinHex(byte[] buffer, int index, int count)
@@ -38,9 +48,19 @@ namespace SoapCore
                       .Select(x => Convert.ToByte(hexString.Substring(x, 2), 16))
                       .ToArray();
 #endif
-			int bytesToCopy = Math.Min(count, data.Length) - index;
+			int bytesToCopy = Math.Max(Math.Min(count, data.Length) - index, 0);
 			Array.Copy(data, 0, buffer, index, bytesToCopy);
 			return bytesToCopy;
+		}
+
+		public override int ReadElementContentAsBinHex(byte[] buffer, int index, int count)
+		{
+			if (!Read() || _reader.NodeType != XmlNodeType.Text)
+			{
+				return 0;
+			}
+
+			return ReadContentAsBinHex(buffer, index, count);
 		}
 
 		public override bool Read() => _reader.Read();

--- a/src/SoapCore/XDocumentXmlReader.cs
+++ b/src/SoapCore/XDocumentXmlReader.cs
@@ -10,15 +10,12 @@ namespace SoapCore
 {
 	public class XDocumentXmlReader : XmlReader
 	{
-		private readonly XDocument _document;
 		private readonly XmlReader _reader;
 		private MemoryStream _binaryStream;
 		private bool _isReadingBinary;
-		private bool _isBase64Mode;
 
 		public XDocumentXmlReader(XDocument document)
 		{
-			_document = document ?? throw new ArgumentNullException(nameof(document));
 			_reader = document.CreateReader();
 		}
 
@@ -90,6 +87,13 @@ namespace SoapCore
 		public override void ResolveEntity() => _reader.ResolveEntity();
 		public override bool ReadAttributeValue() => _reader.ReadAttributeValue();
 
+		protected override void Dispose(bool disposing)
+		{
+			_binaryStream?.Dispose();
+			_binaryStream = null;
+			base.Dispose(disposing);
+		}
+
 #if NET8_0_OR_GREATER
 		private static byte[] ConvertHexStringToBytes(string hexString) => Convert.FromHexString(hexString);
 #else
@@ -106,7 +110,6 @@ namespace SoapCore
 		{
 			if (!_isReadingBinary)
 			{
-				_isBase64Mode = isBase64;
 				string data = ReadAllTextContent();
 				byte[] binaryData = isBase64 ? Convert.FromBase64String(data) : ConvertHexStringToBytes(data);
 


### PR DESCRIPTION
Proof-of-concept-branch with additional performance work

Right now this is only used for reading the Request message. If it is going to be used for the Response message I have to figure out how this relates to CustomMessage. Should I merge the two implementations? Probably...

This branch uses a custom implementation of Message to make working with it more efficient. I also had to implement a custom XmlReader since the one returned by `XDocument.GetReader()` doesn't support binary data.

All tests pass, but nasty edge case bugs are still possible.

**develop**
| Method    | LoopNum | Mean     | Error     | StdDev    | Gen0      | Allocated |
|---------- |-------- |---------:|----------:|----------:|----------:|----------:|
| EmptyTask | 100     | 1.456 ms | 0.0474 ms | 0.0123 ms |  261.7188 |   1.05 MB |
| Echo      | 100     | 8.745 ms | 0.6351 ms | 0.1649 ms | 1656.2500 |   6.64 MB |

**This branch**
| Method    | LoopNum | Mean     | Error     | StdDev    | Gen0      | Gen1    | Allocated |
|---------- |-------- |---------:|----------:|----------:|----------:|--------:|----------:|
| EmptyTask | 100     | 1.550 ms | 0.0965 ms | 0.1112 ms |  263.6719 |  1.9531 |   1.05 MB |
| Echo      | 100     | 7.110 ms | 0.0646 ms | 0.0718 ms | 1187.5000 | 31.2500 |   4.82 MB |