### PR TITLE
Fixed matching URL path to service type in Extensibility.AuthorizeOperationMessageProcessor

### DIFF
--- a/src/SoapCore.Tests/Startup.cs
+++ b/src/SoapCore.Tests/Startup.cs
@@ -45,16 +45,17 @@ namespace SoapCore.Tests
 					};
 				});
 
-			services.AddSoapMessageProcessor(new AuthorizeOperationMessageProcessor(new Dictionary<string, Type>
-			{
-				{ "/Service.svc", typeof(TestService) },
-				{ "/ServiceCI.svc", typeof(TestService) },
-				{ "/Service.asmx", typeof(TestService) },
-				{ "/WSA10Service.svc", typeof(TestService) },
-				{ "/WSA11ISO88591Service.svc", typeof(TestService) },
-				{ "/ServiceWithDifferentEncodings.asmx", typeof(TestService) },
-				{ "/ServiceWithOverwrittenContentType.asmx", typeof(TestService) },
-			}));
+			services.AddSoapMessageProcessor(new AuthorizeOperationMessageProcessor(
+				new Dictionary<string, Type>
+				{
+					{ "/Service.svc", typeof(TestService) },
+					{ "/ServiceCI.svc", typeof(TestService) },
+					{ "/Service.asmx", typeof(TestService) },
+					{ "/WSA10Service.svc", typeof(TestService) },
+					{ "/WSA11ISO88591Service.svc", typeof(TestService) },
+					{ "/ServiceWithDifferentEncodings.asmx", typeof(TestService) },
+					{ "/ServiceWithOverwrittenContentType.asmx", typeof(TestService) },
+				}, options => options.CaseInsensitivePath = true));
 			services.AddAuthorization(options =>
 			{
 				options.AddPolicy("something", policy => policy.RequireClaim("someclaim", "somevalue"));

--- a/src/SoapCore.Tests/Startup.cs
+++ b/src/SoapCore.Tests/Startup.cs
@@ -47,13 +47,13 @@ namespace SoapCore.Tests
 
 			services.AddSoapMessageProcessor(new AuthorizeOperationMessageProcessor(new Dictionary<string, Type>
 			{
-				{ "/Service.svc".ToLowerInvariant(), typeof(TestService) },
-				{ "/ServiceCI.svc".ToLowerInvariant(), typeof(TestService) },
-				{ "/Service.asmx".ToLowerInvariant(), typeof(TestService) },
-				{ "/WSA10Service.svc".ToLowerInvariant(), typeof(TestService) },
-				{ "/WSA11ISO88591Service.svc".ToLowerInvariant(), typeof(TestService) },
-				{ "/ServiceWithDifferentEncodings.asmx".ToLowerInvariant(), typeof(TestService) },
-				{ "/ServiceWithOverwrittenContentType.asmx".ToLowerInvariant(), typeof(TestService) },
+				{ "/Service.svc", typeof(TestService) },
+				{ "/ServiceCI.svc", typeof(TestService) },
+				{ "/Service.asmx", typeof(TestService) },
+				{ "/WSA10Service.svc", typeof(TestService) },
+				{ "/WSA11ISO88591Service.svc", typeof(TestService) },
+				{ "/ServiceWithDifferentEncodings.asmx", typeof(TestService) },
+				{ "/ServiceWithOverwrittenContentType.asmx", typeof(TestService) },
 			}));
 			services.AddAuthorization(options =>
 			{

--- a/src/SoapCore/Extensibility/AuthorizeOperationMessageProcessor.cs
+++ b/src/SoapCore/Extensibility/AuthorizeOperationMessageProcessor.cs
@@ -35,9 +35,21 @@ namespace SoapCore.Extensibility
 		/// <param name="pathAndTypes">A dictionary that has the path of the endpoint as Key and the corresponding type as Value. Similar to using the UseSoapEndpoint extension function.</param>
 		/// <param name="generateSoapActionWithoutContractName">Whether to generate the soapAction without the contract name. Default is false.</param>
 		public AuthorizeOperationMessageProcessor(Dictionary<string, Type> pathAndTypes, bool generateSoapActionWithoutContractName = false)
+			: this(pathAndTypes, options => options.GenerateSoapActionWithoutContractName = generateSoapActionWithoutContractName)
 		{
-			_pathTypes = new Dictionary<string, Type>(pathAndTypes, StringComparer.OrdinalIgnoreCase);
-			_generateSoapActionWithoutContractName = generateSoapActionWithoutContractName;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="AuthorizeOperationMessageProcessor"/> class.
+		/// </summary>
+		/// <param name="pathAndTypes">A dictionary that has the path of the endpoint as Key and the corresponding type as Value. Similar to using the UseSoapEndpoint extension function.</param>
+		/// <param name="options">Action that returns the configured options.</param>
+		public AuthorizeOperationMessageProcessor(Dictionary<string, Type> pathAndTypes, Action<SoapCoreOptions> options)
+		{
+			var configuredOptions = new SoapCoreOptions() { Path = string.Empty };
+			options?.Invoke(configuredOptions);
+			_pathTypes = new Dictionary<string, Type>(pathAndTypes, configuredOptions.CaseInsensitivePath ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+			_generateSoapActionWithoutContractName = configuredOptions.GenerateSoapActionWithoutContractName;
 		}
 
 		public async Task<Message> ProcessMessage(Message requestMessage, HttpContext httpContext, Func<Message, Task<Message>> next)

--- a/src/SoapCore/Extensibility/AuthorizeOperationMessageProcessor.cs
+++ b/src/SoapCore/Extensibility/AuthorizeOperationMessageProcessor.cs
@@ -36,7 +36,12 @@ namespace SoapCore.Extensibility
 		/// <param name="generateSoapActionWithoutContractName">Whether to generate the soapAction without the contract name. Default is false.</param>
 		public AuthorizeOperationMessageProcessor(Dictionary<string, Type> pathAndTypes, bool generateSoapActionWithoutContractName = false)
 		{
-			_pathTypes = pathAndTypes;
+			_pathTypes = new Dictionary<string, Type>();
+			foreach (var kvp in pathAndTypes)
+			{
+				_pathTypes[kvp.Key.ToLowerInvariant()] = kvp.Value;
+			}
+
 			_generateSoapActionWithoutContractName = generateSoapActionWithoutContractName;
 		}
 

--- a/src/SoapCore/Extensibility/AuthorizeOperationMessageProcessor.cs
+++ b/src/SoapCore/Extensibility/AuthorizeOperationMessageProcessor.cs
@@ -36,12 +36,7 @@ namespace SoapCore.Extensibility
 		/// <param name="generateSoapActionWithoutContractName">Whether to generate the soapAction without the contract name. Default is false.</param>
 		public AuthorizeOperationMessageProcessor(Dictionary<string, Type> pathAndTypes, bool generateSoapActionWithoutContractName = false)
 		{
-			_pathTypes = new Dictionary<string, Type>();
-			foreach (var kvp in pathAndTypes)
-			{
-				_pathTypes[kvp.Key.ToLowerInvariant()] = kvp.Value;
-			}
-
+			_pathTypes = new Dictionary<string, Type>(pathAndTypes, StringComparer.OrdinalIgnoreCase);
 			_generateSoapActionWithoutContractName = generateSoapActionWithoutContractName;
 		}
 


### PR DESCRIPTION
Previously, the caller of the constructor had the responsibility to make the path for the service to be lowercase. I modified the constructor to make the path lowercase as it is not obvious to the caller that this is necessary.