### PR TITLE
Fix XSD schemaLocation when UrlOverride is specified

### DIFF
--- a/src/SoapCore.Tests/WsdlFromFile/WsdlIncludeTests.cs
+++ b/src/SoapCore.Tests/WsdlFromFile/WsdlIncludeTests.cs
@@ -110,7 +110,7 @@ namespace SoapCore.Tests.WsdlFromFile
 			var addresses = _host.ServerFeatures.Get<IServerAddressesFeature>();
 			var address = addresses.Addresses.Single();
 
-			string url = address + "/Service.asmx?xsd&name=echoIncluded.xsd";
+			string url = address + "/Management/Service.asmx?xsd&name=echoIncluded.xsd";
 
 			Assert.IsNotNull(element);
 			Assert.AreEqual(url, element.Attributes["schemaLocation"]?.Value);

--- a/src/SoapCore/HeadersHelper.cs
+++ b/src/SoapCore/HeadersHelper.cs
@@ -145,8 +145,7 @@ namespace SoapCore
 				}
 #endif
 
-				if (soapAction != null &&
-				    (GetTrimmedSoapAction(soapAction).Length == 0 || GetTrimmedClearedSoapAction(soapAction).Length == 0))
+				if (GetTrimmedSoapAction(soapAction).Length == 0 || GetTrimmedClearedSoapAction(soapAction).Length == 0)
 				{
 					soapAction = ReadOnlySpan<char>.Empty;
 				}

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -1060,9 +1060,9 @@ namespace SoapCore
 				meta.CurrentWebServer = options.VirtualPath + "/";
 			}
 
-			meta.CurrentWebService = httpContext.Request.Path.Value.Replace("/", string.Empty);
-			var mapping = options.WebServiceWSDLMapping[meta.CurrentWebService];
-
+			string url = httpContext.Request.Path.Value.Replace("/", string.Empty);
+			var mapping = options.WebServiceWSDLMapping[url];
+			meta.CurrentWebService = string.IsNullOrEmpty(mapping.UrlOverride) ? url : mapping.UrlOverride;
 			meta.WSDLFolder = mapping.WSDLFolder;
 			meta.XsdFolder = mapping.SchemaFolder;
 			meta.ServerUrl = GetServerUrl(options, httpContext);
@@ -1135,15 +1135,7 @@ namespace SoapCore
 				meta.CurrentWebServer = options.VirtualPath + "/";
 			}
 
-			if (string.IsNullOrEmpty(mapping.UrlOverride))
-			{
-				meta.CurrentWebService = url;
-			}
-			else
-			{
-				meta.CurrentWebService = mapping.UrlOverride;
-			}
-
+			meta.CurrentWebService = string.IsNullOrEmpty(mapping.UrlOverride) ? url : mapping.UrlOverride;
 			meta.WSDLFolder = mapping.WSDLFolder;
 			meta.XsdFolder = mapping.SchemaFolder;
 			meta.ServerUrl = GetServerUrl(options, httpContext);


### PR DESCRIPTION
sWe have a webservice in the following address: https://pannonris.hu/web/PannonRisIf3Ws?import&name=ServiceDefinitions.xml
The application server hosts the service in the /DataExcahngeService location, but in the public service it is overwritten to web/PannonRisIf3Ws

In the url above the schemaLocation is wrong since the overwrite is not applied sometimes:
<img width="1529" height="357" alt="image" src="https://github.com/user-attachments/assets/042a8b23-25bb-4e5b-8081-b07aa4fff808" />

Another small issue is also fixed... with newer .NET (10) I get a warning, that in the HeaderHelper comparing soapAction to null is redundant, since it is a Span, it wont be null. 