### PR TITLE
Fix: "A concurrent update was performed on this collection and corrupted its state."

### DIFF
--- a/src/SoapCore.Tests/FaultExceptionTransformer/TestFaultExceptionTransformer.cs
+++ b/src/SoapCore.Tests/FaultExceptionTransformer/TestFaultExceptionTransformer.cs
@@ -9,7 +9,7 @@ namespace SoapCore.Tests.FaultExceptionTransformer
 {
 	public class TestFaultExceptionTransformer : IFaultExceptionTransformer
 	{
-		public Message ProvideFault(Exception exception, MessageVersion messageVersion, Message requestMessage, XmlNamespaceManager xmlNamespaceManager)
+		public Message ProvideFault(Exception exception, MessageVersion messageVersion, Message requestMessage, ConcurrentXmlNamespaceLookup xmlNamespaceLookup)
 		{
 			var fault = new TestFault
 			{

--- a/src/SoapCore.Tests/IntegrationTests.cs
+++ b/src/SoapCore.Tests/IntegrationTests.cs
@@ -343,6 +343,22 @@ namespace SoapCore.Tests
 			Assert.AreEqual("OK", result);
 		}
 
+		/// <summary>
+		/// Test that reproduces issue. This is a flaky test that can fail randomly.
+		/// https://github.com/DigDes/SoapCore/issues/743
+		/// </summary>
+		/// <returns>Task</returns>
+		[TestMethod]
+		public async Task ReproduceStateCorruptionIssue()
+		{
+			var client = CreateClient();
+
+			var r = await Task.WhenAll(client.AsyncMethod(), client.AsyncMethod());
+
+			Assert.AreEqual("hello, async", r[0]);
+			Assert.AreEqual("hello, async", r[1]);
+		}
+
 		private ITestService CreateClient(bool caseInsensitivePath = false)
 		{
 			var binding = new BasicHttpBinding();

--- a/src/SoapCore.Tests/IntegrationTests.cs
+++ b/src/SoapCore.Tests/IntegrationTests.cs
@@ -344,12 +344,12 @@ namespace SoapCore.Tests
 		}
 
 		/// <summary>
-		/// Test that reproduces issue. This is a flaky test that can fail randomly.
-		/// https://github.com/DigDes/SoapCore/issues/743
+		/// Handles concurrent calls correctly.
+		/// Test that reproduces (flaky, not with all runs) issue https://github.com/DigDes/SoapCore/issues/743
 		/// </summary>
 		/// <returns>Task</returns>
 		[TestMethod]
-		public async Task ReproduceStateCorruptionIssue()
+		public async Task HandleConcurrentCallsCorrectly()
 		{
 			var client = CreateClient();
 

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -905,7 +905,7 @@ namespace SoapCore.Tests.Wsdl
 			Trace.TraceInformation(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var headerComplexType = root.XPathSelectElements("//xsd:complexType[@name='AuthenticationContextSoapHeader']", nm);
 			Assert.IsNotNull(headerComplexType);
@@ -932,7 +932,7 @@ namespace SoapCore.Tests.Wsdl
 			Trace.TraceInformation(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			bool allNeededAreUnqualified = root.XPathSelectElements($"//xsd:complexType[@name='{nameof(TypeWithUnqualifiedMembers)}' or @name='{nameof(UnqType2)}']/xsd:sequence/xsd:element[contains(@name, 'Unqualified')]", nm)
 				.All(x => x.Attribute("form")?.Value.Equals("unqualified") == true);
@@ -948,7 +948,7 @@ namespace SoapCore.Tests.Wsdl
 		[DataRow(SoapSerializer.DataContractSerializer)]
 		public async Task CheckDateTimeOffsetServiceWsdl(SoapSerializer soapSerializer)
 		{
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var wsdl = await GetWsdlFromMetaBodyWriter<DateTimeOffsetService>(soapSerializer);
 			var root = XElement.Parse(wsdl);
@@ -987,7 +987,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var responseDateElem = root.XPathSelectElement("//xsd:element[@name='GetDateResponse']/xsd:complexType/xsd:sequence/xsd:element[@name='GetDateResult' and contains(@type, ':date')]", nm);
 			Assert.IsNotNull(responseDateElem);
@@ -1011,7 +1011,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var nullableArray = root.XPathSelectElement("//xsd:complexType[@name='ArrayRequest']/xsd:sequence/xsd:element[@name='LongNullableArray' and @type='tns:ArrayOfNullableLong' and @nillable='true']", nm);
 			Assert.IsNotNull(nullableArray);
@@ -1051,7 +1051,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var normalEnum = root.XPathSelectElement("//xsd:complexType[@name='TypeWithEnums']/xsd:sequence/xsd:element[@name='Enum' and @type='tns:NulEnum' and not(@nillable)]", nm);
 			Assert.IsNotNull(normalEnum);
@@ -1069,7 +1069,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var enumWithSpecifiedBool = root.XPathSelectElement("//xsd:complexType[@name='TypeWithSpecifiedEnum']/xsd:sequence/xsd:element[@name='Enum' and @type='tns:NulEnum' and not(@nillable) and @minOccurs='0' and @maxOccurs='1']", nm);
 			Assert.IsNotNull(enumWithSpecifiedBool);
@@ -1126,7 +1126,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsFalse(wsdl.Contains("name=\"\""));
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var requestTypeElement = root.XPathSelectElement("//xsd:element[@name='RequestRoot']", nm);
 			Assert.IsNotNull(requestTypeElement);
@@ -1171,7 +1171,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var typeWithXmlArrayAttribute = root.XPathSelectElement("//xsd:complexType[@name='TypeWithXmlArrayAttribute']/xsd:sequence/xsd:element[@name='AvlRoomTypeItems' and @type='tns:ArrayOfAvlRoomTypeItem' and @nillable='true' and @minOccurs='0' and @maxOccurs='1']", nm);
 			Assert.IsNotNull(typeWithXmlArrayAttribute);
@@ -1193,7 +1193,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsFalse(wsdl.Contains("name=\"\""));
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var requestTypeElement = root.XPathSelectElement("//xsd:element[@name='GetResponseResponse']", nm);
 			Assert.IsNotNull(requestTypeElement);
@@ -1224,7 +1224,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsFalse(wsdl.Contains("name=\"\""));
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var stringPropertyElement = root.XPathSelectElement("//xsd:element[@name='ModifiedStringProperty']", nm);
 			Assert.IsNotNull(stringPropertyElement);
@@ -1240,7 +1240,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsFalse(wsdl.Contains("name=\"\""));
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var booleanWithNoDefaultPropertyElement = root.XPathSelectElement("//xsd:element[@name='BooleanWithNoDefaultProperty' and @minOccurs='1' and @maxOccurs='1' and not(@default)]", nm);
 			Assert.IsNotNull(booleanWithNoDefaultPropertyElement);
@@ -1280,7 +1280,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsFalse(wsdl.Contains("name=\"\""));
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var schemaElement = root.XPathSelectElement("//xsd:schema[@targetNamespace='http://schemas.datacontract.org/2004/07/SoapCore.Tests.Model']", nm);
 			Assert.IsNotNull(schemaElement);
@@ -1300,7 +1300,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var derivedTypeContent = root.XPathSelectElement("//xsd:complexType[@name='DerivedType']/xsd:complexContent[@mixed='false']/xsd:extension[@base='tns:BaseType']/xsd:sequence/xsd:element[@name='DerivedName' and @type='xsd:string' and not(@nillable)]", nm);
 			Assert.IsNotNull(derivedTypeContent);
@@ -1370,7 +1370,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateXmlNamespaceLookup(false);
+			var nm = Namespaces.CreateDefaultXmlNamespaceLookup(false);
 
 			var addressElement = GetElements(root, _soapSchema + "address").SingleOrDefault(a => a.Attribute("location")?.Value.StartsWith("https") == true);
 			Assert.IsNotNull(addressElement);
@@ -1417,7 +1417,7 @@ namespace SoapCore.Tests.Wsdl
 		{
 			var service = new ServiceDescription(typeof(T), false);
 			var baseUrl = "http://tempuri.org/";
-			var xmlNamespaceLookup = Namespaces.CreateXmlNamespaceLookup(useMicrosoftGuid);
+			var xmlNamespaceLookup = Namespaces.CreateDefaultXmlNamespaceLookup(useMicrosoftGuid);
 			xmlNamespaceLookup.AddNamespace("tns", service.GeneralContract.Namespace);
 			var defaultBindingName = !string.IsNullOrWhiteSpace(bindingName) ? bindingName : "BasicHttpBinding";
 			var bodyWriter = serializer == SoapSerializer.DataContractSerializer

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -905,7 +905,7 @@ namespace SoapCore.Tests.Wsdl
 			Trace.TraceInformation(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var headerComplexType = root.XPathSelectElements("//xsd:complexType[@name='AuthenticationContextSoapHeader']", nm);
 			Assert.IsNotNull(headerComplexType);
@@ -932,7 +932,7 @@ namespace SoapCore.Tests.Wsdl
 			Trace.TraceInformation(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			bool allNeededAreUnqualified = root.XPathSelectElements($"//xsd:complexType[@name='{nameof(TypeWithUnqualifiedMembers)}' or @name='{nameof(UnqType2)}']/xsd:sequence/xsd:element[contains(@name, 'Unqualified')]", nm)
 				.All(x => x.Attribute("form")?.Value.Equals("unqualified") == true);
@@ -948,7 +948,7 @@ namespace SoapCore.Tests.Wsdl
 		[DataRow(SoapSerializer.DataContractSerializer)]
 		public async Task CheckDateTimeOffsetServiceWsdl(SoapSerializer soapSerializer)
 		{
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var wsdl = await GetWsdlFromMetaBodyWriter<DateTimeOffsetService>(soapSerializer);
 			var root = XElement.Parse(wsdl);
@@ -987,7 +987,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var responseDateElem = root.XPathSelectElement("//xsd:element[@name='GetDateResponse']/xsd:complexType/xsd:sequence/xsd:element[@name='GetDateResult' and contains(@type, ':date')]", nm);
 			Assert.IsNotNull(responseDateElem);
@@ -1011,7 +1011,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var nullableArray = root.XPathSelectElement("//xsd:complexType[@name='ArrayRequest']/xsd:sequence/xsd:element[@name='LongNullableArray' and @type='tns:ArrayOfNullableLong' and @nillable='true']", nm);
 			Assert.IsNotNull(nullableArray);
@@ -1051,7 +1051,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var normalEnum = root.XPathSelectElement("//xsd:complexType[@name='TypeWithEnums']/xsd:sequence/xsd:element[@name='Enum' and @type='tns:NulEnum' and not(@nillable)]", nm);
 			Assert.IsNotNull(normalEnum);
@@ -1069,7 +1069,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var enumWithSpecifiedBool = root.XPathSelectElement("//xsd:complexType[@name='TypeWithSpecifiedEnum']/xsd:sequence/xsd:element[@name='Enum' and @type='tns:NulEnum' and not(@nillable) and @minOccurs='0' and @maxOccurs='1']", nm);
 			Assert.IsNotNull(enumWithSpecifiedBool);
@@ -1126,7 +1126,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsFalse(wsdl.Contains("name=\"\""));
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var requestTypeElement = root.XPathSelectElement("//xsd:element[@name='RequestRoot']", nm);
 			Assert.IsNotNull(requestTypeElement);
@@ -1171,7 +1171,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var typeWithXmlArrayAttribute = root.XPathSelectElement("//xsd:complexType[@name='TypeWithXmlArrayAttribute']/xsd:sequence/xsd:element[@name='AvlRoomTypeItems' and @type='tns:ArrayOfAvlRoomTypeItem' and @nillable='true' and @minOccurs='0' and @maxOccurs='1']", nm);
 			Assert.IsNotNull(typeWithXmlArrayAttribute);
@@ -1193,7 +1193,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsFalse(wsdl.Contains("name=\"\""));
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var requestTypeElement = root.XPathSelectElement("//xsd:element[@name='GetResponseResponse']", nm);
 			Assert.IsNotNull(requestTypeElement);
@@ -1224,7 +1224,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsFalse(wsdl.Contains("name=\"\""));
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var stringPropertyElement = root.XPathSelectElement("//xsd:element[@name='ModifiedStringProperty']", nm);
 			Assert.IsNotNull(stringPropertyElement);
@@ -1240,7 +1240,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsFalse(wsdl.Contains("name=\"\""));
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var booleanWithNoDefaultPropertyElement = root.XPathSelectElement("//xsd:element[@name='BooleanWithNoDefaultProperty' and @minOccurs='1' and @maxOccurs='1' and not(@default)]", nm);
 			Assert.IsNotNull(booleanWithNoDefaultPropertyElement);
@@ -1280,7 +1280,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsFalse(wsdl.Contains("name=\"\""));
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var schemaElement = root.XPathSelectElement("//xsd:schema[@targetNamespace='http://schemas.datacontract.org/2004/07/SoapCore.Tests.Model']", nm);
 			Assert.IsNotNull(schemaElement);
@@ -1300,7 +1300,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false).ToXmlNamespaceManager();
 
 			var derivedTypeContent = root.XPathSelectElement("//xsd:complexType[@name='DerivedType']/xsd:complexContent[@mixed='false']/xsd:extension[@base='tns:BaseType']/xsd:sequence/xsd:element[@name='DerivedName' and @type='xsd:string' and not(@nillable)]", nm);
 			Assert.IsNotNull(derivedTypeContent);
@@ -1370,7 +1370,7 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(wsdl);
 
 			var root = XElement.Parse(wsdl);
-			var nm = Namespaces.CreateDefaultXmlNamespaceManager(false);
+			var nm = Namespaces.CreateXmlNamespaceLookup(false);
 
 			var addressElement = GetElements(root, _soapSchema + "address").SingleOrDefault(a => a.Attribute("location")?.Value.StartsWith("https") == true);
 			Assert.IsNotNull(addressElement);
@@ -1417,18 +1417,18 @@ namespace SoapCore.Tests.Wsdl
 		{
 			var service = new ServiceDescription(typeof(T), false);
 			var baseUrl = "http://tempuri.org/";
-			var xmlNamespaceManager = Namespaces.CreateDefaultXmlNamespaceManager(useMicrosoftGuid);
-			xmlNamespaceManager.AddNamespace("tns", service.GeneralContract.Namespace);
+			var xmlNamespaceLookup = Namespaces.CreateXmlNamespaceLookup(useMicrosoftGuid);
+			xmlNamespaceLookup.AddNamespace("tns", service.GeneralContract.Namespace);
 			var defaultBindingName = !string.IsNullOrWhiteSpace(bindingName) ? bindingName : "BasicHttpBinding";
 			var bodyWriter = serializer == SoapSerializer.DataContractSerializer
 				? new MetaWCFBodyWriter(service, baseUrl, defaultBindingName, false, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }, new DefaultWsdlOperationNameGenerator()) as BodyWriter
-				: new MetaBodyWriter(service, baseUrl, xmlNamespaceManager, defaultBindingName, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }, useMicrosoftGuid, new DefaultWsdlOperationNameGenerator()) as BodyWriter;
+				: new MetaBodyWriter(service, baseUrl, xmlNamespaceLookup, defaultBindingName, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }, useMicrosoftGuid, new DefaultWsdlOperationNameGenerator()) as BodyWriter;
 			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, Encoding.UTF8, false, XmlDictionaryReaderQuotas.Max, false, false, null, bindingName, portName, true);
 			var responseMessage = Message.CreateMessage(encoder.MessageVersion, null, bodyWriter);
 			responseMessage = new MetaMessage(
 				responseMessage,
 				service,
-				xmlNamespaceManager,
+				xmlNamespaceLookup,
 				defaultBindingName,
 				false,
 				[responseMessage.Version]);

--- a/src/SoapCore/ConcurrentXmlNamespaceLookup.cs
+++ b/src/SoapCore/ConcurrentXmlNamespaceLookup.cs
@@ -1,0 +1,29 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Xml;
+
+namespace SoapCore;
+
+public class ConcurrentXmlNamespaceLookup
+{
+	private readonly ConcurrentDictionary<string, string> _uriToPrefix = new ();
+	private readonly ConcurrentDictionary<string, string> _prefixToUri = new ();
+
+	public IDictionary<string, string> GetNamespacesInScope(XmlNamespaceScope scope) => ToXmlNamespaceManager().GetNamespacesInScope(scope);
+	public string LookupPrefix(string uri) => _uriToPrefix.TryGetValue(uri, out var r) ? r : null;
+	public string LookupNamespace(string prefix) => _prefixToUri.TryGetValue(prefix, out var r) ? r : null;
+	public void AddNamespace(string prefix, string uri)
+	{
+		_uriToPrefix.AddOrUpdate(uri, _ => prefix, (_, _) => prefix);
+		_prefixToUri.AddOrUpdate(prefix, _ => uri, (_, _) => uri);
+	}
+	public XmlNamespaceManager ToXmlNamespaceManager()
+	{
+		var r = new XmlNamespaceManager(new NameTable());
+		foreach (var e in _prefixToUri)
+		{
+			r.AddNamespace(e.Key, e.Value);
+		}
+		return r;
+	}
+}

--- a/src/SoapCore/CustomMessage.cs
+++ b/src/SoapCore/CustomMessage.cs
@@ -16,7 +16,7 @@ namespace SoapCore
 
 		public Message Message { get; internal set; }
 
-		public XmlNamespaceManager NamespaceManager { get; internal set; }
+		public ConcurrentXmlNamespaceLookup XmlNamespaceLookup { get; internal set; }
 
 		public System.Collections.Generic.Dictionary<string, string> AdditionalEnvelopeXmlnsAttributes { get; internal set; }
 
@@ -43,14 +43,14 @@ namespace SoapCore
 				writer.WriteStartDocument();
 			}
 
-			var prefix = Version.Envelope.NamespacePrefix(NamespaceManager);
+			var prefix = Version.Envelope.NamespacePrefix(XmlNamespaceLookup);
 			writer.WriteStartElement(prefix, "Envelope", Version.Envelope.Namespace());
 			writer.WriteXmlnsAttribute(prefix, Version.Envelope.Namespace());
 
-			var xsdPrefix = Namespaces.AddNamespaceIfNotAlreadyPresentAndGetPrefix(NamespaceManager, "xsd", Namespaces.XMLNS_XSD);
+			var xsdPrefix = Namespaces.AddNamespaceIfNotAlreadyPresentAndGetPrefix(XmlNamespaceLookup, "xsd", Namespaces.XMLNS_XSD);
 			writer.WriteXmlnsAttribute(xsdPrefix, Namespaces.XMLNS_XSD);
 
-			var xsiPrefix = Namespaces.AddNamespaceIfNotAlreadyPresentAndGetPrefix(NamespaceManager, "xsi", Namespaces.XMLNS_XSI);
+			var xsiPrefix = Namespaces.AddNamespaceIfNotAlreadyPresentAndGetPrefix(XmlNamespaceLookup, "xsi", Namespaces.XMLNS_XSI);
 			writer.WriteXmlnsAttribute(xsiPrefix, Namespaces.XMLNS_XSI);
 
 			if (AdditionalEnvelopeXmlnsAttributes != null)
@@ -64,12 +64,12 @@ namespace SoapCore
 
 		protected override void OnWriteStartHeaders(XmlDictionaryWriter writer)
 		{
-			writer.WriteStartElement(Version.Envelope.NamespacePrefix(NamespaceManager), "Header", Version.Envelope.Namespace());
+			writer.WriteStartElement(Version.Envelope.NamespacePrefix(XmlNamespaceLookup), "Header", Version.Envelope.Namespace());
 		}
 
 		protected override void OnWriteStartBody(XmlDictionaryWriter writer)
 		{
-			writer.WriteStartElement(Version.Envelope.NamespacePrefix(NamespaceManager), "Body", Version.Envelope.Namespace());
+			writer.WriteStartElement(Version.Envelope.NamespacePrefix(XmlNamespaceLookup), "Body", Version.Envelope.Namespace());
 		}
 
 		protected override void OnWriteBodyContents(XmlDictionaryWriter writer)

--- a/src/SoapCore/DefaultFaultExceptionTransformer.cs
+++ b/src/SoapCore/DefaultFaultExceptionTransformer.cs
@@ -25,7 +25,7 @@ namespace SoapCore
 			_exceptionTransformer = exceptionTransformer;
 		}
 
-		public Message ProvideFault(Exception exception, MessageVersion messageVersion, Message requestMessage, XmlNamespaceManager xmlNamespaceManager)
+		public Message ProvideFault(Exception exception, MessageVersion messageVersion, Message requestMessage, ConcurrentXmlNamespaceLookup xmlNamespaceLookup)
 		{
 			var bodyWriter = _exceptionTransformer == null ?
 				new FaultBodyWriter(exception, messageVersion) :
@@ -36,7 +36,7 @@ namespace SoapCore
 			T_MESSAGE customMessage = new T_MESSAGE
 			{
 				Message = soapCoreFaultMessage,
-				NamespaceManager = xmlNamespaceManager
+				XmlNamespaceLookup = xmlNamespaceLookup
 			};
 
 			return customMessage;

--- a/src/SoapCore/EnvelopeVersionExtentions.cs
+++ b/src/SoapCore/EnvelopeVersionExtentions.cs
@@ -15,7 +15,7 @@ namespace SoapCore
 			return Namespaces.SOAP12_ENVELOPE_NS;
 		}
 
-		public static string NamespacePrefix(this EnvelopeVersion envelopeVersion, XmlNamespaceManager namespaces)
+		public static string NamespacePrefix(this EnvelopeVersion envelopeVersion, ConcurrentXmlNamespaceLookup namespaces)
 		{
 			string prefix;
 			if (envelopeVersion == EnvelopeVersion.Soap11)

--- a/src/SoapCore/Extensibility/IFaultExceptionTransformer.cs
+++ b/src/SoapCore/Extensibility/IFaultExceptionTransformer.cs
@@ -19,9 +19,9 @@ namespace SoapCore.Extensibility
 		/// <param name="exception">Exception to transform</param>
 		/// <param name="messageVersion">SOAP message version</param>
 		/// <param name="requestMessage">SOAP requestMessage</param>
-		/// <param name="xmlNamespaceManager">Namespace manager</param>
+		/// <param name="xmlNamespaceLookup">Namespace manager</param>
 		/// <returns>Fully formatted SOAP Message</returns>
 		/// <seealso cref="MessageFaultBodyWriter"/>
-		Message ProvideFault(Exception exception, MessageVersion messageVersion, Message requestMessage, XmlNamespaceManager xmlNamespaceManager);
+		Message ProvideFault(Exception exception, MessageVersion messageVersion, Message requestMessage, ConcurrentXmlNamespaceLookup xmlNamespaceLookup);
 	}
 }

--- a/src/SoapCore/Meta/BodyWriterExtensions.cs
+++ b/src/SoapCore/Meta/BodyWriterExtensions.cs
@@ -15,7 +15,7 @@ namespace SoapCore.Meta
 		//switches to easily revert to previous behaviour if there is a problem
 		private static readonly bool UseXmlSchemaProvider = true;
 		private static readonly bool UseXmlReflectionImporter = false;
-		public static bool TryAddSchemaTypeFromXmlSchemaProviderAttribute(this XmlDictionaryWriter writer, Type type, string name, SoapSerializer serializer, XmlNamespaceManager xmlNamespaceManager = null, bool isUnqualified = false)
+		public static bool TryAddSchemaTypeFromXmlSchemaProviderAttribute(this XmlDictionaryWriter writer, Type type, string name, SoapSerializer serializer, ConcurrentXmlNamespaceLookup xmlNamespaceLookup = null, bool isUnqualified = false)
 		{
 			if (!UseXmlSchemaProvider && !UseXmlReflectionImporter)
 			{
@@ -47,14 +47,14 @@ namespace SoapCore.Meta
 				return true;
 			}
 
-			var xmlSchemaSet = xmlNamespaceManager == null ? new XmlSchemaSet() : new XmlSchemaSet(xmlNamespaceManager.NameTable);
+			var xmlSchemaSet = xmlNamespaceLookup == null ? new XmlSchemaSet() : new XmlSchemaSet(xmlNamespaceLookup.ToXmlNamespaceManager().NameTable);
 			var xmlSchemaProviderAttribute = type.GetCustomAttribute<XmlSchemaProviderAttribute>(true);
 			if (xmlSchemaProviderAttribute != null && true)
 			{
 				XmlSchema schema = new XmlSchema();
-				if (xmlNamespaceManager != null)
+				if (xmlNamespaceLookup != null)
 				{
-					schema.Namespaces = xmlNamespaceManager.Convert();
+					schema.Namespaces = xmlNamespaceLookup.Convert();
 				}
 
 				if (xmlSchemaProviderAttribute.IsAny)
@@ -246,10 +246,10 @@ namespace SoapCore.Meta
 			return "ArrayOf" + (isNullable ? "Nullable" : null) + (ClrTypeResolver.ResolveOrDefault(typeName) ?? typeName).FirstCharToUpperOrDefault();
 		}
 
-		private static XmlSerializerNamespaces Convert(this XmlNamespaceManager xmlNamespaceManager)
+		private static XmlSerializerNamespaces Convert(this ConcurrentXmlNamespaceLookup xmlNamespaceLookup)
 		{
 			XmlSerializerNamespaces xmlSerializerNamespaces = new XmlSerializerNamespaces();
-			foreach (var ns in xmlNamespaceManager.GetNamespacesInScope(XmlNamespaceScope.Local))
+			foreach (var ns in xmlNamespaceLookup.GetNamespacesInScope(XmlNamespaceScope.Local))
 			{
 				xmlSerializerNamespaces.Add(ns.Key, ns.Value);
 			}

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -24,7 +24,7 @@ namespace SoapCore.Meta
 		//private static int _namespaceCounter = 1;
 		private readonly ServiceDescription _service;
 		private readonly string _baseUrl;
-		private readonly XmlNamespaceManager _xmlNamespaceManager;
+		private readonly ConcurrentXmlNamespaceLookup _xmlNamespaceLookup;
 
 		private readonly Queue<Type> _enumToBuild;
 		private readonly Queue<TypeToBuild> _complexTypeToBuild;
@@ -36,11 +36,11 @@ namespace SoapCore.Meta
 		private readonly bool _buildMicrosoftGuid = false;
 		private IWsdlOperationNameGenerator _wsdlOperationNameGenerator;
 
-		public MetaBodyWriter(ServiceDescription service, string baseUrl, XmlNamespaceManager xmlNamespaceManager, string bindingName, SoapBindingInfo[] soapBindings, bool buildMicrosoftGuid, IWsdlOperationNameGenerator wsdlOperationNameGenerator) : base(isBuffered: true)
+		public MetaBodyWriter(ServiceDescription service, string baseUrl, ConcurrentXmlNamespaceLookup xmlNamespaceLookup, string bindingName, SoapBindingInfo[] soapBindings, bool buildMicrosoftGuid, IWsdlOperationNameGenerator wsdlOperationNameGenerator) : base(isBuffered: true)
 		{
 			_service = service;
 			_baseUrl = baseUrl;
-			_xmlNamespaceManager = xmlNamespaceManager;
+			_xmlNamespaceLookup = xmlNamespaceLookup;
 
 			_enumToBuild = new Queue<Type>();
 			_complexTypeToBuild = new Queue<TypeToBuild>();
@@ -478,7 +478,7 @@ namespace SoapCore.Meta
 					writer.WriteStartElement("simpleType", Namespaces.XMLNS_XSD);
 					writer.WriteAttributeString("name", typeName);
 					writer.WriteStartElement("restriction", Namespaces.XMLNS_XSD);
-					writer.WriteAttributeString("base", $"{_xmlNamespaceManager.LookupPrefix(Namespaces.XMLNS_XSD)}:string");
+					writer.WriteAttributeString("base", $"{_xmlNamespaceLookup.LookupPrefix(Namespaces.XMLNS_XSD)}:string");
 
 					// enum values are ordered by the order in which they are specified in the source code.
 					var orderedNames = toBuild.GetFields().Where(fi => fi.IsStatic).OrderBy(fi => fi.MetadataToken).Select(fi => fi.Name);
@@ -528,7 +528,7 @@ namespace SoapCore.Meta
 				writer.WriteAttributeString("name", "guid");
 
 				writer.WriteStartElement("restriction", Namespaces.XMLNS_XSD);
-				writer.WriteAttributeString("base", $"{_xmlNamespaceManager.LookupPrefix(Namespaces.XMLNS_XSD)}:string");
+				writer.WriteAttributeString("base", $"{_xmlNamespaceLookup.LookupPrefix(Namespaces.XMLNS_XSD)}:string");
 
 				writer.WriteStartElement("pattern", Namespaces.XMLNS_XSD);
 				writer.WriteAttributeString("value", "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
@@ -1093,7 +1093,7 @@ namespace SoapCore.Meta
 			var typeInfo = type.GetTypeInfo();
 			var typeName = type.GetSerializedTypeName();
 
-			if (writer.TryAddSchemaTypeFromXmlSchemaProviderAttribute(type, name, SoapSerializer.XmlSerializer, _xmlNamespaceManager, isUnqualified))
+			if (writer.TryAddSchemaTypeFromXmlSchemaProviderAttribute(type, name, SoapSerializer.XmlSerializer, _xmlNamespaceLookup, isUnqualified))
 			{
 				return;
 			}
@@ -1132,12 +1132,12 @@ namespace SoapCore.Meta
 				}
 				else if (typeInfo.IsEnum)
 				{
-					xsTypename = new XmlQualifiedName(typeName, _xmlNamespaceManager.LookupNamespace("tns"));
+					xsTypename = new XmlQualifiedName(typeName, _xmlNamespaceLookup.LookupNamespace("tns"));
 					_enumToBuild.Enqueue(type);
 				}
 				else if (underlyingType?.IsEnum == true)
 				{
-					xsTypename = new XmlQualifiedName(underlyingType.GetSerializedTypeName(), _xmlNamespaceManager.LookupNamespace("tns"));
+					xsTypename = new XmlQualifiedName(underlyingType.GetSerializedTypeName(), _xmlNamespaceLookup.LookupNamespace("tns"));
 					writer.WriteAttributeString("nillable", "true");
 					_enumToBuild.Enqueue(underlyingType);
 				}
@@ -1186,7 +1186,7 @@ namespace SoapCore.Meta
 				}
 				else
 				{
-					writer.WriteAttributeString("type", $"{_xmlNamespaceManager.LookupPrefix(xsTypename.Namespace)}:{xsTypename.Name}");
+					writer.WriteAttributeString("type", $"{_xmlNamespaceLookup.LookupPrefix(xsTypename.Namespace)}:{xsTypename.Name}");
 				}
 
 				if (isAttribute && typeInfo.IsValueType && !isOptionalAttribute)
@@ -1221,7 +1221,7 @@ namespace SoapCore.Meta
 
 					writer.WriteAttributeString("name", name);
 					WriteQualification(writer, isUnqualified);
-					writer.WriteAttributeString("type", $"{_xmlNamespaceManager.LookupPrefix(Namespaces.XMLNS_XSD)}:base64Binary");
+					writer.WriteAttributeString("type", $"{_xmlNamespaceLookup.LookupPrefix(Namespaces.XMLNS_XSD)}:base64Binary");
 				}
 				else if (type.IsArray)
 				{

--- a/src/SoapCore/Meta/MetaMessage.cs
+++ b/src/SoapCore/Meta/MetaMessage.cs
@@ -10,14 +10,14 @@ namespace SoapCore.Meta
 	{
 		private readonly Message _message;
 		private readonly ServiceDescription _service;
-		private readonly XmlNamespaceManager _xmlNamespaceManager;
+		private readonly ConcurrentXmlNamespaceLookup _xmlNamespaceLookup;
 		private readonly string _bindingName;
 		private readonly bool _hasBasicAuthentication;
 		private readonly MessageVersion[] _soapVersions;
 
-		public MetaMessage(Message message, ServiceDescription service, XmlNamespaceManager xmlNamespaceManager, string bindingName, bool hasBasicAuthentication, MessageVersion[] soapVersions)
+		public MetaMessage(Message message, ServiceDescription service, ConcurrentXmlNamespaceLookup xmlNamespaceLookup, string bindingName, bool hasBasicAuthentication, MessageVersion[] soapVersions)
 		{
-			_xmlNamespaceManager = xmlNamespaceManager;
+			_xmlNamespaceLookup = xmlNamespaceLookup;
 			_message = message;
 			_service = service;
 			_bindingName = bindingName;
@@ -37,7 +37,7 @@ namespace SoapCore.Meta
 
 		protected override void OnWriteStartEnvelope(XmlDictionaryWriter writer)
 		{
-			writer.WriteStartElement(_xmlNamespaceManager.LookupPrefix(Namespaces.WSDL_NS), "definitions", Namespaces.WSDL_NS);
+			writer.WriteStartElement(_xmlNamespaceLookup.LookupPrefix(Namespaces.WSDL_NS), "definitions", Namespaces.WSDL_NS);
 
 			var wroteSoapNamespace = false;
 			if (_soapVersions.Contains(MessageVersion.Soap11) ||
@@ -70,7 +70,7 @@ namespace SoapCore.Meta
 			writer.WriteAttributeString("name", _service.ServiceName);
 			WriteXmlnsAttribute(writer, Namespaces.WSDL_NS);
 
-			if (!string.IsNullOrEmpty(_xmlNamespaceManager.LookupPrefix(Namespaces.MICROSOFT_TYPES)))
+			if (!string.IsNullOrEmpty(_xmlNamespaceLookup.LookupPrefix(Namespaces.MICROSOFT_TYPES)))
 			{
 				WriteXmlnsAttribute(writer, Namespaces.MICROSOFT_TYPES);
 			}
@@ -78,7 +78,7 @@ namespace SoapCore.Meta
 			if (_hasBasicAuthentication)
 			{
 				writer.WriteStartElement("Policy", Namespaces.WSP_NS);
-				writer.WriteAttributeString("Id", _xmlNamespaceManager.LookupPrefix(Namespaces.WSU_NS), $"{_bindingName}_{_service.GeneralContract.Name}_policy");
+				writer.WriteAttributeString("Id", _xmlNamespaceLookup.LookupPrefix(Namespaces.WSU_NS), $"{_bindingName}_{_service.GeneralContract.Name}_policy");
 				writer.WriteStartElement("ExactlyOne", Namespaces.WSP_NS);
 				writer.WriteStartElement("All", Namespaces.WSP_NS);
 				writer.WriteStartElement("BasicAuthentication", Namespaces.HTTP_NS);
@@ -108,7 +108,7 @@ namespace SoapCore.Meta
 
 		private void WriteXmlnsAttribute(XmlDictionaryWriter writer, string namespaceUri)
 		{
-			var prefix = string.IsNullOrEmpty(namespaceUri) ? null : _xmlNamespaceManager.LookupPrefix(namespaceUri);
+			var prefix = string.IsNullOrEmpty(namespaceUri) ? null : _xmlNamespaceLookup.LookupPrefix(namespaceUri);
 			writer.WriteXmlnsAttribute(prefix, namespaceUri);
 		}
 	}

--- a/src/SoapCore/Namespaces.cs
+++ b/src/SoapCore/Namespaces.cs
@@ -53,7 +53,7 @@ namespace SoapCore
 			return existingPrefix;
 		}
 
-		public static ConcurrentXmlNamespaceLookup CreateXmlNamespaceLookup(bool addMicrosoftTypesNamespace)
+		public static ConcurrentXmlNamespaceLookup CreateDefaultXmlNamespaceLookup(bool addMicrosoftTypesNamespace)
 		{
 			var xmlNamespaceLookup = new ConcurrentXmlNamespaceLookup();
 

--- a/src/SoapCore/Namespaces.cs
+++ b/src/SoapCore/Namespaces.cs
@@ -29,15 +29,15 @@ namespace SoapCore
 		public const string MICROSOFT_TYPES = "http://microsoft.com/wsdl/types/";
 #pragma warning restore SA1310 // Field names must not contain underscore
 
-		public static string AddNamespaceIfNotAlreadyPresentAndGetPrefix(XmlNamespaceManager xmlNamespaceManager, string preferredPrefix, string uri)
+		public static string AddNamespaceIfNotAlreadyPresentAndGetPrefix(ConcurrentXmlNamespaceLookup xmlNamespaceLookup, string preferredPrefix, string uri)
 		{
-			var existingPrefix = xmlNamespaceManager.LookupPrefix(uri);
+			var existingPrefix = xmlNamespaceLookup.LookupPrefix(uri);
 			if (existingPrefix == null)
 			{
 				var localPrefix = preferredPrefix;
 				for (int i = 1; ; i++)
 				{
-					var existingNamespace = xmlNamespaceManager.LookupNamespace(localPrefix);
+					var existingNamespace = xmlNamespaceLookup.LookupNamespace(localPrefix);
 					if (existingNamespace == null)
 					{
 						break;
@@ -46,35 +46,35 @@ namespace SoapCore
 					localPrefix = $"{preferredPrefix}{i}";
 				}
 
-				xmlNamespaceManager.AddNamespace(localPrefix, uri);
+				xmlNamespaceLookup.AddNamespace(localPrefix, uri);
 				return localPrefix;
 			}
 
 			return existingPrefix;
 		}
 
-		public static XmlNamespaceManager CreateDefaultXmlNamespaceManager(bool addMicrosoftTypesNamespace)
+		public static ConcurrentXmlNamespaceLookup CreateXmlNamespaceLookup(bool addMicrosoftTypesNamespace)
 		{
-			var xmlNamespaceManager = new XmlNamespaceManager(new NameTable());
+			var xmlNamespaceLookup = new ConcurrentXmlNamespaceLookup();
 
-			xmlNamespaceManager.AddNamespace("xsd", Namespaces.XMLNS_XSD);
-			xmlNamespaceManager.AddNamespace("wsdl", Namespaces.WSDL_NS);
-			xmlNamespaceManager.AddNamespace("msc", Namespaces.MSC_NS);
-			xmlNamespaceManager.AddNamespace("wsp", Namespaces.WSP_NS);
-			xmlNamespaceManager.AddNamespace("wsu", Namespaces.WSU_NS);
-			xmlNamespaceManager.AddNamespace("http", Namespaces.HTTP_NS);
-			xmlNamespaceManager.AddNamespace("http1", Namespaces.TRANSPORT_SCHEMA);
-			xmlNamespaceManager.AddNamespace("soap", Namespaces.SOAP11_NS);
-			xmlNamespaceManager.AddNamespace("soap12", Namespaces.SOAP12_NS);
-			xmlNamespaceManager.AddNamespace("ser", Namespaces.SERIALIZATION_NS);
-			xmlNamespaceManager.AddNamespace("wsam", Namespaces.WSAM_NS);
+			xmlNamespaceLookup.AddNamespace("xsd", Namespaces.XMLNS_XSD);
+			xmlNamespaceLookup.AddNamespace("wsdl", Namespaces.WSDL_NS);
+			xmlNamespaceLookup.AddNamespace("msc", Namespaces.MSC_NS);
+			xmlNamespaceLookup.AddNamespace("wsp", Namespaces.WSP_NS);
+			xmlNamespaceLookup.AddNamespace("wsu", Namespaces.WSU_NS);
+			xmlNamespaceLookup.AddNamespace("http", Namespaces.HTTP_NS);
+			xmlNamespaceLookup.AddNamespace("http1", Namespaces.TRANSPORT_SCHEMA);
+			xmlNamespaceLookup.AddNamespace("soap", Namespaces.SOAP11_NS);
+			xmlNamespaceLookup.AddNamespace("soap12", Namespaces.SOAP12_NS);
+			xmlNamespaceLookup.AddNamespace("ser", Namespaces.SERIALIZATION_NS);
+			xmlNamespaceLookup.AddNamespace("wsam", Namespaces.WSAM_NS);
 
 			if (addMicrosoftTypesNamespace)
 			{
-				xmlNamespaceManager.AddNamespace("mst", Namespaces.MICROSOFT_TYPES);
+				xmlNamespaceLookup.AddNamespace("mst", Namespaces.MICROSOFT_TYPES);
 			}
 
-			return xmlNamespaceManager;
+			return xmlNamespaceLookup;
 		}
 	}
 }

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -47,7 +47,6 @@ namespace SoapCore
 		private readonly IXmlSerializationHandler _serializerHandler;
 		private static IOperationInvoker _operationInvoker;
 
-		private readonly ConcurrentDictionary<string, XmlNamespaceManager> _xmlNamespaceManagersByMessageEncoder = new ConcurrentDictionary<string, XmlNamespaceManager>();
 		public SoapEndpointMiddleware(ILogger<SoapEndpointMiddleware<T_MESSAGE>> logger, RequestDelegate next, SoapOptions options, IServiceProvider serviceProvider)
 		{
 			_logger = logger;
@@ -1174,7 +1173,7 @@ namespace SoapCore
 			
 		private XmlNamespaceManager GetXmlNamespaceManager(SoapMessageEncoder messageEncoder)
 		{
-			return _xmlNamespaceManagersByMessageEncoder.GetOrAdd(messageEncoder?.ToString() ?? "no_encoder", _ => CreateDefaultNamespaceManager(messageEncoder));
+			return CreateDefaultNamespaceManager(messageEncoder);
 
 			XmlNamespaceManager CreateDefaultNamespaceManager(SoapMessageEncoder messageEncoder)
 			{

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -47,6 +47,7 @@ namespace SoapCore
 		private readonly IXmlSerializationHandler _serializerHandler;
 		private static IOperationInvoker _operationInvoker;
 
+		private readonly ConcurrentDictionary<string, ConcurrentXmlNamespaceLookup> _xmlNamespaceLookupsByMessageEncoder = new ConcurrentDictionary<string, ConcurrentXmlNamespaceLookup>();
 		public SoapEndpointMiddleware(ILogger<SoapEndpointMiddleware<T_MESSAGE>> logger, RequestDelegate next, SoapOptions options, IServiceProvider serviceProvider)
 		{
 			_logger = logger;
@@ -235,10 +236,10 @@ namespace SoapCore
 		{
 			var scheme = string.IsNullOrEmpty(_options.SchemeOverride) ? httpContext.Request.Scheme : _options.SchemeOverride;
 			var baseUrl = scheme + "://" + httpContext.Request.Host + httpContext.Request.PathBase + httpContext.Request.Path;
-			var xmlNamespaceManager = GetXmlNamespaceManager(null);
+			var xmlNamespaceLookup = GetXmlNamespaceLookup(null);
 			var bindingName = !string.IsNullOrWhiteSpace(_options.EncoderOptions[0].BindingName) ? _options.EncoderOptions[0].BindingName : "BasicHttpBinding_" + _service.GeneralContract.Name;
 			var bodyWriter = _options.SoapSerializer == SoapSerializer.XmlSerializer
-				? new MetaBodyWriter(_service, baseUrl, xmlNamespaceManager, bindingName, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray(), _options.UseMicrosoftGuid, _options.WsdlOperationNameGenerator)
+				? new MetaBodyWriter(_service, baseUrl, xmlNamespaceLookup, bindingName, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray(), _options.UseMicrosoftGuid, _options.WsdlOperationNameGenerator)
 				: (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, bindingName, _options.UseBasicAuthentication, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray(), _options.WsdlOperationNameGenerator);
 
 			//assumption that you want soap12 if your service supports that
@@ -248,7 +249,7 @@ namespace SoapCore
 			using var responseMessage = new MetaMessage(
 				Message.CreateMessage(messageEncoder.MessageVersion, null, bodyWriter),
 				_service,
-				GetXmlNamespaceManager(messageEncoder),
+				GetXmlNamespaceLookup(messageEncoder),
 				bindingName,
 				_options.UseBasicAuthentication,
 				soapVersions);
@@ -590,7 +591,7 @@ namespace SoapCore
 
 			// Create response message
 			var bodyWriter = new ServiceBodyWriter(_options.SoapSerializer, operation, responseObject, resultOutDictionary);
-			var xmlNamespaceManager = GetXmlNamespaceManager(soapMessageEncoder);
+			var xmlNamespaceLookup = GetXmlNamespaceLookup(soapMessageEncoder);
 
 			if (soapMessageEncoder.MessageVersion.Addressing == AddressingVersion.WSAddressing10)
 			{
@@ -599,7 +600,7 @@ namespace SoapCore
 					StandAloneAttribute = _options.StandAloneAttribute,
 					Message = Message.CreateMessage(soapMessageEncoder.MessageVersion, soapAction, bodyWriter),
 					AdditionalEnvelopeXmlnsAttributes = _options.AdditionalEnvelopeXmlnsAttributes,
-					NamespaceManager = xmlNamespaceManager
+					XmlNamespaceLookup = xmlNamespaceLookup
 				};
 
 				responseMessage.Headers.Action = operation.ReplyAction;
@@ -613,7 +614,7 @@ namespace SoapCore
 					StandAloneAttribute = _options.StandAloneAttribute,
 					Message = Message.CreateMessage(soapMessageEncoder.MessageVersion, null, bodyWriter),
 					AdditionalEnvelopeXmlnsAttributes = _options.AdditionalEnvelopeXmlnsAttributes,
-					NamespaceManager = xmlNamespaceManager
+					XmlNamespaceLookup = xmlNamespaceLookup
 				};
 			}
 
@@ -837,13 +838,13 @@ namespace SoapCore
 		{
 
 			var messageHeadersMembers = (from p in parameterType.GetPropertyOrFieldMembers()
-					   let attr = p.GetCustomAttribute<MessageHeaderAttribute>()
-					   where attr != null
-					   select new
-					   {
-						   MemberInfo = p,
-						   MessageHeaderMemberAttribute = attr
-					   }).ToArray();
+										 let attr = p.GetCustomAttribute<MessageHeaderAttribute>()
+										 where attr != null
+										 select new
+										 {
+											 MemberInfo = p,
+											 MessageHeaderMemberAttribute = attr
+										 }).ToArray();
 
 			var wrapperObject = Activator.CreateInstance(parameterInfo.Parameter.ParameterType);
 
@@ -981,9 +982,9 @@ namespace SoapCore
 		{
 			_logger.LogError(exception, "An error occurred processing the message");
 
-			var xmlNamespaceManager = GetXmlNamespaceManager(messageEncoder);
+			var xmlNamespaceLookup = GetXmlNamespaceLookup(messageEncoder);
 			var faultExceptionTransformer = serviceProvider.GetRequiredService<IFaultExceptionTransformer>();
-			var faultMessage = faultExceptionTransformer.ProvideFault(exception, messageEncoder.MessageVersion, requestMessage, xmlNamespaceManager);
+			var faultMessage = faultExceptionTransformer.ProvideFault(exception, messageEncoder.MessageVersion, requestMessage, xmlNamespaceLookup);
 
 			if (!httpContext.Response.HasStarted)
 			{
@@ -1170,22 +1171,22 @@ namespace SoapCore
 			httpContext.Response.ContentType = "text/xml;charset=UTF-8";
 			await httpContext.Response.WriteAsync(modifiedWsdl);
 		}
-			
-		private XmlNamespaceManager GetXmlNamespaceManager(SoapMessageEncoder messageEncoder)
+
+		private ConcurrentXmlNamespaceLookup GetXmlNamespaceLookup(SoapMessageEncoder messageEncoder)
 		{
-			return CreateDefaultNamespaceManager(messageEncoder);
+			return _xmlNamespaceLookupsByMessageEncoder.GetOrAdd(messageEncoder?.ToString() ?? "no_encoder", _ => CreateDefaultNamespaceManager(messageEncoder));
 
-			XmlNamespaceManager CreateDefaultNamespaceManager(SoapMessageEncoder messageEncoder)
+			ConcurrentXmlNamespaceLookup CreateDefaultNamespaceManager(SoapMessageEncoder messageEncoder)
 			{
-				var xmlNamespaceManager = Namespaces.CreateDefaultXmlNamespaceManager(_options.UseMicrosoftGuid);
+				var xmlNamespaceLookup = Namespaces.CreateXmlNamespaceLookup(_options.UseMicrosoftGuid);
 
-				xmlNamespaceManager.AddNamespace("tns", _service.GeneralContract.Namespace);
+				xmlNamespaceLookup.AddNamespace("tns", _service.GeneralContract.Namespace);
 
 				if (_options.XmlNamespacePrefixOverrides != null)
 				{
 					foreach (var ns in _options.XmlNamespacePrefixOverrides.GetNamespacesInScope(XmlNamespaceScope.Local))
 					{
-						xmlNamespaceManager.AddNamespace(ns.Key, ns.Value);
+						xmlNamespaceLookup.AddNamespace(ns.Key, ns.Value);
 					}
 				}
 
@@ -1193,11 +1194,11 @@ namespace SoapCore
 				{
 					foreach (var ns in messageEncoder.XmlNamespaceOverrides.GetNamespacesInScope(XmlNamespaceScope.Local))
 					{
-						xmlNamespaceManager.AddNamespace(ns.Key, ns.Value);
+						xmlNamespaceLookup.AddNamespace(ns.Key, ns.Value);
 					}
 				}
 
-				return xmlNamespaceManager;
+				return xmlNamespaceLookup;
 			}
 		}
 	}

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -1178,7 +1178,7 @@ namespace SoapCore
 
 			ConcurrentXmlNamespaceLookup CreateDefaultNamespaceManager(SoapMessageEncoder messageEncoder)
 			{
-				var xmlNamespaceLookup = Namespaces.CreateXmlNamespaceLookup(_options.UseMicrosoftGuid);
+				var xmlNamespaceLookup = Namespaces.CreateDefaultXmlNamespaceLookup(_options.UseMicrosoftGuid);
 
 				xmlNamespaceLookup.AddNamespace("tns", _service.GeneralContract.Namespace);
 


### PR DESCRIPTION
Fix: "A concurrent update was performed on this collection and corrupted its state."

Don't share XmlNamespaceManager kept in a singleton with request scoped objects that modify it to avoid state corruption.

XmlNamespaceManager Is not thread safe!