### PR TITLE
Fix SA1127: Generic type constraints should be on their own line

### DIFF
--- a/src/SoapCore/MembersWithAttributeCache.cs
+++ b/src/SoapCore/MembersWithAttributeCache.cs
@@ -5,7 +5,8 @@ namespace SoapCore
 {
 	internal static partial class ReflectionExtensions
 	{
-		private static class MembersWithAttributeCache<TAttribute> where TAttribute : Attribute
+		private static class MembersWithAttributeCache<TAttribute>
+			where TAttribute : Attribute
 		{
 			public static ConcurrentDictionary<Type, MemberWithAttribute<TAttribute>[]> CacheEntries = new();
 		}

--- a/src/SoapCore/ReflectionExtensions.cs
+++ b/src/SoapCore/ReflectionExtensions.cs
@@ -141,7 +141,7 @@ namespace SoapCore
 		}
 
 		internal static IEnumerable<MemberWithAttribute<TAttribute>> GetMembersWithAttribute<TAttribute>(this Type type)
-	where TAttribute : Attribute
+			where TAttribute : Attribute
 		{
 			// return from p in GetPropertyOrFieldMembers(type)
 			//     let attr = p.GetCustomAttribute<TAttribute>()
@@ -151,7 +151,7 @@ namespace SoapCore
 		}
 
 		private static MemberWithAttribute<TAttribute>[] ComputeMembersWithAttribute<TAttribute>(Type type)
-		   where TAttribute : Attribute
+			where TAttribute : Attribute
 		{
 			var res = from p in GetPropertyOrFieldMembers(type)
 					  let attr = p.GetCustomAttribute<TAttribute>()

--- a/src/SoapCore/SoapEndpointExtensions.cs
+++ b/src/SoapCore/SoapEndpointExtensions.cs
@@ -145,7 +145,7 @@ namespace SoapCore
 		}
 
 		public static IEndpointConventionBuilder UseSoapEndpoint<T, T_MESSAGE>(this IEndpointRouteBuilder routes, string path, SoapEncoderOptions[] encoders, SoapSerializer serializer = SoapSerializer.DataContractSerializer, bool caseInsensitivePath = false, ISoapModelBounder soapModelBounder = null, WsdlFileOptions wsdlFileOptions = null, bool indentXml = true, bool omitXmlDeclaration = true, string schemeOverride = null)
-		where T_MESSAGE : CustomMessage, new()
+			where T_MESSAGE : CustomMessage, new()
 		{
 			return routes.UseSoapEndpoint<T, T_MESSAGE>(opt =>
 			{


### PR DESCRIPTION
Contributes to https://github.com/DigDes/SoapCore/issues/1163

https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1127.md