### PR TITLE
Add namespace override support to soap 1.1 faults

### DIFF
--- a/src/SoapCore.Tests/RawRequestSoap11Tests.cs
+++ b/src/SoapCore.Tests/RawRequestSoap11Tests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -173,6 +174,93 @@ namespace SoapCore.Tests
 					Assert.IsTrue(response.Contains(pingValue));
 					Assert.AreNotEqual(requestContentType, responseContentType);
 				}
+			}
+		}
+
+		[TestMethod]
+		public async Task Soap11FaultWithDefaultNamespacePrefix()
+		{
+			var messageFault = "Test fault message";
+			var body = $@"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"">
+  <soapenv:Body>
+    <ThrowExceptionWithMessage xmlns=""http://tempuri.org/"">
+      <message>{messageFault}</message>
+    </ThrowExceptionWithMessage>
+  </soapenv:Body>
+</soapenv:Envelope>
+";
+
+			using (var host = CreateTestHost())
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body, Encoding.UTF8, "text/xml"))
+			using (var res = host.CreateRequest("/Service.svc").AddHeader("SOAPAction", @"""ThrowExceptionWithMessage""").And(msg => msg.Content = content).PostAsync().Result)
+			{
+				Assert.AreEqual(HttpStatusCode.InternalServerError, res.StatusCode);
+
+				var response = await res.Content.ReadAsStringAsync();
+
+				Assert.IsTrue(response.Contains(messageFault));
+				Assert.IsTrue(response.Contains("xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\""), "Should contain default namespace");
+				Assert.IsTrue(response.Contains("s:Envelope"), "Should use default prefix");
+				Assert.IsTrue(response.Contains("s:Client"), "Should use default prefix");
+			}
+		}
+
+		[TestMethod]
+		public async Task Soap11FaultWithNamespacePrefixOverride()
+		{
+			var messageFault = "Test fault message";
+			var body = $@"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"">
+  <soapenv:Body>
+    <ThrowExceptionWithMessage xmlns=""http://tempuri.org/"">
+      <message>{messageFault}</message>
+    </ThrowExceptionWithMessage>
+  </soapenv:Body>
+</soapenv:Envelope>
+";
+
+			using (var host = CreateTestHost())
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body, Encoding.UTF8, "text/xml"))
+			using (var res = host.CreateRequest("/ServiceWithOverwrittenNamespace.asmx").AddHeader("SOAPAction", @"""ThrowExceptionWithMessage""").And(msg => msg.Content = content).PostAsync().Result)
+			{
+				Assert.AreEqual(HttpStatusCode.InternalServerError, res.StatusCode);
+
+				var response = await res.Content.ReadAsStringAsync();
+
+				Assert.IsTrue(response.Contains(messageFault));
+				Assert.IsTrue(response.Contains("xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\""), "Should contain override namespace");
+				Assert.IsTrue(response.Contains("soapenv:Envelope"), "Should use override prefix");
+				Assert.IsTrue(response.Contains("soapenv:Client"), "Should use override prefix");
+			}
+		}
+
+		[TestMethod]
+		public async Task Soap11PingWithNamespacePrefixOverride()
+		{
+			var pingValue = "abc";
+			var body = $@"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"">
+  <soapenv:Body>
+    <Ping xmlns=""http://tempuri.org/"">
+      <s>{pingValue}</s>
+    </Ping>
+  </soapenv:Body>
+</soapenv:Envelope>
+";
+
+			using (var host = CreateTestHost())
+			using (var client = host.CreateClient())
+			using (var content = new StringContent(body, Encoding.UTF8, "text/xml"))
+			using (var res = host.CreateRequest("/ServiceWithOverwrittenNamespace.asmx").AddHeader("SOAPAction", @"""Ping""").And(msg => msg.Content = content).PostAsync().Result)
+			{
+				res.EnsureSuccessStatusCode();
+
+				var response = await res.Content.ReadAsStringAsync();
+
+				Assert.IsTrue(response.Contains(pingValue));
+				Assert.IsTrue(response.Contains("xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\""), "Should contain override namespace");
+				Assert.IsTrue(response.Contains("soapenv:Envelope"), "Should use override prefix");
+				Assert.IsTrue(response.Contains("soapenv:Body"), "Should use override prefix");
 			}
 		}
 

--- a/src/SoapCore.Tests/Startup.cs
+++ b/src/SoapCore.Tests/Startup.cs
@@ -54,6 +54,7 @@ namespace SoapCore.Tests
 				{ "/WSA11ISO88591Service.svc".ToLowerInvariant(), typeof(TestService) },
 				{ "/ServiceWithDifferentEncodings.asmx".ToLowerInvariant(), typeof(TestService) },
 				{ "/ServiceWithOverwrittenContentType.asmx".ToLowerInvariant(), typeof(TestService) },
+				{ "/ServiceWithOverwrittenNamespace.asmx".ToLowerInvariant(), typeof(TestService) },
 			}));
 			services.AddAuthorization(options =>
 			{
@@ -204,6 +205,21 @@ namespace SoapCore.Tests
 				};
 
 				app2.UseSoapEndpoint<TestService>("/ServiceWithOverwrittenContentType.asmx", soapEncodingOptions, SoapSerializer.XmlSerializer);
+			});
+
+			app.UseWhen(ctx => ctx.Request.Path.Value.Contains("/ServiceWithOverwrittenNamespace.asmx"), app2 =>
+			{
+				app2.UseRouting();
+				var xmlNamespaceManager = Namespaces.CreateDefaultXmlNamespaceManager(false);
+				xmlNamespaceManager.AddNamespace("soapenv", "http://schemas.xmlsoap.org/soap/envelope/");
+
+				var soapEncodingOptions = new SoapEncoderOptions
+				{
+					MessageVersion = MessageVersion.Soap11,
+					XmlNamespaceOverrides = xmlNamespaceManager
+				};
+
+				app2.UseSoapEndpoint<TestService>("/ServiceWithOverwrittenNamespace.asmx", soapEncodingOptions, SoapSerializer.XmlSerializer);
 			});
 		}
 #endif

--- a/src/SoapCore/DefaultFaultExceptionTransformer.cs
+++ b/src/SoapCore/DefaultFaultExceptionTransformer.cs
@@ -28,8 +28,8 @@ namespace SoapCore
 		public Message ProvideFault(Exception exception, MessageVersion messageVersion, Message requestMessage, XmlNamespaceManager xmlNamespaceManager)
 		{
 			var bodyWriter = _exceptionTransformer == null ?
-				new FaultBodyWriter(exception, messageVersion) :
-				new FaultBodyWriter(exception, messageVersion, faultStringOverride: _exceptionTransformer.Transform(exception));
+				new FaultBodyWriter(exception, messageVersion, xmlNamespaceManager) :
+				new FaultBodyWriter(exception, messageVersion, xmlNamespaceManager, faultStringOverride: _exceptionTransformer.Transform(exception));
 
 			var soapCoreFaultMessage = Message.CreateMessage(messageVersion, null, bodyWriter);
 

--- a/src/SoapCore/FaultBodyWriter.cs
+++ b/src/SoapCore/FaultBodyWriter.cs
@@ -11,12 +11,14 @@ namespace SoapCore
 	public class FaultBodyWriter : BodyWriter
 	{
 		private readonly MessageVersion _version;
+		private readonly XmlNamespaceManager _xmlNamespaceManager;
 		private readonly Exception _exception;
 		private readonly string _faultStringOverride;
 
-		public FaultBodyWriter(Exception exception, MessageVersion version, bool isBuffered = true, string faultStringOverride = null) : base(isBuffered)
+		public FaultBodyWriter(Exception exception, MessageVersion version, XmlNamespaceManager xmlNamespaceManager, bool isBuffered = true, string faultStringOverride = null) : base(isBuffered)
 		{
 			_version = version;
+			_xmlNamespaceManager = xmlNamespaceManager;
 			_exception = exception;
 			_faultStringOverride = faultStringOverride;
 		}
@@ -47,7 +49,7 @@ namespace SoapCore
 
 			var faultString = _faultStringOverride ?? (_exception.InnerException != null ? _exception.InnerException.Message : _exception.Message);
 			var faultDetail = ExtractFaultDetailsAsXmlElement(_exception);
-			var prefix = writer.LookupPrefix(Namespaces.SOAP12_ENVELOPE_NS) ?? "s";
+			var prefix = _xmlNamespaceManager.LookupPrefix(Namespaces.SOAP12_ENVELOPE_NS) ?? "s";
 
 			writer.WriteStartElement(prefix, "Fault", Namespaces.SOAP12_ENVELOPE_NS);
 
@@ -80,6 +82,7 @@ namespace SoapCore
 		{
 			var faultString = _faultStringOverride ?? (_exception.InnerException != null ? _exception.InnerException.Message : _exception.Message);
 			var faultDetail = ExtractFaultDetailsAsXmlElement(_exception);
+			var faultCodePrefix = _xmlNamespaceManager.LookupPrefix(Namespaces.SOAP11_ENVELOPE_NS);
 
 			writer.WriteStartElement("Fault", Namespaces.SOAP11_ENVELOPE_NS);
 
@@ -119,19 +122,19 @@ namespace SoapCore
 					}
 					else
 					{
-						writer.WriteElementString("faultcode", "s:" + faultException.Code.Name);
+						writer.WriteElementString("faultcode", $"{faultCodePrefix}:{faultException.Code.Name}");
 					}
 				}
 				else
 				{
-					writer.WriteElementString("faultcode", "s:Client");
+					writer.WriteElementString("faultcode", $"{faultCodePrefix}:Client");
 				}
 
 				actor = faultException.CreateMessageFault()?.Actor;
 			}
 			else
 			{
-				writer.WriteElementString("faultcode", "s:Client");
+				writer.WriteElementString("faultcode", $"{faultCodePrefix}:Client");
 			}
 
 			writer.WriteElementString("faultstring", faultString);

--- a/src/SoapCore/FaultBodyWriter.cs
+++ b/src/SoapCore/FaultBodyWriter.cs
@@ -82,7 +82,7 @@ namespace SoapCore
 		{
 			var faultString = _faultStringOverride ?? (_exception.InnerException != null ? _exception.InnerException.Message : _exception.Message);
 			var faultDetail = ExtractFaultDetailsAsXmlElement(_exception);
-			var faultCodePrefix = _xmlNamespaceManager.LookupPrefix(Namespaces.SOAP11_ENVELOPE_NS);
+			var faultCodePrefix = _xmlNamespaceManager.LookupPrefix(Namespaces.SOAP11_ENVELOPE_NS) ?? "s";
 
 			writer.WriteStartElement("Fault", Namespaces.SOAP11_ENVELOPE_NS);
 


### PR DESCRIPTION
Add support for overriding the default namespaces for soap 1.1 faults. The default is soap envelope namespace `s`, but this allows to override to anything. 

The issue was that the fault code value must also have the same prefix as the soap envelope, but before this was hardcoded to `s:`. 

Resolves https://github.com/DigDes/SoapCore/issues/1143

