### PR TITLE
Fix WSDL schema generator with non-annotated System.Object

### DIFF
--- a/src/SoapCore.Tests/Wsdl/Services/ComplexTypeWithSystemObject.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/ComplexTypeWithSystemObject.cs
@@ -1,0 +1,6 @@
+namespace SoapCore.Tests.Wsdl.Services;
+
+public class ComplexTypeWithSystemObject
+{
+	public object SystemObject { get; set; }
+}

--- a/src/SoapCore.Tests/Wsdl/Services/IComplexTypeWithSystemObjectService.cs
+++ b/src/SoapCore.Tests/Wsdl/Services/IComplexTypeWithSystemObjectService.cs
@@ -1,0 +1,17 @@
+using System;
+using System.ServiceModel;
+
+namespace SoapCore.Tests.Wsdl.Services
+{
+	[ServiceContract]
+	public interface IComplexTypeWithSystemObjectService
+	{
+		[OperationContract]
+		ComplexTypeWithSystemObject Test();
+	}
+
+	public class ComplexTypeWithSystemObjectService : IComplexTypeWithSystemObjectService
+	{
+		public ComplexTypeWithSystemObject Test() => throw new NotImplementedException();
+	}
+}

--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -1407,6 +1407,25 @@ namespace SoapCore.Tests.Wsdl
 			Assert.AreEqual($"tns:{genericTypeName}Of{genericTypeArgumentName}{genericTypeArgumentName}", typeName);
 		}
 
+		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
+		public async Task CheckComplexTypeWithSystemObjectWsdl(SoapSerializer soapSerializer)
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<ComplexTypeWithSystemObjectService>(soapSerializer);
+			Trace.TraceInformation(wsdl);
+			Assert.IsNotNull(wsdl);
+
+			var root = XElement.Parse(wsdl);
+
+			var systemObjectElement = GetElements(root, _xmlSchema + "element")
+				.SingleOrDefault(a => a.Attribute("name")?.Value.Equals(nameof(ComplexTypeWithSystemObject.SystemObject)) == true);
+
+			Assert.IsNotNull(systemObjectElement);
+
+			var typeAttribute = systemObjectElement.Attribute("type");
+			Assert.IsNull(typeAttribute);
+		}
+
 		[TestMethod]
 		public void CheckSchemeOverride()
 		{

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -1273,6 +1273,11 @@ namespace SoapCore.Meta
 						_complexTypeToBuild.Enqueue(newTypeToBuild);
 					}
 				}
+				else if (type == typeof(object))
+				{
+					writer.WriteAttributeString("name", name);
+					WriteQualification(writer, isUnqualified);
+				}
 				else if (toBuild.IsAnonumous)
 				{
 					if (string.IsNullOrEmpty(name))


### PR DESCRIPTION
XmlSerializer adds empty complex type for System.Object.
It seems like this:
```
<xsd:complexType name="SoapEntityField">
  <xsd:sequence>
    <xsd:element minOccurs="0" maxOccurs="1" name="FieldValue" type="tns:Object"/>
  </xsd:sequence>
</xsd:complexType>
<xsd:complexType name="Object"/>
```

This patch avoid creation empty complex type.
I not work with classic WCF, but i think classic WCF not adds complex type for System.Object, maybe this patch can add backcompability.