### PR TITLE
Fix: WSDL validation fails - XmlDocument complex type has blank name

### DIFF
--- a/src/SoapCore/Meta/MetaBodyWriter.cs
+++ b/src/SoapCore/Meta/MetaBodyWriter.cs
@@ -1275,6 +1275,11 @@ namespace SoapCore.Meta
 				}
 				else if (type == typeof(object))
 				{
+					if (string.IsNullOrEmpty(name))
+					{
+						name = typeName;
+					}
+
 					writer.WriteAttributeString("name", name);
 					WriteQualification(writer, isUnqualified);
 				}


### PR DESCRIPTION
Added string.IsNullOrEmpty(name) check to Object type