### PR TITLE
fixed generic type serialization in GetSerializedTypeName

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/ComplexTypeWithGeneric.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ComplexTypeWithGeneric.cs
@@ -1,0 +1,26 @@
+﻿namespace SoapCore.Tests.Wsdl.Services;
+
+public class ComplexTypeWithGeneric
+{
+	public int Id { get; set; }
+
+	public InnerGenericTypeWithSingleArgument<InnerType> SingleGenericArgument { get; set; }
+
+	public InnerGenericTypeWithMultipleArguments<InnerType, InnerType> MultipleGenericArguments { get; set; }
+
+	public class InnerGenericTypeWithSingleArgument<T>
+		where T : class
+	{
+	}
+
+	public class InnerGenericTypeWithMultipleArguments<T, TK>
+		where T : class
+		where TK : class
+	{
+	}
+
+	public class InnerType
+	{
+		public string Text { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/ComplexTypeWithMultipleGenericArguments.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ComplexTypeWithMultipleGenericArguments.cs
@@ -1,0 +1,19 @@
+﻿namespace SoapCore.Tests.Wsdl.Services;
+
+public class ComplexTypeWithMultipleGenericArguments
+{
+	public int Id { get; set; }
+
+	public InnerGenericType<InnerType, InnerType> InnerObject { get; set; }
+
+	public class InnerGenericType<T, TK>
+		where T : class
+		where TK : class
+	{
+	}
+
+	public class InnerType
+	{
+		public string Text { get; set; }
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/Services/IComplexGenericTypeService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IComplexGenericTypeService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface IComplexGenericTypeService
+	{
+		[OperationContract]
+		void Test(ComplexTypeWithGeneric model);
+	}
+
+	public class ComplexGenericTypeService : IComplexGenericTypeService
+	{
+		public void Test(ComplexTypeWithGeneric model) => throw new NotImplementedException();
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -1361,6 +1361,52 @@ namespace SoapCore.Tests.Wsdl
 			Assert.IsNotNull(arrayElementType);
 		}
 
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
+		public async Task CheckComplexGenericTypeWithSingleArgumentWsdl(SoapSerializer soapSerializer)
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<ComplexGenericTypeService>(soapSerializer);
+			Trace.TraceInformation(wsdl);
+			Assert.IsNotNull(wsdl);
+
+			var root = XElement.Parse(wsdl);
+
+			var endpointInnerObjectTypeArgument = GetElements(root, _xmlSchema + "element")
+				.SingleOrDefault(a => a.Attribute("name")?.Value.Equals(nameof(ComplexTypeWithGeneric.SingleGenericArgument)) == true);
+
+			Assert.IsNotNull(endpointInnerObjectTypeArgument);
+
+			var typeName = endpointInnerObjectTypeArgument.Attribute("type")?.Value;
+
+			const string genericTypeName = "InnerGenericTypeWithSingleArgument";
+			const string genericTypeArgumentName = "InnerType";
+
+			Assert.AreEqual($"tns:{genericTypeName}Of{genericTypeArgumentName}", typeName);
+		}
+
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
+		public async Task CheckComplexGenericTypeWithMultipleArgumentsWsdl(SoapSerializer soapSerializer)
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<ComplexGenericTypeService>(soapSerializer);
+			Trace.TraceInformation(wsdl);
+			Assert.IsNotNull(wsdl);
+
+			var root = XElement.Parse(wsdl);
+
+			var endpointInnerObjectTypeArgument = GetElements(root, _xmlSchema + "element")
+				.SingleOrDefault(a => a.Attribute("name")?.Value.Equals(nameof(ComplexTypeWithGeneric.MultipleGenericArguments)) == true);
+
+			Assert.IsNotNull(endpointInnerObjectTypeArgument);
+
+			var typeName = endpointInnerObjectTypeArgument.Attribute("type")?.Value;
+
+			const string genericTypeName = "InnerGenericTypeWithMultipleArguments";
+			const string genericTypeArgumentName = "InnerType";
+
+			Assert.AreEqual($"tns:{genericTypeName}Of{genericTypeArgumentName}{genericTypeArgumentName}", typeName);
+		}
+
 		[TestMethod]
 		public void CheckSchemeOverride()
 		{

--- a/src/SoapCore/Meta/BodyWriterExtensions.cs
+++ b/src/SoapCore/Meta/BodyWriterExtensions.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Text;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
@@ -237,8 +239,30 @@ namespace SoapCore.Meta
 
 				typeName = GetArrayTypeName(typeName.Replace("[]", string.Empty), isNullableArray);
 			}
+			else if (isGenericType)
+			{
+				typeName = namedType.GetGenericTypeName();
+			}
 
 			return typeName;
+		}
+
+		/// <summary>
+		/// Returns the name of the type without the generic arity.
+		/// <example>
+		/// <c>typeof(List&lt;int&gt;).Name</c> is <c>List`1</c>.
+		/// <br/>
+		/// <c>typeof(List&lt;int&gt;).GetNameWithoutGenericArity()</c> is <c>List</c>.
+		/// </example>
+		/// </summary>
+		/// <param name="type">Type</param>
+		/// <returns>Type name without the generic arity</returns>
+		public static string GetNameWithoutGenericArity(this Type type)
+		{
+			var arityIndex = type.Name.IndexOf('`');
+			return arityIndex == -1
+				? type.Name
+				: type.Name.Substring(0, arityIndex);
 		}
 
 		private static string GetArrayTypeName(string typeName, bool isNullable)
@@ -265,6 +289,24 @@ namespace SoapCore.Meta
 			}
 
 			return input.First().ToString().ToUpper() + input.Substring(1);
+		}
+
+		private static string GetGenericTypeName(this Type type)
+		{
+			var clearName = type.GetNameWithoutGenericArity();
+
+			var genericArguments = type.GetGenericArguments();
+
+			var sb = new StringBuilder(clearName);
+
+			sb.Append("Of");
+
+			foreach (var arg in genericArguments)
+			{
+				sb.Append(arg.GetNameWithoutGenericArity());
+			}
+
+			return sb.ToString();
 		}
 	}
 }


### PR DESCRIPTION
My contracts contain generic classes.  

__SoapCore__ lib generates the next WSDL schema:  
```xml
<xsd:complexType name="SomeParentObj">
  <xsd:complexContent mixed="false">
    <xsd:extension base="tns:GenericObj`1"> <--- Here is the problem
      <xsd:sequence>
        <xsd:element minOccurs="1" maxOccurs="1" name="Field1" type="xsd:boolean"/>
        <xsd:element minOccurs="1" maxOccurs="1" name="Field2" type="xsd:boolean"/>
        <xsd:element minOccurs="1" maxOccurs="1" name="Field3" type="xsd:boolean"/>
...
```

Attempting to generate `.cs` file using __wsdl.exe__ utility results in an error:  
> Error: Schema item 'complexType' named 'SomeParentObj' from namespace {namespace}
>  - Invalid 'base' attribute: 'The '`' character, hexadecimal value 0x60, cannot be included in a name.'.
>  - The '`' character, hexadecimal value 0x60, cannot be included in a name.