### PR TITLE
Enable CA1865-CA1867: Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1,0 +1,13 @@
+is_global = true
+
+# CA1865: Use char overload
+# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1865
+dotnet_diagnostic.CA1865.severity = warning
+
+# CA1866: Use char overload
+# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1866
+dotnet_diagnostic.CA1866.severity = warning
+
+# CA1867: Use char overload
+# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1867
+dotnet_diagnostic.CA1867.severity = warning

--- a/src/SoapCore/ServiceModel/OperationDescription.cs
+++ b/src/SoapCore/ServiceModel/OperationDescription.cs
@@ -189,7 +189,7 @@ namespace SoapCore.ServiceModel
 
 		private static string GetNameByAction(string action)
 		{
-			var index = action?.LastIndexOf("/");
+			var index = action?.LastIndexOf('/');
 			return (index ?? -1) > -1
 				? action.Substring(index.Value + 1, action.Length - index.Value - 1)
 				: null;


### PR DESCRIPTION
Fix https://github.com/DigDes/SoapCore/issues/1156

https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1865-ca1867