### PR TITLE
Fix handling of trailing slash in remainingPath

### DIFF
--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -112,7 +112,7 @@ namespace SoapCore
 
 					if (getRequest)
 					{
-						if (!string.IsNullOrWhiteSpace(remainingPath))
+						if (!string.IsNullOrWhiteSpace(remainingPath) && remainingPath != "/")
 						{
 							await ProcessHttpOperation(httpContext, scopedServiceProvider, remainingPath.Value.Trim('/'));
 						}
@@ -141,7 +141,7 @@ namespace SoapCore
 					}
 					else
 					{
-						if (!string.IsNullOrWhiteSpace(remainingPath))
+						if (!string.IsNullOrWhiteSpace(remainingPath) && remainingPath != "/")
 						{
 							if ((httpContext.Request.IsHttps && !_options.HttpsPostEnabled) || (!httpContext.Request.IsHttps && !_options.HttpPostEnabled))
 							{


### PR DESCRIPTION
Fixed handling of a trailing slash ("/") in remainingPath.
Previously, when a trailing slash was present, an incorrect error related to the Content-Type header was returned.

In my case, all requests ending with a trailing slash resulted in the following error:
`System.ServiceModel.ProtocolException: An HTTP Content-Type header is required for SOAP messaging and none was found.`

