### PR TITLE
Fix SA1000: Spacing around keywords

### DIFF
--- a/src/SoapCore/MembersWithAttributeCache.cs
+++ b/src/SoapCore/MembersWithAttributeCache.cs
@@ -8,7 +8,7 @@ namespace SoapCore
 		private static class MembersWithAttributeCache<TAttribute>
 			where TAttribute : Attribute
 		{
-			public static ConcurrentDictionary<Type, MemberWithAttribute<TAttribute>[]> CacheEntries = new();
+			public static ConcurrentDictionary<Type, MemberWithAttribute<TAttribute>[]> CacheEntries = new ();
 		}
 	}
 }

--- a/src/SoapCore/Meta/MetaMessage.cs
+++ b/src/SoapCore/Meta/MetaMessage.cs
@@ -54,7 +54,7 @@ namespace SoapCore.Meta
 				wroteSoapNamespace = true;
 			}
 
-			if(!wroteSoapNamespace)
+			if (!wroteSoapNamespace)
 			{
 				throw new ArgumentOutOfRangeException(nameof(Version), "Unsupported MessageVersion encountered while writing envelope.");
 			}


### PR DESCRIPTION
Fix https://github.com/DigDes/SoapCore/issues/1172

https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md