### PR TITLE
Issue 1161 - creates various ways to trigger the exception

### DIFF
--- a/issue1161/MyMessage.cs
+++ b/issue1161/MyMessage.cs
@@ -1,0 +1,40 @@
+using System.ServiceModel;
+using System.Xml;
+using System.Xml.Serialization;
+
+[MessageContract]
+public class MyMessage {
+    private string _body;
+
+    [MessageHeader(Name = "MessageHeader", Namespace = "http://www.ebxml.org/namespaces/messageHeader")]
+    public MyMessageHeader Header { get; set; }
+
+    [MessageBodyMember]
+    public string BodyMessage
+    {
+        get => _body;
+        set => _body = value;
+    }
+}
+
+
+[XmlType(AnonymousType = true, Namespace = "http://www.ebxml.org/namespaces/messageHeader")]
+public class MyMessageHeader
+{
+    private string _from;
+    private XmlAttribute[] _anyAttr;
+
+    [XmlElement(Order = 0)]
+    public string From
+    {
+        get => _from;
+        set => _from = value;
+    }
+
+    [XmlAnyAttribute]
+    public XmlAttribute[] SomeOtherAttributes
+    {
+        get => _anyAttr;
+        set => _anyAttr = value;
+    }
+}

--- a/issue1161/MySoapService.cs
+++ b/issue1161/MySoapService.cs
@@ -1,0 +1,17 @@
+using System.ServiceModel;
+
+[ServiceContract]
+public interface IMySoapService
+{
+    [OperationContract]
+    MyMessage Process(MyMessage rq);
+}
+
+public class MySoapService : IMySoapService
+{
+    public MyMessage Process(MyMessage msg)
+    {
+        return msg;
+    }
+
+}

--- a/issue1161/Program.cs
+++ b/issue1161/Program.cs
@@ -1,0 +1,22 @@
+using System.ServiceModel.Channels;
+using SoapCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSoapCore();
+builder.Services.AddSingleton<IMySoapService, MySoapService>();
+
+var app = builder.Build();
+
+
+app.UseRouting();
+app.UseEndpoints(endpoints =>
+{
+    endpoints.UseSoapEndpoint<IMySoapService>("/myService", new SoapEncoderOptions()
+        {
+            MessageVersion = MessageVersion.Soap11
+        },
+        SoapSerializer.XmlSerializer);
+});
+
+app.Run();

--- a/issue1161/Properties/launchSettings.json
+++ b/issue1161/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:15581",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "myService",
+      "applicationUrl": "http://localhost:5220",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "myService",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/issue1161/SoapCore-Issue-1161.csproj
+++ b/issue1161/SoapCore-Issue-1161.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>SoapCore_Issue_1161</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\SoapCore\SoapCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/issue1161/SoapCore-Issue-1161.http
+++ b/issue1161/SoapCore-Issue-1161.http
@@ -1,0 +1,46 @@
+@SoapCore_Issue_1161_HostAddress = http://localhost:5220
+
+### Get WSDL
+GET {{SoapCore_Issue_1161_HostAddress}}/myService
+Accept: application/json
+
+
+### Test SOAP ProcessUser (passes)
+POST {{SoapCore_Issue_1161_HostAddress}}/myService
+Content-Type: text/xml; charset=utf-8
+SOAPAction: "http://tempuri.org/IMySoapService/Process"
+
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Header>
+    <MessageHeader xmlns="http://www.ebxml.org/namespaces/messageHeader" >
+      <From>SomeSender</From>
+    </MessageHeader>
+  </s:Header>
+  <s:Body>
+   <MyMessage xmlns="http://tempuri.org/">
+      <BodyMessage>someBody</BodyMessage>
+    </MyMessage>
+  </s:Body>
+ </s:Envelope>
+
+### Test SOAP ProcessUser (fails with SoapCore 1.2.1)
+POST {{SoapCore_Issue_1161_HostAddress}}/myService
+Content-Type: text/xml; charset=utf-8
+SOAPAction: "http://tempuri.org/IMySoapService/Process"
+
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Header>
+    <h:MessageHeader xmlns:h="http://www.ebxml.org/namespaces/messageHeader"
+      xmlns="http://www.ebxml.org/namespaces/messageHeader" >
+      <From>SomeSender</From>
+    </h:MessageHeader>
+  </s:Header>
+  <s:Body>
+   <MyMessage xmlns="http://tempuri.org/">
+      <BodyMessage>someBody</BodyMessage>
+    </MyMessage>
+  </s:Body>
+ </s:Envelope>
+

--- a/issue1161/appsettings.Development.json
+++ b/issue1161/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/issue1161/appsettings.json
+++ b/issue1161/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/SoapCore.Tests/ITestService.cs
+++ b/src/SoapCore.Tests/ITestService.cs
@@ -5,6 +5,7 @@ using System.Xml;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SoapCore.Tests.Model;
+using SoapCore.Tests.Serialization.Models.DataContract;
 
 namespace SoapCore.Tests
 {
@@ -105,6 +106,9 @@ namespace SoapCore.Tests
 
 		[OperationContract]
 		XmlElement XmlElementInput(XmlElement input);
+
+		[OperationContract]
+		MessageHeadersModelWithDuplicateNamespaces GetWithDuplicateNamespaces(MessageHeadersModelWithDuplicateNamespaces input);
 
 		/// <summary>
 		/// Return type is different than the one bellow due to customizations. Use SoapCore.Tests.NativeAuthenticationAndAuthorization.IActionResultContractService to access these endpoints.

--- a/src/SoapCore.Tests/IntegrationTests.cs
+++ b/src/SoapCore.Tests/IntegrationTests.cs
@@ -248,6 +248,20 @@ namespace SoapCore.Tests
 		}
 
 		[TestMethod]
+		public void MessageWithDuplicateNamespace()
+		{
+			var client = CreateClient();
+			var output = client.GetWithDuplicateNamespaces(new ()
+			{
+				BodyMessage = "test",
+				Header = new () { From = "test" }
+			});
+
+			Assert.AreEqual("test", output.BodyMessage);
+			Assert.AreEqual("test", output.Header.From);
+		}
+
+		[TestMethod]
 		public void ThrowsFaultException()
 		{
 			var client = CreateClient();

--- a/src/SoapCore.Tests/Serialization/MessageHeadersTests.cs
+++ b/src/SoapCore.Tests/Serialization/MessageHeadersTests.cs
@@ -149,5 +149,37 @@ namespace SoapCore.Tests.Serialization
 			Assert.Equal(model.Prop3, result.Prop3);
 			Assert.Equal(model.Prop4, result.Prop4);
 		}
+
+		[Theory]
+		[InlineData(SoapSerializer.XmlSerializer)]
+		public void TestMessageWithDuplicateNamespace(SoapSerializer serializer)
+		{
+			var service = _fixture.GetSampleServiceClient(serializer);
+			var model = new MessageHeadersModelWithDuplicateNamespaces
+			{
+				BodyMessage = "test",
+				Header = new MessageHeadersModelWithDuplicateNamespacesHeader()
+				{
+					From = "test"
+				}
+			};
+
+			_fixture.ServiceMock.Setup(x => x.GetWithDuplicateNamespaces(It.IsAny<MessageHeadersModelWithDuplicateNamespaces>())).Callback((MessageHeadersModelWithDuplicateNamespaces m) =>
+			{
+				m.ShouldDeepEqual(model);
+			}).Returns(new MessageHeadersModelWithDuplicateNamespaces
+			{
+				BodyMessage = "test",
+				Header = new MessageHeadersModelWithDuplicateNamespacesHeader()
+				{
+					From = "test"
+				}
+			});
+
+			var result = service.GetWithDuplicateNamespaces(model);
+
+			Assert.Equal(model.BodyMessage, result.BodyMessage);
+			Assert.Equal(model.Header.From, result.Header.From);
+		}
 	}
 }

--- a/src/SoapCore.Tests/Serialization/Models.DataContract/ISampleServiceWithMessageHeaders.cs
+++ b/src/SoapCore.Tests/Serialization/Models.DataContract/ISampleServiceWithMessageHeaders.cs
@@ -13,5 +13,8 @@ namespace SoapCore.Tests.Serialization.Models.DataContract
 
 		[OperationContract]
 		MessageHeadersModelWithNamespace GetWithNamespace(MessageHeadersModelWithNamespace model);
+
+		[OperationContract]
+		MessageHeadersModelWithDuplicateNamespaces GetWithDuplicateNamespaces(MessageHeadersModelWithDuplicateNamespaces input);
 	}
 }

--- a/src/SoapCore.Tests/Serialization/Models.DataContract/MessageHeadersModelWithDuplicateNamespaces.cs
+++ b/src/SoapCore.Tests/Serialization/Models.DataContract/MessageHeadersModelWithDuplicateNamespaces.cs
@@ -1,0 +1,14 @@
+using System.Runtime.Serialization;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Serialization.Models.DataContract;
+
+[MessageContract]
+public class MessageHeadersModelWithDuplicateNamespaces
+{
+	[MessageHeader(Name = "MessageHeader", Namespace = "MessageWithNamespacesHeaderNamespace")]
+	public MessageHeadersModelWithDuplicateNamespacesHeader Header { get; set; }
+
+	[MessageBodyMember]
+	public string BodyMessage { get; set; }
+}

--- a/src/SoapCore.Tests/Serialization/Models.DataContract/MessageHeadersModelWithDuplicateNamespacesHeader.cs
+++ b/src/SoapCore.Tests/Serialization/Models.DataContract/MessageHeadersModelWithDuplicateNamespacesHeader.cs
@@ -1,0 +1,14 @@
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace SoapCore.Tests.Serialization.Models.DataContract;
+
+[XmlType(AnonymousType = true, Namespace = "MessageWithNamespacesHeaderNamespace")]
+public class MessageHeadersModelWithDuplicateNamespacesHeader
+{
+	[XmlElement(Order = 0)]
+	public string From { get; set; }
+
+	[XmlAnyAttribute]
+	public XmlAttribute[] SomeOtherAttributes { get; set; }
+}

--- a/src/SoapCore.Tests/SoapCore.Tests.csproj
+++ b/src/SoapCore.Tests/SoapCore.Tests.csproj
@@ -54,7 +54,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.Formats.Asn1" Version="9.0.2"/>
+		<PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
 		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.2" />
 	</ItemGroup>
 

--- a/src/SoapCore.Tests/TestService.cs
+++ b/src/SoapCore.Tests/TestService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.AspNetCore.Mvc;
 using SoapCore.Tests.Model;
+using SoapCore.Tests.Serialization.Models.DataContract;
 
 namespace SoapCore.Tests
 {
@@ -365,6 +366,11 @@ namespace SoapCore.Tests
 					StatusCode = 500
 				};
 			}
+		}
+
+		public MessageHeadersModelWithDuplicateNamespaces GetWithDuplicateNamespaces(MessageHeadersModelWithDuplicateNamespaces input)
+		{
+			return input;
 		}
 	}
 }

--- a/src/SoapCore.sln
+++ b/src/SoapCore.sln
@@ -1,12 +1,14 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36705.20 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoapCore", "SoapCore\SoapCore.csproj", "{576F47D4-97EC-4D42-8CD5-89648EEAB688}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoapCore.Tests", "SoapCore.Tests\SoapCore.Tests.csproj", "{2B200D78-B473-4590-9E4C-532AD0219BA9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoapCore.Benchmark", "SoapCore.Benchmark\SoapCore.Benchmark.csproj", "{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SoapCore-Issue-1161", "..\issue1161\SoapCore-Issue-1161.csproj", "{26918EE6-B839-7C0E-D4D1-5C9BAD20B69F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -54,6 +56,18 @@ Global
 		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Release|x64.Build.0 = Release|Any CPU
 		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Release|x86.ActiveCfg = Release|Any CPU
 		{B54A69DB-ADA2-48E0-A0D7-7649EDA987E1}.Release|x86.Build.0 = Release|Any CPU
+		{26918EE6-B839-7C0E-D4D1-5C9BAD20B69F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26918EE6-B839-7C0E-D4D1-5C9BAD20B69F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26918EE6-B839-7C0E-D4D1-5C9BAD20B69F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{26918EE6-B839-7C0E-D4D1-5C9BAD20B69F}.Debug|x64.Build.0 = Debug|Any CPU
+		{26918EE6-B839-7C0E-D4D1-5C9BAD20B69F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{26918EE6-B839-7C0E-D4D1-5C9BAD20B69F}.Debug|x86.Build.0 = Debug|Any CPU
+		{26918EE6-B839-7C0E-D4D1-5C9BAD20B69F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26918EE6-B839-7C0E-D4D1-5C9BAD20B69F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26918EE6-B839-7C0E-D4D1-5C9BAD20B69F}.Release|x64.ActiveCfg = Release|Any CPU
+		{26918EE6-B839-7C0E-D4D1-5C9BAD20B69F}.Release|x64.Build.0 = Release|Any CPU
+		{26918EE6-B839-7C0E-D4D1-5C9BAD20B69F}.Release|x86.ActiveCfg = Release|Any CPU
+		{26918EE6-B839-7C0E-D4D1-5C9BAD20B69F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR is demonstrating the issue #1161 by adding a Minimal Reproductible Example.

This creates three ways to trigger the issue, unfortunately with 3 different results, and I'm not sure whether they are the result of unit tests misconfiguration or other underlying problems:

- The new unit test in `MessageHeadersTests` fails the comparison because the `Header` is not filled
- The new unit test in `IntegrationTests` throws a weird exception wherein it mentions different property names

The third way to trigger the exception is as follows:

- open the solution with Visual Studio
- ensure you have the proper exception settings: menu Debug > Windows > Exception Settings, then check the root of "Common Language Runtime Exceptions"
- right click on the project "SoapCore-Issue-1161" and click "Set as startup project"
- run the project (F5)
- in the project, open the file "SoapCore-Issue-1161.http"
- in the second request, click "send request"
<img width="547" height="108" alt="image" src="https://github.com/user-attachments/assets/001abd1a-7b2f-4da0-ba18-bfb1f6f0f91f" />

This should put you in the place that throws the exception
<img width="860" height="513" alt="image" src="https://github.com/user-attachments/assets/161439ce-8d67-4fab-a2af-3694750b2cf7" />
