### PR TITLE
ArrayOfGuid and guid types in wsdl

### DIFF
--- a/src/SoapCore/Meta/BodyWriterExtensions.cs
+++ b/src/SoapCore/Meta/BodyWriterExtensions.cs
@@ -160,6 +160,18 @@ namespace SoapCore.Meta
 					attr.AttributeType == typeof(XmlIgnoreAttribute));
 		}
 
+		public static bool IsIgnored(this MemberInfo member, bool xmlIgnoreOnly)
+		{
+			if (xmlIgnoreOnly)
+			{
+				return member
+					.CustomAttributes
+					.Any(attr => attr.AttributeType == typeof(XmlIgnoreAttribute));
+			}
+
+			return member.IsIgnored();
+		}
+
 		/// <summary>
 		/// Checks if the parent has a ShouldSerialize*() method defined for a specific member.
 		/// </summary>

--- a/src/SoapCore/Meta/ClrTypeResolver.cs
+++ b/src/SoapCore/Meta/ClrTypeResolver.cs
@@ -1,7 +1,16 @@
+using System;
+
 namespace SoapCore.Meta
 {
 	public class ClrTypeResolver
 	{
+		/// <summary>
+		/// When true, Guid types are resolved as "guid" (for Microsoft WSDL types namespace)
+		/// instead of "string". This affects array naming (List&lt;Guid&gt; becomes ArrayOfGuid).
+		/// </summary>
+		[ThreadStatic]
+		public static bool UseMicrosoftGuid;
+
 		public static string ResolveOrDefault(string typeName)
 		{
 			switch (typeName)
@@ -33,7 +42,9 @@ namespace SoapCore.Meta
 				case "DateTime":
 					return "dateTime";
 				case "Guid":
-					return "string";
+					// When UseMicrosoftGuid is true, return null so callers fall back to original type name "Guid"
+					// This ensures ArrayOfGuid naming while avoiding invalid "s:guid" type references
+					return UseMicrosoftGuid ? null : "string";
 				case "Char":
 					return "string";
 				case "TimeSpan":

--- a/src/SoapCore/Meta/IWsdlOperationNameGenerator.cs
+++ b/src/SoapCore/Meta/IWsdlOperationNameGenerator.cs
@@ -20,4 +20,17 @@ namespace SoapCore.Meta
 			return $"{service.GeneralContract.Name}_{operation.Name}_OutputMessage";
 		}
 	}
+
+	public class LegacyWsdlOperationNameGenerator : IWsdlOperationNameGenerator
+	{
+		public string GenerateWsdlInputMessageName(OperationDescription operation, ServiceDescription service)
+		{
+			return $"{operation.Name}SoapIn";
+		}
+
+		public string GenerateWsdlOutputMessageName(OperationDescription operation, ServiceDescription service)
+		{
+			return $"{operation.Name}SoapOut";
+		}
+	}
 }

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -215,6 +215,13 @@ namespace SoapCore.Meta
 		private XmlQualifiedName ResolveType(Type type)
 		{
 			string typeName = type.IsEnum ? type.GetEnumUnderlyingType().Name : type.Name;
+
+			// Handle Guid specially when UseMicrosoftGuid is enabled
+			if (typeName == "Guid" && _buildMicrosoftGuid)
+			{
+				return new XmlQualifiedName("guid", Namespaces.MICROSOFT_TYPES);
+			}
+
 			string resolvedType = ClrTypeResolver.ResolveOrDefault(typeName);
 
 			if (string.IsNullOrEmpty(resolvedType))

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -34,9 +34,10 @@ namespace SoapCore.Meta
 		private readonly Dictionary<string, Dictionary<string, string>> _requestedDynamicTypes;
 
 		private readonly bool _buildMicrosoftGuid = false;
+		private readonly bool _xmlIgnoreOnlyForWsdl = false;
 		private IWsdlOperationNameGenerator _wsdlOperationNameGenerator;
 
-		public MetaBodyWriter(ServiceDescription service, string baseUrl, ConcurrentXmlNamespaceLookup xmlNamespaceLookup, string bindingName, SoapBindingInfo[] soapBindings, bool buildMicrosoftGuid, IWsdlOperationNameGenerator wsdlOperationNameGenerator) : base(isBuffered: true)
+		public MetaBodyWriter(ServiceDescription service, string baseUrl, ConcurrentXmlNamespaceLookup xmlNamespaceLookup, string bindingName, SoapBindingInfo[] soapBindings, bool buildMicrosoftGuid, IWsdlOperationNameGenerator wsdlOperationNameGenerator, bool xmlIgnoreOnlyForWsdl = false) : base(isBuffered: true)
 		{
 			_service = service;
 			_baseUrl = baseUrl;
@@ -52,6 +53,7 @@ namespace SoapCore.Meta
 			PortName = bindingName;
 			SoapBindings = soapBindings;
 			_buildMicrosoftGuid = buildMicrosoftGuid;
+			_xmlIgnoreOnlyForWsdl = xmlIgnoreOnlyForWsdl;
 			_wsdlOperationNameGenerator = wsdlOperationNameGenerator;
 		}
 
@@ -863,7 +865,7 @@ namespace SoapCore.Meta
 					if (!isWrappedBodyType)
 					{
 						var propertyOrFieldMembers = toBuildBodyType.GetPropertyOrFieldMembers()
-							.Where(mi => !mi.IsIgnored() && mi.DeclaringType == toBuildType)
+							.Where(mi => !mi.IsIgnored(_xmlIgnoreOnlyForWsdl) && mi.DeclaringType == toBuildType)
 							.ToList();
 
 						var elements = propertyOrFieldMembers.Where(t => !t.IsAttribute() && t.GetCustomAttribute<XmlAnyAttributeAttribute>() == null).ToList();
@@ -894,7 +896,7 @@ namespace SoapCore.Meta
 					else
 					{
 						// TODO: should this also be changed to GetPropertyOrFieldMembers?
-						var properties = toBuildType.GetProperties().Where(prop => !prop.IsIgnored())
+						var properties = toBuildType.GetProperties().Where(prop => !prop.IsIgnored(_xmlIgnoreOnlyForWsdl))
 							.ToList();
 
 						var elements = properties.Where(t => !t.IsAttribute()).ToList();

--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -36,8 +36,9 @@ namespace SoapCore.Meta
 		private readonly bool _buildMicrosoftGuid = false;
 		private readonly bool _xmlIgnoreOnlyForWsdl = false;
 		private IWsdlOperationNameGenerator _wsdlOperationNameGenerator;
+		private readonly string _portTypeSuffix;
 
-		public MetaBodyWriter(ServiceDescription service, string baseUrl, ConcurrentXmlNamespaceLookup xmlNamespaceLookup, string bindingName, SoapBindingInfo[] soapBindings, bool buildMicrosoftGuid, IWsdlOperationNameGenerator wsdlOperationNameGenerator, bool xmlIgnoreOnlyForWsdl = false) : base(isBuffered: true)
+		public MetaBodyWriter(ServiceDescription service, string baseUrl, ConcurrentXmlNamespaceLookup xmlNamespaceLookup, string bindingName, SoapBindingInfo[] soapBindings, bool buildMicrosoftGuid, IWsdlOperationNameGenerator wsdlOperationNameGenerator, bool xmlIgnoreOnlyForWsdl = false, string portTypeSuffix = "") : base(isBuffered: true)
 		{
 			_service = service;
 			_baseUrl = baseUrl;
@@ -55,11 +56,12 @@ namespace SoapCore.Meta
 			_buildMicrosoftGuid = buildMicrosoftGuid;
 			_xmlIgnoreOnlyForWsdl = xmlIgnoreOnlyForWsdl;
 			_wsdlOperationNameGenerator = wsdlOperationNameGenerator;
+			_portTypeSuffix = portTypeSuffix ?? "";
 		}
 
 		private SoapBindingInfo[] SoapBindings { get; }
 		private string BindingName { get; }
-		private string BindingType => _service.GeneralContract.Name;
+		private string BindingType => _service.GeneralContract.Name + _portTypeSuffix;
 		private string PortName { get; }
 
 		private string TargetNameSpace => _service.GeneralContract.Namespace;

--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -156,6 +156,14 @@ namespace SoapCore
 		/// </summary>
 		public bool XmlIgnoreOnlyForWsdl { get; set; } = false;
 
+		/// <summary>
+		/// When true, uses legacy WCF/ASMX WSDL naming conventions:
+		/// portType name becomes {ContractName}Soap, and message names
+		/// use {OperationName}SoapIn/{OperationName}SoapOut pattern.
+		/// <para>Defaults to false</para>
+		/// </summary>
+		public bool UseLegacyWsdlNaming { get; set; } = false;
+
 		public void UseCustomSerializer<TCustomSerializer>()
 			where TCustomSerializer : class, IXmlSerializationHandler
 		{

--- a/src/SoapCore/SoapCoreOptions.cs
+++ b/src/SoapCore/SoapCoreOptions.cs
@@ -148,6 +148,14 @@ namespace SoapCore
 		/// </summary>
 		public string SchemeOverride { get; set; }
 
+		/// <summary>
+		/// When true, only [XmlIgnore] is used to exclude properties from WSDL generation,
+		/// ignoring [IgnoreDataMember]. This matches legacy WCF/ASMX XmlSerializer behavior
+		/// where [IgnoreDataMember] had no effect on XmlSerializer.
+		/// <para>Defaults to false</para>
+		/// </summary>
+		public bool XmlIgnoreOnlyForWsdl { get; set; } = false;
+
 		public void UseCustomSerializer<TCustomSerializer>()
 			where TCustomSerializer : class, IXmlSerializationHandler
 		{

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -242,7 +242,7 @@ namespace SoapCore
 			var xmlNamespaceLookup = GetXmlNamespaceLookup(null);
 			var bindingName = !string.IsNullOrWhiteSpace(_options.EncoderOptions[0].BindingName) ? _options.EncoderOptions[0].BindingName : "BasicHttpBinding_" + _service.GeneralContract.Name;
 			var bodyWriter = _options.SoapSerializer == SoapSerializer.XmlSerializer
-				? new MetaBodyWriter(_service, baseUrl, xmlNamespaceLookup, bindingName, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray(), _options.UseMicrosoftGuid, _options.WsdlOperationNameGenerator, _options.XmlIgnoreOnlyForWsdl)
+				? new MetaBodyWriter(_service, baseUrl, xmlNamespaceLookup, bindingName, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray(), _options.UseMicrosoftGuid, _options.UseLegacyWsdlNaming ? new LegacyWsdlOperationNameGenerator() : _options.WsdlOperationNameGenerator, _options.XmlIgnoreOnlyForWsdl, _options.UseLegacyWsdlNaming ? "Soap" : "")
 				: (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, bindingName, _options.UseBasicAuthentication, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray(), _options.WsdlOperationNameGenerator);
 
 			//assumption that you want soap12 if your service supports that

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -234,6 +234,9 @@ namespace SoapCore
 
 		private async Task ProcessMeta(HttpContext httpContext, bool showDocumentation)
 		{
+			// Set the flag for ClrTypeResolver so that List<Guid> becomes ArrayOfGuid
+			Meta.ClrTypeResolver.UseMicrosoftGuid = _options.UseMicrosoftGuid;
+
 			var scheme = string.IsNullOrEmpty(_options.SchemeOverride) ? httpContext.Request.Scheme : _options.SchemeOverride;
 			var baseUrl = scheme + "://" + httpContext.Request.Host + httpContext.Request.PathBase + httpContext.Request.Path;
 			var xmlNamespaceLookup = GetXmlNamespaceLookup(null);

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -242,7 +242,7 @@ namespace SoapCore
 			var xmlNamespaceLookup = GetXmlNamespaceLookup(null);
 			var bindingName = !string.IsNullOrWhiteSpace(_options.EncoderOptions[0].BindingName) ? _options.EncoderOptions[0].BindingName : "BasicHttpBinding_" + _service.GeneralContract.Name;
 			var bodyWriter = _options.SoapSerializer == SoapSerializer.XmlSerializer
-				? new MetaBodyWriter(_service, baseUrl, xmlNamespaceLookup, bindingName, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray(), _options.UseMicrosoftGuid, _options.WsdlOperationNameGenerator)
+				? new MetaBodyWriter(_service, baseUrl, xmlNamespaceLookup, bindingName, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray(), _options.UseMicrosoftGuid, _options.WsdlOperationNameGenerator, _options.XmlIgnoreOnlyForWsdl)
 				: (BodyWriter)new MetaWCFBodyWriter(_service, baseUrl, bindingName, _options.UseBasicAuthentication, _messageEncoders.Select(me => new SoapBindingInfo(me.MessageVersion, me.BindingName, me.PortName)).ToArray(), _options.WsdlOperationNameGenerator);
 
 			//assumption that you want soap12 if your service supports that

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -71,6 +71,8 @@ namespace SoapCore
 
 		public string SchemeOverride { get; set; }
 
+		public bool XmlIgnoreOnlyForWsdl { get; set; } = false;
+
 		[Obsolete]
 		public static SoapOptions FromSoapCoreOptions<T>(SoapCoreOptions opt)
 		{
@@ -105,6 +107,7 @@ namespace SoapCore
 				GenerateSoapActionWithoutContractName = opt.GenerateSoapActionWithoutContractName,
 				NormalizeNewLines = opt.NormalizeNewLines,
 				SchemeOverride = opt.SchemeOverride,
+				XmlIgnoreOnlyForWsdl = opt.XmlIgnoreOnlyForWsdl,
 			};
 
 			return options;

--- a/src/SoapCore/SoapOptions.cs
+++ b/src/SoapCore/SoapOptions.cs
@@ -73,6 +73,8 @@ namespace SoapCore
 
 		public bool XmlIgnoreOnlyForWsdl { get; set; } = false;
 
+		public bool UseLegacyWsdlNaming { get; set; } = false;
+
 		[Obsolete]
 		public static SoapOptions FromSoapCoreOptions<T>(SoapCoreOptions opt)
 		{
@@ -108,6 +110,7 @@ namespace SoapCore
 				NormalizeNewLines = opt.NormalizeNewLines,
 				SchemeOverride = opt.SchemeOverride,
 				XmlIgnoreOnlyForWsdl = opt.XmlIgnoreOnlyForWsdl,
+				UseLegacyWsdlNaming = opt.UseLegacyWsdlNaming,
 			};
 
 			return options;


### PR DESCRIPTION
Adjusted ClrTypeResolver to return guid on "Guid" types but preserve "string" type by default 
MetaBodyWriter - use proper XML qualified namespace (avoids using guid for ttp://www.w3.org/2001/XMLSchema namespace)
SoapEndpointMiddleware - make the UseMicrosoftGuid static for other method access