### PR TITLE
Fix duplicate fault response on the error path #1192

### DIFF
--- a/src/SoapCore.Tests/DuplicateFault/CountingFaultExceptionTransformer.cs
+++ b/src/SoapCore.Tests/DuplicateFault/CountingFaultExceptionTransformer.cs
@@ -1,0 +1,25 @@
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using SoapCore.Extensibility;
+
+namespace SoapCore.Tests.DuplicateFault
+{
+	public class CountingFaultExceptionTransformer : IFaultExceptionTransformer
+	{
+		private int _provideFaultCallCount;
+
+		public int ProvideFaultCallCount => _provideFaultCallCount;
+
+		public Message ProvideFault(Exception exception, MessageVersion messageVersion, Message requestMessage, ConcurrentXmlNamespaceLookup xmlNamespaceLookup)
+		{
+			_provideFaultCallCount++;
+
+			var faultException = new FaultException(new FaultReason(exception.Message), new FaultCode("Sender"), null);
+			var messageFault = faultException.CreateMessageFault();
+			var bodyWriter = new MessageFaultBodyWriter(messageFault, messageVersion);
+
+			return Message.CreateMessage(messageVersion, null, bodyWriter);
+		}
+	}
+}

--- a/src/SoapCore.Tests/DuplicateFault/CountingLoggerProvider.cs
+++ b/src/SoapCore.Tests/DuplicateFault/CountingLoggerProvider.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace SoapCore.Tests.DuplicateFault
+{
+	public sealed class CountingLoggerProvider : ILoggerProvider
+	{
+		private readonly List<string> _errors = new List<string>();
+
+		public IReadOnlyList<string> Errors
+		{
+			get
+			{
+				lock (_errors)
+				{
+					return _errors.ToList();
+				}
+			}
+		}
+
+		public ILogger CreateLogger(string categoryName)
+		{
+			return new CountingLogger(this);
+		}
+
+		public void Dispose()
+		{
+		}
+
+		private void AddError(string message)
+		{
+			lock (_errors)
+			{
+				_errors.Add(message);
+			}
+		}
+
+		private sealed class CountingLogger : ILogger
+		{
+			private readonly CountingLoggerProvider _provider;
+
+			public CountingLogger(CountingLoggerProvider provider)
+			{
+				_provider = provider;
+			}
+
+			public IDisposable BeginScope<TState>(TState state)
+				where TState : notnull
+			{
+				return null;
+			}
+
+			public bool IsEnabled(LogLevel logLevel)
+			{
+				return true;
+			}
+
+			public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+			{
+				if (logLevel != LogLevel.Error)
+				{
+					return;
+				}
+
+				_provider.AddError(formatter(state, exception));
+			}
+		}
+	}
+}

--- a/src/SoapCore.Tests/DuplicateFault/DuplicateFaultTests.cs
+++ b/src/SoapCore.Tests/DuplicateFault/DuplicateFaultTests.cs
@@ -1,0 +1,132 @@
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SoapCore.Tests.DuplicateFault
+{
+	// https://github.com/DigDes/SoapCore/issues/1192
+	[TestClass]
+	public class DuplicateFaultTests
+	{
+		private const string FaultMessage = "Test fault message";
+		private const string ErrorLogMessage = "An error occurred processing the message";
+
+		[TestMethod]
+		public async Task ProvideFaultIsCalledOnce()
+		{
+			using (var host = CreateTestHost())
+			{
+				await PostFaultingRequestAsync(host);
+
+				var faultExceptionTransformer = host.Services.GetRequiredService<CountingFaultExceptionTransformer>();
+
+				Assert.AreEqual(1, faultExceptionTransformer.ProvideFaultCallCount);
+			}
+		}
+
+		[TestMethod]
+		public async Task ErrorIsLoggedOnce()
+		{
+			using (var host = CreateTestHost())
+			{
+				await PostFaultingRequestAsync(host);
+
+				var loggerProvider = host.Services.GetRequiredService<CountingLoggerProvider>();
+
+				Assert.AreEqual(1, loggerProvider.Errors.Count(error => error == ErrorLogMessage));
+			}
+		}
+
+		[TestMethod]
+		public async Task BeforeSendReplyIsCalledOnce()
+		{
+			using (var host = CreateTestHost())
+			{
+				await PostFaultingRequestAsync(host);
+
+				var messageInspector = host.Services.GetRequiredService<StampingMessageInspector>();
+
+				Assert.AreEqual(1, messageInspector.AfterReceiveRequestCallCount);
+				Assert.AreEqual(1, messageInspector.BeforeSendReplyCallCount);
+			}
+		}
+
+		[TestMethod]
+		public async Task BeforeSendReplyIsCalledOnceWhenTheResponseFilterThrows()
+		{
+			using (var host = CreateTestHost(registerThrowingResponseFilter: true))
+			{
+				await PostPingRequestAsync(host);
+
+				var messageInspector = host.Services.GetRequiredService<StampingMessageInspector>();
+
+				Assert.AreEqual(1, messageInspector.AfterReceiveRequestCallCount);
+				Assert.AreEqual(1, messageInspector.BeforeSendReplyCallCount);
+			}
+		}
+
+		[TestMethod]
+		public async Task MessageHandedToBeforeSendReplyIsTheMessageThatIsSent()
+		{
+			using (var host = CreateTestHost())
+			{
+				var response = await PostFaultingRequestAsync(host);
+
+				Assert.IsTrue(response.Contains(FaultMessage), "The fault should carry the reason of the exception");
+				Assert.IsTrue(response.Contains(StampingMessageInspector.HeaderName), "The fault should carry the header added by BeforeSendReply");
+				Assert.IsTrue(response.Contains(StampingMessageInspector.HeaderValue), "The fault should carry the value written by BeforeSendReply");
+			}
+		}
+
+		private TestServer CreateTestHost(bool registerThrowingResponseFilter = false)
+		{
+			var webHostBuilder = new WebHostBuilder()
+				.UseStartup<Startup>()
+				.UseSetting(Startup.ThrowingResponseFilterSetting, registerThrowingResponseFilter.ToString());
+
+			return new TestServer(webHostBuilder);
+		}
+
+		private Task<string> PostFaultingRequestAsync(TestServer host)
+		{
+			var bodyContent = $@"<ThrowExceptionWithMessage xmlns=""http://tempuri.org/"">
+      <message>{FaultMessage}</message>
+    </ThrowExceptionWithMessage>";
+
+			return PostAsync(host, "ThrowExceptionWithMessage", bodyContent);
+		}
+
+		private Task<string> PostPingRequestAsync(TestServer host)
+		{
+			var bodyContent = @"<Ping xmlns=""http://tempuri.org/"">
+      <s>Hello World</s>
+    </Ping>";
+
+			return PostAsync(host, "Ping", bodyContent);
+		}
+
+		private async Task<string> PostAsync(TestServer host, string soapAction, string bodyContent)
+		{
+			var body = $@"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"">
+  <soapenv:Body>
+    {bodyContent}
+  </soapenv:Body>
+</soapenv:Envelope>
+";
+
+			using (var content = new StringContent(body, Encoding.UTF8, "text/xml"))
+			using (var res = await host.CreateRequest("/Service.svc").AddHeader("SOAPAction", $@"""{soapAction}""").And(msg => msg.Content = content).PostAsync())
+			{
+				Assert.AreEqual(HttpStatusCode.InternalServerError, res.StatusCode);
+
+				return await res.Content.ReadAsStringAsync();
+			}
+		}
+	}
+}

--- a/src/SoapCore.Tests/DuplicateFault/StampingMessageInspector.cs
+++ b/src/SoapCore.Tests/DuplicateFault/StampingMessageInspector.cs
@@ -1,0 +1,34 @@
+using System.ServiceModel.Channels;
+using SoapCore.Extensibility;
+using SoapCore.ServiceModel;
+
+namespace SoapCore.Tests.DuplicateFault
+{
+	public class StampingMessageInspector : IMessageInspector2
+	{
+		public const string HeaderName = "InspectorStamp";
+		public const string HeaderNamespace = "urn:soapcore-tests";
+		public const string HeaderValue = "was-here";
+
+		private int _afterReceiveRequestCallCount;
+		private int _beforeSendReplyCallCount;
+
+		public int AfterReceiveRequestCallCount => _afterReceiveRequestCallCount;
+
+		public int BeforeSendReplyCallCount => _beforeSendReplyCallCount;
+
+		public object AfterReceiveRequest(ref Message message, ServiceDescription serviceDescription)
+		{
+			_afterReceiveRequestCallCount++;
+
+			return null;
+		}
+
+		public void BeforeSendReply(ref Message reply, ServiceDescription serviceDescription, object correlationState)
+		{
+			_beforeSendReplyCallCount++;
+
+			reply.Headers.Add(MessageHeader.CreateHeader(HeaderName, HeaderNamespace, HeaderValue));
+		}
+	}
+}

--- a/src/SoapCore.Tests/DuplicateFault/Startup.cs
+++ b/src/SoapCore.Tests/DuplicateFault/Startup.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using SoapCore.Extensibility;
+
+namespace SoapCore.Tests.DuplicateFault
+{
+	public class Startup
+	{
+		public const string ThrowingResponseFilterSetting = "RegisterThrowingResponseFilter";
+
+		public Startup(IConfiguration configuration)
+		{
+			Configuration = configuration;
+			RegisterThrowingResponseFilter = configuration.GetValue<bool>(ThrowingResponseFilterSetting);
+		}
+
+		public IConfiguration Configuration { get; }
+
+		public bool RegisterThrowingResponseFilter { get; }
+
+		public void ConfigureServices(IServiceCollection services)
+		{
+			var loggerProvider = new CountingLoggerProvider();
+			var faultExceptionTransformer = new CountingFaultExceptionTransformer();
+			var messageInspector = new StampingMessageInspector();
+
+			services.AddSingleton(loggerProvider);
+			services.AddLogging(logging => logging.AddProvider(loggerProvider));
+
+			services.AddSoapCore();
+			services.TryAddSingleton<TestService>();
+
+			services.AddSingleton(faultExceptionTransformer);
+			services.AddSingleton<IFaultExceptionTransformer>(faultExceptionTransformer);
+
+			services.AddSingleton(messageInspector);
+			services.AddSoapMessageInspector(messageInspector);
+
+			if (RegisterThrowingResponseFilter)
+			{
+				services.AddSoapMessageFilter(new ThrowingResponseFilter());
+			}
+
+			services.AddRouting();
+		}
+
+#if !NETCOREAPP3_0_OR_GREATER
+		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+		{
+			app.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+		}
+#else
+		public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
+		{
+			app.UseRouting();
+
+			app.UseEndpoints(x =>
+			{
+				x.UseSoapEndpoint<TestService>("/Service.svc", new SoapEncoderOptions(), SoapSerializer.DataContractSerializer);
+			});
+		}
+#endif
+	}
+}

--- a/src/SoapCore.Tests/DuplicateFault/ThrowingResponseFilter.cs
+++ b/src/SoapCore.Tests/DuplicateFault/ThrowingResponseFilter.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ServiceModel.Channels;
+using System.Threading.Tasks;
+using SoapCore.Extensibility;
+
+namespace SoapCore.Tests.DuplicateFault
+{
+	public class ThrowingResponseFilter : IAsyncMessageFilter
+	{
+		public Task OnRequestExecuting(Message message)
+		{
+			return Task.CompletedTask;
+		}
+
+		public Task OnResponseExecuting(Message message)
+		{
+			throw new InvalidOperationException("The response is not acceptable.");
+		}
+	}
+}

--- a/src/SoapCore/SoapEndpointMiddleware.cs
+++ b/src/SoapCore/SoapEndpointMiddleware.cs
@@ -291,6 +291,8 @@ namespace SoapCore
 			Message requestMessage = null;
 			Message responseMessage = null;
 
+			var correlationObjects2 = new List<(IMessageInspector2 inspector, object correlationObject)>();
+
 			try
 			{
 				//Get the message
@@ -305,13 +307,15 @@ namespace SoapCore
 
 				var soapMessageProcessors = serviceProvider.GetServices<ISoapMessageProcessor>().ToArray();
 
-				var processorPipe = MakeProcessorPipe(soapMessageProcessors, httpContext, (requestMessage) => ProcessMessage(requestMessage, messageEncoder, asyncMessageFilters, httpContext, serviceProvider));
+				var processorPipe = MakeProcessorPipe(soapMessageProcessors, httpContext, (requestMessage) => ProcessMessage(requestMessage, messageEncoder, asyncMessageFilters, httpContext, serviceProvider, correlationObjects2));
 
 				responseMessage = await processorPipe(requestMessage);
 			}
 			catch (Exception ex)
 			{
 				responseMessage = CreateErrorResponseMessage(ex, serviceProvider, requestMessage, messageEncoder, httpContext);
+
+				correlationObjects2.ForEach(mi => mi.inspector.BeforeSendReply(ref responseMessage, _service, mi.correlationObject));
 			}
 
 			if (responseMessage != null)
@@ -452,7 +456,7 @@ namespace SoapCore
 			return MakeProcessorPipe();
 		}
 
-		private async Task<Message> ProcessMessage(Message requestMessage, SoapMessageEncoder messageEncoder, IAsyncMessageFilter[] asyncMessageFilters, HttpContext httpContext, IServiceProvider serviceProvider)
+		private async Task<Message> ProcessMessage(Message requestMessage, SoapMessageEncoder messageEncoder, IAsyncMessageFilter[] asyncMessageFilters, HttpContext httpContext, IServiceProvider serviceProvider, List<(IMessageInspector2 inspector, object correlationObject)> correlationObjects2)
 		{
 			Message responseMessage;
 			var soapAction = HeadersHelper.GetSoapAction(httpContext, ref requestMessage);
@@ -464,7 +468,7 @@ namespace SoapCore
 			}
 
 			var messageInspector2s = serviceProvider.GetServices<IMessageInspector2>();
-			var correlationObjects2 = messageInspector2s.Select(mi => (inspector: mi, correlationObject: mi.AfterReceiveRequest(ref requestMessage, _service))).ToList();
+			correlationObjects2.AddRange(messageInspector2s.Select(mi => (inspector: mi, correlationObject: mi.AfterReceiveRequest(ref requestMessage, _service))));
 
 			// for getting soapaction and parameters in (optional) body
 			// GetReaderAtBodyContents must not be called twice in one request
@@ -526,14 +530,7 @@ namespace SoapCore
 				httpContext.Response.Headers["SOAPAction"] = responseMessage.Headers.Action;
 
 				correlationObjects2.ForEach(mi => mi.inspector.BeforeSendReply(ref responseMessage, _service, mi.correlationObject));
-			}
-			catch (Exception ex)
-			{
-				responseMessage = CreateErrorResponseMessage(ex, serviceProvider, requestMessage, messageEncoder, httpContext);
-
-				correlationObjects2.ForEach(mi => mi.inspector.BeforeSendReply(ref responseMessage, _service, mi.correlationObject));
-
-				throw;
+				correlationObjects2.Clear();
 			}
 			finally
 			{


### PR DESCRIPTION
Fixes #1192.

### Change

The `catch` in `ProcessMessage` is removed, and `IMessageInspector2.BeforeSendReply` is invoked from the `catch` in `ProcessOperation`, on the message that is written to the response.

The correlation objects are created in `ProcessMessage`, so `ProcessOperation` creates the list and passes it in. `AfterReceiveRequest` stays inside the `ISoapMessageProcessor` pipe, and `ProcessMessage` is private, so no public API is affected. The list is cleared once the inspectors have seen the reply, so a failure later in the response path cannot notify them a second time.

### Measured

Repro from the issue, single POST to an operation that throws:

| | `v1.2.1.15` | this branch |
| --- | --- | --- |
| `Error` entries "An error occurred processing the message" | 2 | 1 |
| `IFaultExceptionTransformer.ProvideFault` invocations | 2 | 1 |
| `IMessageInspector2.AfterReceiveRequest` invocations | 1 | 1 |
| `IMessageInspector2.BeforeSendReply` invocations | 1 | 1 |
| Header added by `BeforeSendReply` present in the fault received by the client | no | yes |

### Adjacent paths

| Path | Behaviour |
| --- | --- |
| exception before any `AfterReceiveRequest` | no inspector notified, unchanged |
| one inspector throws in `AfterReceiveRequest` | the inspectors before it are notified, keeping their calls paired |
| `ISoapMessageProcessor` swallows the exception and returns its own message | no fault built, so no log entry and no notification |
| inspector throws in `BeforeSendReply` | the exception leaves the middleware, so the client gets a plain 500 instead of a fault |

### Tests

`src/SoapCore.Tests/DuplicateFault` runs a `TestServer` with a counting `IFaultExceptionTransformer`, an `IMessageInspector2` that stamps a header onto the reply, and an `ILoggerProvider` that records `Error` entries. One faulting request asserts the rows of the table above. A fifth test asserts that a successful operation followed by a throwing `IAsyncMessageFilter.OnResponseExecuting` notifies the inspectors once.

Three of the five fail on `develop`.

##### Note

`dotnet test src/SoapCore.Tests`: 292 of 293 pass. `TestIssue1183` fails on `develop` as well.
