### PR TITLE
Fix support for MessageVersion.Soap12

### DIFF
--- a/src/SoapCore.Tests/Wsdl/WsdlTests.cs
+++ b/src/SoapCore.Tests/Wsdl/WsdlTests.cs
@@ -50,6 +50,22 @@ namespace SoapCore.Tests.Wsdl
 		}
 
 		[DataTestMethod]
+		[DataRow(SoapSerializer.XmlSerializer)]
+		[DataRow(SoapSerializer.DataContractSerializer)]
+		public async Task CheckBindingAndPortNameSoap12(SoapSerializer soapSerializer)
+		{
+			var wsdl = await GetWsdlFromMetaBodyWriter<TaskNoReturnService>(soapSerializer, "BindingName", "PortName", messageVersion: MessageVersion.Soap12);
+			var root = XElement.Parse(wsdl);
+
+			// We should have in the wsdl the definition of a complex type representing the nullable enum
+			var bindingElements = GetElements(root, _wsdlSchema + "binding").Where(a => a.Attribute("name")?.Value.Equals("BindingName") == true).ToArray();
+			bindingElements.ShouldNotBeEmpty();
+
+			var portElements = GetElements(root, _wsdlSchema + "port").Where(a => a.Attribute("name")?.Value.Equals("PortName") == true).ToArray();
+			portElements.ShouldNotBeEmpty();
+		}
+
+		[DataTestMethod]
 		[DataRow(SoapSerializer.XmlSerializer, "_soap")]
 		[DataRow(SoapSerializer.DataContractSerializer, "")]
 		public async Task CheckDefaultBindingAndPortName(SoapSerializer soapSerializer, string bindingSuffix)
@@ -1478,7 +1494,7 @@ namespace SoapCore.Tests.Wsdl
 			}
 		}
 
-		private async Task<string> GetWsdlFromMetaBodyWriter<T>(SoapSerializer serializer, string bindingName = null, string portName = null, bool useMicrosoftGuid = false)
+		private async Task<string> GetWsdlFromMetaBodyWriter<T>(SoapSerializer serializer, string bindingName = null, string portName = null, bool useMicrosoftGuid = false, MessageVersion messageVersion = null)
 		{
 			var service = new ServiceDescription(typeof(T), false);
 			var baseUrl = "http://tempuri.org/";
@@ -1488,7 +1504,7 @@ namespace SoapCore.Tests.Wsdl
 			var bodyWriter = serializer == SoapSerializer.DataContractSerializer
 				? new MetaWCFBodyWriter(service, baseUrl, defaultBindingName, false, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }, new DefaultWsdlOperationNameGenerator()) as BodyWriter
 				: new MetaBodyWriter(service, baseUrl, xmlNamespaceLookup, defaultBindingName, new[] { new SoapBindingInfo(MessageVersion.None, bindingName, portName) }, useMicrosoftGuid, new DefaultWsdlOperationNameGenerator()) as BodyWriter;
-			var encoder = new SoapMessageEncoder(MessageVersion.Soap12WSAddressingAugust2004, Encoding.UTF8, false, XmlDictionaryReaderQuotas.Max, false, false, null, bindingName, portName, true);
+			var encoder = new SoapMessageEncoder(messageVersion ?? MessageVersion.Soap12WSAddressingAugust2004, Encoding.UTF8, false, XmlDictionaryReaderQuotas.Max, false, false, null, bindingName, portName, true);
 			var responseMessage = Message.CreateMessage(encoder.MessageVersion, null, bodyWriter);
 			responseMessage = new MetaMessage(
 				responseMessage,

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -199,7 +199,7 @@ namespace SoapCore.Meta
 		private (string soapPrefix, string ns, string qualifiedBindingName, string qualifiedPortName) GetSoapMetaParameters(SoapBindingInfo bindingInfo)
 		{
 			int soapVersion = 11;
-			if (bindingInfo.MessageVersion == MessageVersion.Soap12WSAddressingAugust2004 || bindingInfo.MessageVersion == MessageVersion.Soap12WSAddressing10)
+			if (bindingInfo.MessageVersion.Envelope == EnvelopeVersion.Soap12)
 			{
 				soapVersion = 12;
 			}

--- a/src/SoapCore/Meta/MetaMessage.cs
+++ b/src/SoapCore/Meta/MetaMessage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Xml;
 using SoapCore.ServiceModel;
@@ -40,15 +41,13 @@ namespace SoapCore.Meta
 			writer.WriteStartElement(_xmlNamespaceLookup.LookupPrefix(Namespaces.WSDL_NS), "definitions", Namespaces.WSDL_NS);
 
 			var wroteSoapNamespace = false;
-			if (_soapVersions.Contains(MessageVersion.Soap11) ||
-			    _soapVersions.Contains(MessageVersion.Soap11WSAddressingAugust2004))
+			if (_soapVersions.Any(version => version.Envelope == EnvelopeVersion.Soap11))
 			{
 				WriteXmlnsAttribute(writer, Namespaces.SOAP11_NS);
 				wroteSoapNamespace = true;
 			}
 
-			if (_soapVersions.Contains(MessageVersion.Soap12WSAddressing10) ||
-			    _soapVersions.Contains(MessageVersion.Soap12WSAddressingAugust2004))
+			if (_soapVersions.Any(version => version.Envelope == EnvelopeVersion.Soap12))
 			{
 				WriteXmlnsAttribute(writer, Namespaces.SOAP12_NS);
 				wroteSoapNamespace = true;

--- a/src/SoapCore/Meta/MetaWCFBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaWCFBodyWriter.cs
@@ -1656,7 +1656,7 @@ namespace SoapCore.Meta
 		private (string soapPrefix, string ns, string qualifiedBindingName, string qualifiedPortName) GetSoapMetaParameters(SoapBindingInfo bindingInfo)
 		{
 			int soapVersion = 11;
-			if (bindingInfo.MessageVersion == MessageVersion.Soap12WSAddressingAugust2004 || bindingInfo.MessageVersion == MessageVersion.Soap12WSAddressing10)
+			if (bindingInfo.MessageVersion.Envelope == EnvelopeVersion.Soap12)
 			{
 				soapVersion = 12;
 			}

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -243,7 +243,7 @@ namespace SoapCore
 				: (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, bindingName, _options.UseBasicAuthentication, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray(), _options.WsdlOperationNameGenerator);
 
 			//assumption that you want soap12 if your service supports that
-			var messageEncoder = _messageEncoders.FirstOrDefault(me => me.MessageVersion == MessageVersion.Soap12WSAddressing10 || me.MessageVersion == MessageVersion.Soap12WSAddressingAugust2004) ?? _messageEncoders[0];
+			var messageEncoder = _messageEncoders.FirstOrDefault(me => me.MessageVersion.Envelope == EnvelopeVersion.Soap12) ?? _messageEncoders[0];
 			var soapVersions = _messageEncoders.Select(me => me.MessageVersion).Distinct().ToArray();
 
 			using var responseMessage = new MetaMessage(


### PR DESCRIPTION
`MessageVersion.Soap12` was introduced (or to be more precise, the missing API has been added) with `System.ServiceModel.Primitives` version 6.1.0: https://github.com/dotnet/wcf/commit/7b01263abc18ab285921058397525264d94e5e53

For this reason, the comparison with this SOAP version was probably missing in the code, because this cannot be called with the version of .NET Core 3.1.

I have replaced the comparison to the concrete `MessageVersion` with the `EnvelopeVersion` in the code passages, because this is actually the point of interest.

I had noticed this, because when calling the `...?wsdl` URL the error “Unsupported MessageVersion encountered while writing envelope.” was thrown.